### PR TITLE
site: wrong info about expo workflow

### DIFF
--- a/packages/site/data/docs/guides/expo.mdx
+++ b/packages/site/data/docs/guides/expo.mdx
@@ -5,6 +5,6 @@ description: How to set up Tamagui with Expo
 
 <Notice>We're putting together a better guide soon!</Notice>
 
-If you'd like to get a good idea of a set up with Expo, try out `npm create-tamagui-app@latest` which generates a bare expo project.
+If you'd like to get a good idea of a set up with Expo, try out `npm create-tamagui-app@latest` which generates a managed expo project.
 
 [The source for that is here](https://github.com/tamagui/starters).


### PR DESCRIPTION
Now it says that `create-tamagui-app` bootstraps a `bare` expo app, which is untrue, as bare apps have `android` and `ios` folders (there's much more behind, but we'll keep it simple)