### PR TITLE
Fix for create-tamagui-app for Windows

### DIFF
--- a/packages/create-tamagui-app/src/index.ts
+++ b/packages/create-tamagui-app/src/index.ts
@@ -185,7 +185,7 @@ ${chalk.bold(chalk.red(`Please pick a different project name 🥸`))}`
             ? `file://${repoRoot}`
             : `https://github.com/tamagui/tamagui.git`
 
-        await $`git clone --branch ${branch} --depth 1 --filter=blob:none --sparse ${sourceGitRepo} ${targetGitDir}`
+        execSync(`git clone --branch ${branch} --depth 1 --filter=blob:none --sparse ${sourceGitRepo} ${targetGitDir}`);
       } else {
         if (!(await pathExists(join(targetGitDir, '.git')))) {
           console.error(`Corrupt Tamagui directory, please delete ${targetGitDir} and re-run`)
@@ -194,10 +194,9 @@ ${chalk.bold(chalk.red(`Please pick a different project name 🥸`))}`
       }
 
       console.log(`Updating tamagui starters repo`)
-      cd(targetGitDir)
-      await $`git sparse-checkout set starters`
+      execSync(`git sparse-checkout set starters`, { cwd: targetGitDir });
       try {
-        await $`git pull --rebase --allow-unrelated-histories --depth 1 origin ${branch}`
+        execSync(`git pull --rebase --allow-unrelated-histories --depth 1 origin ${branch}`, { cwd: targetGitDir });
       } catch (err: any) {
         console.log(
           `Error updating: ${err.message} ${


### PR DESCRIPTION
Hi @natew - I've tested this on Windows and WSL (Linux) systems and it seem to solve the create app issues on Windows.

The main problem was coming from the "zx" library: https://github.com/google/zx/issues/551

It was creating commands which were not formatted correctly on Windows (specifically the commands related to git things), so they were failing. I've replaced the failing commands with `execSync()` instead, and all seems to work just as expected.

This PR should fix https://github.com/tamagui/tamagui/issues/312