### PR TITLE
[Issue] pressStyle={{ bg: ... }} has issues on native

### DIFF
--- a/starters/next-expo-solito/packages/app/features/home/screen.tsx
+++ b/starters/next-expo-solito/packages/app/features/home/screen.tsx
@@ -5,6 +5,7 @@ import {
   H1,
   MyComponent,
   Paragraph,
+  SizableText,
   Separator,
   Sheet,
   XStack,
@@ -42,9 +43,14 @@ export function HomeScreen() {
         </Paragraph>
       </YStack>
 
-      <XStack>
-        <Button {...linkProps}>Link to user</Button>
-      </XStack>
+      <YStack>
+        <SizableText onPress={() => {}} pressStyle={{ bg: 'red' }}>
+          Press me and see what happens
+        </SizableText>
+        <SizableText onPress={() => {}} pressStyle={{ bg: 'transparent' }}>
+          Press me and see what happens
+        </SizableText>
+      </YStack>
 
       <XStack $sm={{ fd: 'column' }} space>
         <MyComponent w={50} h={50} blue />


### PR DESCRIPTION
There's no way to get rid of the grey background color that occurs when pressing on pressable text in native.

You'll notice in this example that it works as expected on Web, but in Native we get a grey background color no matter what. The example with `bg: 'red'` seems to work, but we still end up with a grey border.

This grey background color behavior seems to be default in React Native. I did some basic research and saw that you can remove it like this:

```
  <TouchableOpacity onPress={() => console.log('pressing text')} activeOpacity={1}>
    <RNText style={{ color: 'white' }}>Press this text</RNText>
  </TouchableOpacity>
```

Just wondering how hard it would be to implement this sort of thing in Tamagui so that we can configure the background pressStyle using tamagui component props?

Thanks!