### PR TITLE
fix(list-item): Make sure icon after spacer does not use the full width if not content will end up being cropped

### DIFF
--- a/packages/list-item/src/ListItem.tsx
+++ b/packages/list-item/src/ListItem.tsx
@@ -213,7 +213,7 @@ export const useListItem = (
           )}
           {themedIconAfter ? (
             <>
-              <Spacer flex size={spaceSize} />
+              <Spacer size={spaceSize} />
               {themedIconAfter}
             </>
           ) : null}


### PR DESCRIPTION
### Before
<img width="383" alt="Screenshot 2022-11-15 at 3 39 48 pm" src="https://user-images.githubusercontent.com/21725/201828191-4f24d92b-b8a6-4d25-a1f8-62ee77ac3335.png">


### After
<img width="388" alt="Screenshot 2022-11-15 at 3 40 13 pm" src="https://user-images.githubusercontent.com/21725/201828211-65155629-8665-4610-b4a2-fb4f52d5425a.png">
