### PR TITLE
Should work with non hoisted to root of workspace dependencies (pnpm)

### DIFF
--- a/packages/static/src/extractor/loadTamagui.ts
+++ b/packages/static/src/extractor/loadTamagui.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs'
 /* eslint-disable no-console */
-import { basename, dirname, extname, join, relative, sep } from 'path'
+import { basename, dirname, extname, join, relative, sep, resolve } from 'path'
 
 import generate from '@babel/generator'
 import traverse from '@babel/traverse'
@@ -179,7 +179,8 @@ Tamagui built config and components:`
 }
 
 export function resolveWebOrNativeSpecificEntry(entry: string) {
-  const resolved = require.resolve(entry)
+  const workspaceRoot = resolve()
+  const resolved = require.resolve(entry, {paths: [workspaceRoot]})
   const ext = extname(resolved)
   const fileName = basename(resolved).replace(ext, '')
   const specificExt = process.env.TAMAGUI_TARGET === 'web' ? 'web' : 'native'


### PR DESCRIPTION
Currently when you use pnpm you will get error:

```
Tamagui Webpack Loader Error:
next-app:dev:    Cannot find module '@my/ui'
```

This will fix it and will resolve @my/ui in workspace like for example next-app.