### PR TITLE
Add .tamagui folder to .gitignore

### DIFF
--- a/starters/next-expo-solito/.gitignore
+++ b/starters/next-expo-solito/.gitignore
@@ -13,6 +13,9 @@
 **/.next/*
 /out/
 
+# tamagui
+**/.tamagui/*
+
 # production
 /build
 


### PR DESCRIPTION
`/next/.tamagui` doesn't seem to be necessary for deployment and clogs up git diffs. Shall we ignore it?