### PR TITLE
build: run ci checks on pull requests

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,6 +1,7 @@
 name: Checks
 
 on:
+  pull_request:
   push:
     paths-ignore:
       - 'assets/**'


### PR DESCRIPTION
I'm noticing PRs aren't running CI - the workflow is only hooked to "push" right now for branches local to this project. This should allow incoming PRs to also run the `checks.yaml` workflow.