### PR TITLE
fix config weight usage to be string

### DIFF
--- a/apps/site/data/docs/core/configuration.mdx
+++ b/apps/site/data/docs/core/configuration.mdx
@@ -80,8 +80,8 @@ const interFont = createFont({
     // ...
   },
   weight: {
-    4: 300,
-    6: 600,
+    4: '300',
+    6: '600',
   },
   letterSpacing: {
     4: 0,
@@ -270,8 +270,8 @@ const interFont = createFont({
     // ...
   },
   weight: {
-    4: 300,
-    6: 600,
+    4: '300',
+    6: '600',
   },
   letterSpacing: {
     4: 0,


### PR DESCRIPTION
as discussed on discord, examples were showing font weight in a number rather than string -- the former which is turned into pixels and not picked up as a font.

i also changed the font `face` key to be a string. 

the first commit is for docs fix, the second commit changes font face to string in code if you want to keep that too.

