### PR TITLE
Improve `ThemeInverse`

### DIFF
--- a/packages/core/src/helpers/themeable.tsx
+++ b/packages/core/src/helpers/themeable.tsx
@@ -16,17 +16,14 @@ export function themeable<Component extends (props: any) => any>(
   const withThemeComponent = forwardRef(function WithTheme(props: any, ref) {
     const { themeInverse, theme, ...rest } = props
     const element = React.createElement(component, { ...rest, ref } as any)
-    if (themeInverse) {
-      return <ThemeInverse>{element}</ThemeInverse>
-    }
-    if (theme || opts) {
-      return (
+    
+    return (
+      <ThemeInverse disabled={!themeInverse}>
         <Theme componentName={opts?.componentName} name={(theme as any) || null}>
           {element}
         </Theme>
-      )
-    }
-    return element
+      </ThemeInverse>
+    )
   })
 
   const withTheme: any = withThemeComponent

--- a/packages/core/src/views/ThemeInverse.tsx
+++ b/packages/core/src/views/ThemeInverse.tsx
@@ -1,8 +1,17 @@
 import { useIsomorphicLayoutEffect } from '@tamagui/constants'
 import React, { useState } from 'react'
+import { Platform } from 'react-native'
 
 import { useDefaultThemeName, useThemeName } from '../hooks/useTheme'
 import { Theme } from './Theme'
+
+const toggleTheme = (themeName: string) => {
+  if (themeName.startsWith('dark')) {
+    return 'light'
+  } else if (themeName.startsWith('light')) {
+    return 'dark'
+  }
+}
 
 export const ThemeInverse = ({
   children,
@@ -13,20 +22,31 @@ export const ThemeInverse = ({
 }) => {
   const themeName = useThemeName()
   const defaultTheme = useDefaultThemeName()
-  const [name, setName] = useState<null | string>(null)
+  
+  const themeWithFallback = themeName || defaultThemeName
+  
+  const [webThemeName, setWebThemeName] = useState<null | string>(null)
 
-  // ssr
-  useIsomorphicLayoutEffect(() => {
-    if (themeName.startsWith('dark')) {
-      setName('light')
-    } else if (themeName.startsWith('light')) {
-      setName('dark')
-    }
-  }, [defaultTheme, themeName])
-
-  if (disable) {
-    return children as JSX.Element
+  // ssr 
+  // it's ok to break this rule of hooks
+  if (Platform.OS == 'web') {
+    useIsomorphicLayoutEffect(() => {
+      if (themeWithFallback.startsWith('dark')) {
+        setWebThemeName('light')
+      } else if (themeWithFallback.startsWith('light')) {
+        setWebThemeName('dark')
+      }
+    }, [themeWithFallback])
   }
 
-  return <Theme name={name}>{children}</Theme>
+  return (
+    <Theme 
+      name={Platform.select({ 
+        web: webThemeName, 
+        default: disabled ? themeWithFallback : toggleTheme(themeWithFallback) || themeWithFallback
+      })}
+    >
+      {children}
+    </Theme>
+  )
 }


### PR DESCRIPTION
Currently, `ThemeInverse` resets the component tree, which isn't good for cases of getting conditionally rendered. It also double renders on native for Web's SSR support, which is fixed here by deriving the theme rather than triggering a new render.

