### PR TITLE
feat(tailwind): Tamagui tailwind gives you Tailwind style variants and Stack + Text

### DIFF
--- a/packages/tailwind/package.json
+++ b/packages/tailwind/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@tamagui/tailwind",
+  "version": "1.0.1-beta.174",
+  "sideEffects": [
+    "*.css"
+  ],
+  "source": "src/index.ts",
+  "types": "./types/index.d.ts",
+  "main": "dist/cjs",
+  "module": "dist/esm",
+  "module:jsx": "dist/jsx",
+  "files": [
+    "src",
+    "types",
+    "dist"
+  ],
+  "scripts": {
+    "build": "tamagui-build",
+    "watch": "tamagui-build --watch",
+    "lint": "eslint",
+    "lint:fix": "yarn lint --fix"
+  },
+  "dependencies": {
+    "@tamagui/core": "^1.0.1-beta.174"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
+  },
+  "devDependencies": {
+    "@tamagui/build": "^1.0.1-beta.174",
+    "react": "*",
+    "react-dom": "*"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "a49cc7ea6b93ba384e77a4880ae48ac4a5635c14"
+}

--- a/packages/tailwind/src/Stack.tsx
+++ b/packages/tailwind/src/Stack.tsx
@@ -1,0 +1,7 @@
+import { Stack as TStack, styled } from '@tamagui/core'
+
+import { variants } from './variants'
+
+export const Stack = styled(TStack, {
+  variants,
+})

--- a/packages/tailwind/src/Text.tsx
+++ b/packages/tailwind/src/Text.tsx
@@ -1,0 +1,7 @@
+import { Text as TText, styled } from '@tamagui/core'
+
+import { variants } from './variants'
+
+export const Text = styled(TText, {
+  variants,
+})

--- a/packages/tailwind/src/index.ts
+++ b/packages/tailwind/src/index.ts
@@ -1,0 +1,3 @@
+export * from './Stack'
+export * from './Text'
+export * from './variants'

--- a/packages/tailwind/src/variants-width.ts
+++ b/packages/tailwind/src/variants-width.ts
@@ -1,0 +1,57 @@
+export const width = {
+  'w-0': {
+    true: {
+      width: 0,
+    },
+  },
+  'w-1': {
+    true: {
+      width: '$1',
+    },
+  },
+  'w-2': {
+    true: {
+      width: '$2',
+    },
+  },
+  'w-3': {
+    true: {
+      width: '$3',
+    },
+  },
+  'w-4': {
+    true: {
+      width: '$4',
+    },
+  },
+  'w-5': {
+    true: {
+      width: '$5',
+    },
+  },
+  'w-6': {
+    true: {
+      width: '$6',
+    },
+  },
+  'w-7': {
+    true: {
+      width: '$7',
+    },
+  },
+  'w-8': {
+    true: {
+      width: '$8',
+    },
+  },
+  'w-9': {
+    true: {
+      width: '$9',
+    },
+  },
+  'w-10': {
+    true: {
+      width: '$10',
+    },
+  },
+}

--- a/packages/tailwind/src/variants.ts
+++ b/packages/tailwind/src/variants.ts
@@ -1,0 +1,5 @@
+import { width } from './variants-width'
+
+export const variants = {
+  ...width,
+} as const

--- a/packages/tailwind/tsconfig.json
+++ b/packages/tailwind/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": { "composite": true},
+  "references": [
+    { "path": "../core" },
+    
+  ]
+}

--- a/packages/tailwind/types/Stack.d.ts
+++ b/packages/tailwind/types/Stack.d.ts
@@ -1,0 +1,50 @@
+export declare const Stack: import("@tamagui/core").TamaguiComponent<Omit<import("react-native").ViewProps, "display" | "children"> & import("@tamagui/core").RNWViewProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & Omit<{}, "w-0" | "w-1" | "w-2" | "w-3" | "w-4" | "w-5" | "w-6" | "w-7" | "w-8" | "w-9" | "w-10"> & {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+} & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").ViewProps, "display" | "children"> & import("@tamagui/core").RNWViewProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & Omit<{}, "w-0" | "w-1" | "w-2" | "w-3" | "w-4" | "w-5" | "w-6" | "w-7" | "w-8" | "w-9" | "w-10"> & {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+}>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").ViewProps, "display" | "children"> & import("@tamagui/core").RNWViewProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & Omit<{}, "w-0" | "w-1" | "w-2" | "w-3" | "w-4" | "w-5" | "w-6" | "w-7" | "w-8" | "w-9" | "w-10"> & {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+}>>, import("@tamagui/core").TamaguiElement, import("@tamagui/core").StackPropsBase, {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+}>;
+//# sourceMappingURL=Stack.d.ts.map

--- a/packages/tailwind/types/Text.d.ts
+++ b/packages/tailwind/types/Text.d.ts
@@ -1,0 +1,50 @@
+export declare const Text: import("@tamagui/core").TamaguiComponent<Omit<import("react-native").TextProps, "children"> & import("@tamagui/core").RNWTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "w-0" | "w-1" | "w-2" | "w-3" | "w-4" | "w-5" | "w-6" | "w-7" | "w-8" | "w-9" | "w-10"> & {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+} & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children"> & import("@tamagui/core").RNWTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "w-0" | "w-1" | "w-2" | "w-3" | "w-4" | "w-5" | "w-6" | "w-7" | "w-8" | "w-9" | "w-10"> & {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+}>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children"> & import("@tamagui/core").RNWTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "w-0" | "w-1" | "w-2" | "w-3" | "w-4" | "w-5" | "w-6" | "w-7" | "w-8" | "w-9" | "w-10"> & {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+}>>, import("@tamagui/core").TamaguiElement, import("@tamagui/core").TextPropsBase, {
+    readonly 'w-0'?: boolean | undefined;
+    readonly 'w-1'?: boolean | undefined;
+    readonly 'w-2'?: boolean | undefined;
+    readonly 'w-3'?: boolean | undefined;
+    readonly 'w-4'?: boolean | undefined;
+    readonly 'w-5'?: boolean | undefined;
+    readonly 'w-6'?: boolean | undefined;
+    readonly 'w-7'?: boolean | undefined;
+    readonly 'w-8'?: boolean | undefined;
+    readonly 'w-9'?: boolean | undefined;
+    readonly 'w-10'?: boolean | undefined;
+}>;
+//# sourceMappingURL=Text.d.ts.map

--- a/packages/tailwind/types/index.d.ts
+++ b/packages/tailwind/types/index.d.ts
@@ -1,0 +1,4 @@
+export * from './Stack';
+export * from './Text';
+export * from './variants';
+//# sourceMappingURL=index.d.ts.map

--- a/packages/tailwind/types/variants-width.d.ts
+++ b/packages/tailwind/types/variants-width.d.ts
@@ -1,0 +1,58 @@
+export declare const width: {
+    'w-0': {
+        true: {
+            width: number;
+        };
+    };
+    'w-1': {
+        true: {
+            width: string;
+        };
+    };
+    'w-2': {
+        true: {
+            width: string;
+        };
+    };
+    'w-3': {
+        true: {
+            width: string;
+        };
+    };
+    'w-4': {
+        true: {
+            width: string;
+        };
+    };
+    'w-5': {
+        true: {
+            width: string;
+        };
+    };
+    'w-6': {
+        true: {
+            width: string;
+        };
+    };
+    'w-7': {
+        true: {
+            width: string;
+        };
+    };
+    'w-8': {
+        true: {
+            width: string;
+        };
+    };
+    'w-9': {
+        true: {
+            width: string;
+        };
+    };
+    'w-10': {
+        true: {
+            width: string;
+        };
+    };
+};
+//# sourceMappingURL=variants-width.d.ts.map

--- a/packages/tailwind/types/variants.d.ts
+++ b/packages/tailwind/types/variants.d.ts
@@ -1,0 +1,58 @@
+export declare const variants: {
+    readonly 'w-0': {
+        true: {
+            width: number;
+        };
+    };
+    readonly 'w-1': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-2': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-3': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-4': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-5': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-6': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-7': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-8': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-9': {
+        true: {
+            width: string;
+        };
+    };
+    readonly 'w-10': {
+        true: {
+            width: string;
+        };
+    };
+};
+//# sourceMappingURL=variants.d.ts.map


### PR DESCRIPTION
May not touch this for a bit, but it's a good thing to have even if only for experimental sake, and since it will use tons of variants, it may motivate me to improve `styled()` flattening on the compiler.


Allows for:

```tsx
import { Stack } from '@tamagui/tailwind'

export default () => <Stack w-0 />
```