### PR TITLE
fix(core): delete weight/style when face applies

### DIFF
--- a/packages/core/src/createComponent.tsx
+++ b/packages/core/src/createComponent.tsx
@@ -677,6 +677,8 @@ export function createComponent<
             for (const style of styles) {
               if (style?.fontFamily) {
                 style.fontFamily = overrideFace
+                delete style.fontWeight
+                delete style.fontStyle
               }
             }
           }


### PR DESCRIPTION
Delete font weight and style when the font family is being overridden due to a native font face.

This is due to a bug where font weights 700 or above will look for a bold variant that doesn't exist, and fall back on the platform font.