### PR TITLE
remove expo --dev-client and replace with -c

### DIFF
--- a/starters/next-expo-solito/apps/expo/package.json
+++ b/starters/next-expo-solito/apps/expo/package.json
@@ -30,7 +30,7 @@
     "typescript": "^4.7.4"
   },
   "scripts": {
-    "start": "expo start --dev-client",
+    "start": "expo start -c",
     "android": "TAMAGUI_TARGET=native yarn expo run:android",
     "ios": "TAMAGUI_TARGET=native yarn expo run:ios",
     "web": "TAMAGUI_TARGET=web yarn expo start --web",


### PR DESCRIPTION
Currently the tamagui-starter template will prevent expo from building due to the reason that no dev-client is present. This will confuse new users an I suppose this was also not intentional, otherwise the dev-client should be part of the `devDependencies`.