### PR TITLE
fix: make `htmlFor` optional on `Label` component. (fixes #65)

### DIFF
--- a/packages/tamagui/src/views/Label.tsx
+++ b/packages/tamagui/src/views/Label.tsx
@@ -51,7 +51,7 @@ export const LabelFrame = styled(SizableText, {
 })
 
 export type LabelProps = GetProps<typeof LabelFrame> & {
-  htmlFor: string
+  htmlFor?: string
 }
 
 const LabelComponent = React.forwardRef<typeof LabelFrame, LabelProps>((props, forwardedRef) => {


### PR DESCRIPTION
This component has an action that checks if `htmlFor` is defined and do what it needs to do. However, the prop is required as of now, resulting in a type error if left undefined, and a warning if defined on mobile.
With this, the prop will be made optional. That will get rid of the type error, and still maintain the current behavior.