### PR TITLE
fix: correct path to `ci-prepare.sh` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Tamagui is a monorepo that makes it easy to contribute.
 As of now Tamagui has some encrypted files relating to upcoming features that you'll need to remove before install:
 
 ```
-./script/ci-prepare.sh
+./scripts/ci-prepare.sh
 ```
 
 Then install:


### PR DESCRIPTION
`./script/ci-prepare.sh` -> `./scripts/ci-prepare.sh`