### PR TITLE
Ease the dependency on @expo/match-media

### DIFF
--- a/apps/site/data/docs/core/use-media.mdx
+++ b/apps/site/data/docs/core/use-media.mdx
@@ -3,6 +3,18 @@ title: useMedia
 description: Designing for different size screens.
 ---
 
+`@tamagui/core` doesn't provide media capabilities out of the box to native apps. To enable media queries, you need to provide matchMedia implementation by calling `setupMatchMedia` in your configuration file:
+```tsx
+import { createMedia } from '@tamagui/react-native-match-media'
+
+export default createTamagui({
+  media: createMedia({
+    xs: { maxWidth: 660 },
+    // ...
+  })
+})
+```
+
 Define your media rules in the media object of your `tamagui.config.ts`:
 
 ```tsx line=2-6

--- a/packages/core-node/types/helpers/matchMedia.d.ts
+++ b/packages/core-node/types/helpers/matchMedia.d.ts
@@ -1,2 +1,6 @@
-export declare const matchMedia: ((query: string) => MediaQueryList) & typeof globalThis.matchMedia;
+import { MatchMedia, MediaQueryList } from "../types";
+export declare const matchMedia: (((query: string) => globalThis.MediaQueryList) & typeof globalThis.matchMedia) | typeof matchMediaFallback;
+declare function matchMediaFallback(query: string): MediaQueryList;
+export declare function setupMatchMedia(nativeMatchMedia: MatchMedia): void;
+export {};
 //# sourceMappingURL=matchMedia.d.ts.map

--- a/packages/core-node/types/helpers/matchMedia.native.d.ts
+++ b/packages/core-node/types/helpers/matchMedia.native.d.ts
@@ -1,3 +1,4 @@
-import MediaQueryList from '@expo/match-media/build/MediaQueryList.js';
-export declare const matchMedia: (media: string) => MediaQueryList;
+import { MatchMedia, MediaQueryList } from "../types";
+export declare let matchMedia: MatchMedia;
+export declare function setupMatchMedia(nativeMatchMedia: (media: string) => MediaQueryList): void;
 //# sourceMappingURL=matchMedia.native.d.ts.map

--- a/packages/core-node/types/types.d.ts
+++ b/packages/core-node/types/types.d.ts
@@ -270,6 +270,12 @@ export declare type MediaProps<A> = {
 export declare type MediaQueries = {
     [key in MediaQueryKey]: MediaQueryObject;
 };
+export interface MediaQueryList {
+    addListener(listener?: any): void;
+    removeListener(listener?: any): void;
+    matches: boolean;
+}
+export declare type MatchMedia = (query: string) => MediaQueryList;
 export declare type TransformStyleProps = {
     x?: number;
     y?: number;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,6 @@
     "reset.css"
   ],
   "dependencies": {
-    "@expo/match-media": "^0.3.0",
     "@tamagui/compose-refs": "^1.0.1-rc.0.2",
     "@tamagui/constants": "^1.0.1-rc.0.2",
     "@tamagui/helpers": "^1.0.1-rc.0.2",

--- a/packages/core/src/helpers/matchMedia.native.ts
+++ b/packages/core/src/helpers/matchMedia.native.ts
@@ -1,6 +1,25 @@
-import MediaQueryList from '@expo/match-media/build/MediaQueryList.js'
+import { MatchMedia, MediaQueryList } from "../types"
 
-export const matchMedia = (media: string) => new MediaQueryList(media)
+export let matchMedia: MatchMedia;
 
-// @ts-ignore
-globalThis['matchMedia'] = matchMedia
+setupMatchMedia(matchMediaFallback);
+
+function matchMediaFallback(query: string): MediaQueryList {
+  if (
+    process.env.NODE_ENV === 'development'
+  ) {
+    // eslint-disable-next-line no-console
+    console.warn('warning: matchMedia implementation is not provided.')
+  }
+  return {
+    addListener() {},
+    removeListener() {},
+    matches: false,
+  }
+}
+
+export function setupMatchMedia(nativeMatchMedia: (media: string) => MediaQueryList) {
+  matchMedia = nativeMatchMedia;
+  // @ts-ignore
+  globalThis['matchMedia'] = matchMedia
+}

--- a/packages/core/src/helpers/matchMedia.ts
+++ b/packages/core/src/helpers/matchMedia.ts
@@ -1,3 +1,5 @@
+import { MatchMedia, MediaQueryList } from "../types"
+
 export const matchMedia = (typeof window !== 'undefined' && window.matchMedia) || matchMediaFallback
 
 function matchMediaFallback(query: string): MediaQueryList {
@@ -13,5 +15,10 @@ function matchMediaFallback(query: string): MediaQueryList {
     addListener() {},
     removeListener() {},
     matches: false,
-  } as any
+  }
+}
+
+export function setupMatchMedia(nativeMatchMedia: MatchMedia) {
+  // eslint-disable-next-line no-console
+  console.warn('no-op web')
 }

--- a/packages/core/src/types.tsx
+++ b/packages/core/src/types.tsx
@@ -413,6 +413,14 @@ export type MediaQueries = {
   [key in MediaQueryKey]: MediaQueryObject
 }
 
+export interface MediaQueryList {
+  addListener(listener?: any): void;
+  removeListener(listener?: any): void;
+  matches: boolean;
+}
+
+export type MatchMedia = (query: string) => MediaQueryList;
+
 export type TransformStyleProps = {
   x?: number
   y?: number

--- a/packages/core/types/helpers/matchMedia.d.ts
+++ b/packages/core/types/helpers/matchMedia.d.ts
@@ -1,2 +1,6 @@
-export declare const matchMedia: ((query: string) => MediaQueryList) & typeof globalThis.matchMedia;
+import { MatchMedia, MediaQueryList } from "../types";
+export declare const matchMedia: (((query: string) => globalThis.MediaQueryList) & typeof globalThis.matchMedia) | typeof matchMediaFallback;
+declare function matchMediaFallback(query: string): MediaQueryList;
+export declare function setupMatchMedia(nativeMatchMedia: MatchMedia): void;
+export {};
 //# sourceMappingURL=matchMedia.d.ts.map

--- a/packages/core/types/helpers/matchMedia.native.d.ts
+++ b/packages/core/types/helpers/matchMedia.native.d.ts
@@ -1,3 +1,4 @@
-import MediaQueryList from '@expo/match-media/build/MediaQueryList.js';
-export declare const matchMedia: (media: string) => MediaQueryList;
+import { MatchMedia, MediaQueryList } from "../types";
+export declare let matchMedia: MatchMedia;
+export declare function setupMatchMedia(nativeMatchMedia: (media: string) => MediaQueryList): void;
 //# sourceMappingURL=matchMedia.native.d.ts.map

--- a/packages/core/types/types.d.ts
+++ b/packages/core/types/types.d.ts
@@ -270,6 +270,12 @@ export declare type MediaProps<A> = {
 export declare type MediaQueries = {
     [key in MediaQueryKey]: MediaQueryObject;
 };
+export interface MediaQueryList {
+    addListener(listener?: any): void;
+    removeListener(listener?: any): void;
+    matches: boolean;
+}
+export declare type MatchMedia = (query: string) => MediaQueryList;
 export declare type TransformStyleProps = {
     x?: number;
     y?: number;

--- a/packages/react-native-media-driver/package.json
+++ b/packages/react-native-media-driver/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@tamagui/react-native-media-driver",
+  "version": "1.0.1-rc.0.2",
+  "source": "src/index.ts",
+  "main": "dist/cjs",
+  "module": "dist/esm",
+  "types": "./types/index.d.ts",
+  "license": "MIT",
+  "files": [
+    "src",
+    "types",
+    "dist"
+  ],
+  "sideEffects": true,
+  "dependencies": {
+    "@tamagui/core": "^1.0.1-rc.0.2",
+    "css-mediaquery": "^0.1.2"
+  },
+  "devDependencies": {
+    "@tamagui/build": "^1.0.1-rc.0.2",
+    "react-native": "*"
+  },
+  "peerDependencies": {
+    "react-native": "*"
+  },
+  "scripts": {
+    "build": "tamagui-build",
+    "watch": "tamagui-build --watch",
+    "clean": "tamagui-build clean",
+    "clean:build": "tamagui-build clean:build"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/react-native-media-driver/src/createMedia.ts
+++ b/packages/react-native-media-driver/src/createMedia.ts
@@ -1,0 +1,7 @@
+import { setupMatchMedia } from '@tamagui/core'
+import { matchMedia } from './matchMedia'
+
+export function createMedia<A extends Object>(media: A): A{
+  setupMatchMedia(matchMedia)
+  return media
+}

--- a/packages/react-native-media-driver/src/index.ts
+++ b/packages/react-native-media-driver/src/index.ts
@@ -1,0 +1,2 @@
+export * from './createMedia'
+export * from './matchMedia'

--- a/packages/react-native-media-driver/src/matchMedia.ts
+++ b/packages/react-native-media-driver/src/matchMedia.ts
@@ -1,0 +1,4 @@
+import { MatchMedia } from '@tamagui/core'
+import { NativeMediaQueryList } from './mediaQueryList'
+
+export const matchMedia: MatchMedia = (query) => new NativeMediaQueryList(query)

--- a/packages/react-native-media-driver/src/mediaQueryList.ts
+++ b/packages/react-native-media-driver/src/mediaQueryList.ts
@@ -1,0 +1,50 @@
+import mediaQuery from 'css-mediaquery'
+import { Dimensions } from 'react-native'
+import { MediaQueryList } from '@tamagui/core'
+
+type Orientation = 'landscape' | 'portrait';
+
+type Listener = (orientation: Orientation) => void;
+
+export class NativeMediaQueryList implements MediaQueryList {
+  private listeners: Listener[] = []
+  
+  private get orientation(): Orientation {
+    const windowDimensions = Dimensions.get('window')
+    return windowDimensions.height > windowDimensions.width ? 'portrait' : 'landscape'
+  }
+
+  constructor(private query: string) {
+    this.notify()
+    Dimensions.addEventListener('change', () => {
+      this.notify()
+    });
+  }
+
+  private notify() {
+    this.listeners.forEach((listener) => {
+      listener(this.orientation)
+    })
+  }
+
+  addListener(listener: Listener) {
+    this.listeners.push(listener)
+  }
+
+  removeListener(listener: Listener) {
+    const index = this.listeners.indexOf(listener)
+    if (index !== -1) this.listeners.splice(index, 1)
+  }
+
+  get matches(): boolean {
+    const windowDimensions = Dimensions.get("window")
+    const matches = mediaQuery.match(this.query, {
+      type: "screen",
+      orientation: this.orientation,
+      ...windowDimensions,
+      "device-width": windowDimensions.width,
+      "device-height": windowDimensions.height,
+    })
+    return matches
+  }
+}

--- a/packages/react-native-media-driver/tsconfig.json
+++ b/packages/react-native-media-driver/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true
+  }
+}

--- a/packages/react-native-media-driver/types/createMedia.d.ts
+++ b/packages/react-native-media-driver/types/createMedia.d.ts
@@ -1,0 +1,2 @@
+export declare function createMedia<A extends Object>(media: A): A;
+//# sourceMappingURL=createMedia.d.ts.map

--- a/packages/react-native-media-driver/types/index.d.ts
+++ b/packages/react-native-media-driver/types/index.d.ts
@@ -1,0 +1,3 @@
+export * from './createMedia';
+export * from './matchMedia';
+//# sourceMappingURL=index.d.ts.map

--- a/packages/react-native-media-driver/types/matchMedia.d.ts
+++ b/packages/react-native-media-driver/types/matchMedia.d.ts
@@ -1,0 +1,3 @@
+import { MatchMedia } from '@tamagui/core';
+export declare const matchMedia: MatchMedia;
+//# sourceMappingURL=matchMedia.d.ts.map

--- a/packages/react-native-media-driver/types/mediaQueryList.d.ts
+++ b/packages/react-native-media-driver/types/mediaQueryList.d.ts
@@ -1,0 +1,15 @@
+import { MediaQueryList } from '@tamagui/core';
+declare type Orientation = 'landscape' | 'portrait';
+declare type Listener = (orientation: Orientation) => void;
+export declare class NativeMediaQueryList implements MediaQueryList {
+    private query;
+    private listeners;
+    private get orientation();
+    constructor(query: string);
+    private notify;
+    addListener(listener: Listener): void;
+    removeListener(listener: Listener): void;
+    get matches(): boolean;
+}
+export {};
+//# sourceMappingURL=mediaQueryList.d.ts.map

--- a/packages/tamagui/package.json
+++ b/packages/tamagui/package.json
@@ -49,6 +49,7 @@
     "@tamagui/popper": "^1.0.1-rc.0.2",
     "@tamagui/portal": "^1.0.1-rc.0.2",
     "@tamagui/progress": "^1.0.1-rc.0.2",
+    "@tamagui/react-native-media-driver": "^1.0.1-rc.0.2",
     "@tamagui/scroll-view": "^1.0.1-rc.0.2",
     "@tamagui/select": "^1.0.1-rc.0.2",
     "@tamagui/separator": "^1.0.1-rc.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5444,7 +5444,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tamagui/core@workspace:packages/core"
   dependencies:
-    "@expo/match-media": ^0.3.0
     "@tamagui/build": ^1.0.1-rc.0.2
     "@tamagui/compose-refs": ^1.0.1-rc.0.2
     "@tamagui/constants": ^1.0.1-rc.0.2
@@ -5998,6 +5997,19 @@ __metadata:
   dependencies:
     "@reach/auto-id": ^0.18.0
     use-sync-external-store: ^1.2.0
+  languageName: unknown
+  linkType: soft
+
+"@tamagui/react-native-media-driver@^1.0.1-rc.0.2, @tamagui/react-native-media-driver@workspace:packages/react-native-media-driver":
+  version: 0.0.0-use.local
+  resolution: "@tamagui/react-native-media-driver@workspace:packages/react-native-media-driver"
+  dependencies:
+    "@tamagui/build": ^1.0.1-rc.0.2
+    "@tamagui/core": ^1.0.1-rc.0.2
+    css-mediaquery: ^0.1.2
+    react-native: "*"
+  peerDependencies:
+    react-native: "*"
   languageName: unknown
   linkType: soft
 
@@ -22973,6 +22985,7 @@ __metadata:
     "@tamagui/popper": ^1.0.1-rc.0.2
     "@tamagui/portal": ^1.0.1-rc.0.2
     "@tamagui/progress": ^1.0.1-rc.0.2
+    "@tamagui/react-native-media-driver": ^1.0.1-rc.0.2
     "@tamagui/scroll-view": ^1.0.1-rc.0.2
     "@tamagui/select": ^1.0.1-rc.0.2
     "@tamagui/separator": ^1.0.1-rc.0.2


### PR DESCRIPTION
I wanted to bring attention to the hard dependency on @expo/match-media. IMO core module should not force the bare react-native developer to install the expo module, which requires changes to the native code. 

In this PR I drafted an option to make the match-media function pluggable. It will simplify the installation process for react-native developers who might not even use media props.

@natew, let me know how we can tackle this issue.