### PR TITLE
Simply `_app.tsx`

### DIFF
--- a/starters/next-expo-solito/apps/next/pages/_app.tsx
+++ b/starters/next-expo-solito/apps/next/pages/_app.tsx
@@ -9,14 +9,7 @@ import React, { useMemo } from 'react'
 import type { SolitoAppProps } from 'solito'
 import 'raf/polyfill'
 
-function MyApp({ Component, pageProps }: SolitoAppProps) {
-  const [theme, setTheme] = useRootTheme()
-
-  const contents = useMemo(() => {
-    // @ts-ignore
-    return <Component {...pageProps} />
-  }, [Component, pageProps])
-
+function MyApp({ Component, pageProps }: SolitoAppProps) 
   return (
     <>
       <Head>
@@ -24,12 +17,22 @@ function MyApp({ Component, pageProps }: SolitoAppProps) {
         <meta name="description" content="Tamagui, Solito, Expo & Next.js" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <NextThemeProvider onChangeTheme={setTheme}>
-        <Provider disableRootThemeClass defaultTheme={theme}>
-          {contents}
-        </Provider>
-      </NextThemeProvider>
+      <ThemeProvider>
+        <Component {...pageProps} />
+      </ThemeProvider>
     </>
+  )
+}
+
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useRootTheme()
+
+  return (
+    <NextThemeProvider onChangeTheme={setTheme}>
+      <Provider disableRootThemeClass defaultTheme={theme}>
+        {children}
+      </Provider>
+    </NextThemeProvider>
   )
 }
 


### PR DESCRIPTION
The memoization here isn't necessary if we simply use the parent-child paradigm from React. Since `props` will have the same reference for `ThemeProvider`, updating the theme won't trigger any re-renders to its `props.children`.

More context here: https://kentcdodds.com/blog/optimize-react-re-renders