### PR TITLE
Rename Native to React Native in benchmarks, for clarity

### DIFF
--- a/apps/site/components/BenchmarkChart.tsx
+++ b/apps/site/components/BenchmarkChart.tsx
@@ -16,7 +16,7 @@ const getBarColor = (name: string) => {
     case 'react-native-web':
     case 'RN':
     case 'RNW':
-    case 'Native':
+    case 'React Native':
       return '$purple9'
     case 'Emotion':
       return '$green9'

--- a/apps/site/components/BenchmarkChartNative.tsx
+++ b/apps/site/components/BenchmarkChartNative.tsx
@@ -5,7 +5,7 @@ export const BenchmarkChartNative = () => (
     large
     data={[
       { name: 'Tamagui', value: 108 },
-      { name: 'Native', value: 106 },
+      { name: 'React Native', value: 106 },
       { name: 'NativeBase', value: 247 },
     ]}
   />

--- a/apps/site/data/docs/intro/benchmarks.mdx
+++ b/apps/site/data/docs/intro/benchmarks.mdx
@@ -3,7 +3,7 @@ title: Benchmarks
 description: Performance tests and comparisons.
 ---
 
-## Native
+## React Native
 
 In [this benchmark](https://github.com/tamagui/tamagui/blob/master/starters/benchmark/README.md) Tamagui is within 10% of the speed of vanilla React Native, even when using nearly all of it's features. We render list of 28 items with a few sections, text and images. Average of 5 runs on a Apple M2 Air:
 
@@ -22,7 +22,7 @@ Timing rendering a simple custom component.
 <BenchmarkChart
   data={[
     { name: 'Tamagui', value: 0.018 },
-    { name: 'Native', value: 0.057 },
+    { name: 'React Native', value: 0.057 },
     { name: 'NativeBase', value: 0.67 },
     { name: 'Dripsy', value: 0.042 },
   ]}
@@ -35,7 +35,7 @@ Changing variants is fast at runtime, and even faster when compiled:
 <BenchmarkChart
   data={[
     { name: 'Tamagui', value: 0.02 },
-    { name: 'Native', value: 0.063 },
+    { name: 'React Native', value: 0.063 },
     { name: 'NativeBase', value: 0.73 },
     { name: 'Dripsy', value: 0.108 },
   ]}
@@ -50,7 +50,7 @@ Tamagui has a big advantage for inline styles, it's the only library to compile 
 <BenchmarkChart
   data={[
     { name: 'Tamagui', value: 0.025 },
-    { name: 'Native', value: 0.06 },
+    { name: 'React Native', value: 0.06 },
     { name: 'NativeBase', value: 0.8 },
     { name: 'Dripsy', value: 0.266 },
   ]}

--- a/apps/site/data/docs/intro/compiler.mdx
+++ b/apps/site/data/docs/intro/compiler.mdx
@@ -27,7 +27,7 @@ Tamagui's compiler makes sharing significantly more code between native and web 
 
 Or, as a choose-two-of-three:
 
-<Table heading="Choose one">
+<Table heading="Choose one strategy">
   <TableCol>
     <TableCell head></TableCell>
     <TableCell>1</TableCell>


### PR DESCRIPTION
To avoid people thinking the benchmark is against pure native (iOS/Android).