### PR TITLE
Resolve types to `RadiusTokens` for border radius.

### DIFF
--- a/packages/core/types/types.d.ts
+++ b/packages/core/types/types.d.ts
@@ -323,7 +323,7 @@ declare type FontWeightKeys = 'fontWeight';
 declare type FontLetterSpacingKeys = 'letterSpacing';
 declare type LineHeightKeys = 'lineHeight';
 declare type ZIndexKeys = 'zIndex';
-export declare type ThemeValueGet<K extends string | number | symbol> = K extends 'theme' ? ThemeTokens : K extends SizeKeys ? SizeTokens : K extends FontKeys ? FontTokens : K extends FontSizeKeys ? FontSizeTokens : K extends SpaceKeys ? K extends 'shadowOffset' ? {
+export declare type ThemeValueGet<K extends string | number | symbol> = K extends 'theme' ? ThemeTokens : K extends SizeKeys ? SizeTokens : K extends FontKeys ? FontTokens : K extends FontSizeKeys ? FontSizeTokens : K extends `${`border${string | ''}Radius`}` ? RadiusTokens : K extends SpaceKeys ? K extends 'shadowOffset' ? {
     width: SpaceTokens;
     height: SpaceTokens;
 } : SpaceTokens : K extends ColorKeys ? ColorTokens : K extends ZIndexKeys ? ZIndexTokens : K extends LineHeightKeys ? FontLineHeightTokens : K extends FontWeightKeys ? FontWeightTokens : K extends FontLetterSpacingKeys ? FontLetterSpacingTokens : never;


### PR DESCRIPTION
Close #395 by adding this: `K extends `${`border${string | ''}Radius`}` ? RadiusTokens :`.