### PR TITLE
fix(docs): @tamagui/shorthands package link

### DIFF
--- a/packages/site/data/docs/intro/configuration.mdx
+++ b/packages/site/data/docs/intro/configuration.mdx
@@ -354,7 +354,7 @@ export default createTamagui({
 })
 ```
 
-For a full configuration, see [@tamagui/shorthands](https://github.com/tamagui/tamagui/blob/master/packages/shorthands/src/index.ts)
+For a full configuration, see [@tamagui/shorthands](https://github.com/tamagui/tamagui/blob/master/packages/shorthands/src/index.tsx)
 
 ### Others
 


### PR DESCRIPTION
Small fix on the Shorthands section of the docs.

![image](https://user-images.githubusercontent.com/849872/172029092-e858a5fd-24c5-4ef4-b2fd-f158d306b328.png)
