### PR TITLE
fix: let useCurrentColor access token colors

### DIFF
--- a/packages/helpers-tamagui/src/useCurrentColor.tsx
+++ b/packages/helpers-tamagui/src/useCurrentColor.tsx
@@ -3,7 +3,13 @@ import type { TextStyle } from 'react-native'
 
 export const useCurrentColor = (colorProp: ColorProp) => {
   const theme = useTheme()
-  return variableToString(theme[colorProp as any] || colorProp || theme.color)
+  const tokens = getTokens(true)
+  return variableToString(
+    theme[colorProp as any] || 
+    tokens.color[colorProp as any] || 
+    colorProp || 
+    theme.color
+  )
 }
 
 export type ColorProp = ThemeValueFallback | ColorTokens | TextStyle['color'] | undefined


### PR DESCRIPTION
Currently when working with icons inside components and using the `getThemedIcon`, you are unable to pass color tokens from `tokens.color` which have not been declared explicitly in `createTheme({ ... })`.

This PR adds a fallback to the `useCurrentColor` hook to also look for the color in `tokens.color` when returning the current color.