### PR TITLE
fix(site): fixed typo in font language docs

### DIFF
--- a/apps/site/data/docs/core/font-language.mdx
+++ b/apps/site/data/docs/core/font-language.mdx
@@ -7,7 +7,7 @@ The `FontLanguage` component works with the Tamagui design system, allowing you 
 
 ### Rationale
 
-Before `FontLanguage`, you could get custom fonts with some effort. Simple create a `body` font, and a `body_french` font, and switch it out like so on relevant text components: `<Text fontFamily={isFrench ? '$body_french' : 'body'} />`.
+Before `FontLanguage`, you could get custom fonts with some effort. Simply create a `body` font, and a `body_french` font, and switch it out like so on relevant text components: `<Text fontFamily={isFrench ? '$body_french' : 'body'} />`.
 
 This would work, but having to update every Text component on page with a conditional would be terribly verbose and slow.
 


### PR DESCRIPTION
- Added a fix to the core font language page, correcting: "Simple create a `body` font, and a `body_french` font..." -> "Simply create a `body` font, and a `body_french` font..."