### PR TITLE
fix(core): Hash themeKeys in getThemeCSSRules

### DIFF
--- a/packages/core/src/helpers/getThemeCSSRules.ts
+++ b/packages/core/src/helpers/getThemeCSSRules.ts
@@ -2,6 +2,7 @@ import { THEME_CLASSNAME_PREFIX } from '../constants/constants'
 import { Variable, variableToString } from '../createVariable'
 import { CreateTamaguiProps, ThemeParsed } from '../types'
 import { tokensValueToVariable } from './registerCSSVariable'
+import { simpleHash } from '@tamagui/helpers'
 
 export function getThemeCSSRules({
   config,
@@ -34,7 +35,8 @@ export function getThemeCSSRules({
     } else {
       value = tokensValueToVariable.get(variable.val)!.variable
     }
-    vars += `--${themeKey}:${value};`
+    // Hash themeKey in case it has invalid chars too
+    vars += `--${simpleHash(themeKey, 40)}:${value};`
   }
 
   const isDarkOrLightBase = themeName === 'dark' || themeName === 'light'


### PR DESCRIPTION
It looks like we are hashing correctly and processing out `.` characters etc for the base colors in `tokens`, but not for theme token names.

This was resulting in situations where you'd see `<div class="--backgroundsecondary1a ..."/>` but in the CSS panel, no CSS variable `--backgroundsecondary1a` existed.

My solution is to hash the themeKeys when processing theme css rules via `createTamagui()` -> `getThemeCSSRules()`.

So far I haven't seen this affect any other pieces.
