### PR TITLE
fix(focusable): unregister focusable Inputs before reregistering between renders

### DIFF
--- a/packages/focusable/src/registerFocusable.ts
+++ b/packages/focusable/src/registerFocusable.ts
@@ -1,6 +1,6 @@
 import { Focusable } from './focusable'
 
-export const registerFocusable = (id: string, input: Focusable) => {
+export const registerFocusable = (id: string, input: Focusable) => () => {
   // noop focus is handed natively
 }
 

--- a/packages/focusable/types/registerFocusable.d.ts
+++ b/packages/focusable/types/registerFocusable.d.ts
@@ -1,5 +1,5 @@
-import { Focusable } from './focusable';
-export declare const registerFocusable: (id: string, input: Focusable) => void;
-export declare const unregisterFocusable: (id: string) => void;
-export declare const focusFocusable: (id: string) => void;
+import { Focusable } from './focusable'
+export declare const registerFocusable: (id: string, input: Focusable) => () => void
+export declare const unregisterFocusable: (id: string) => void
+export declare const focusFocusable: (id: string) => void
 //# sourceMappingURL=registerFocusable.d.ts.map


### PR DESCRIPTION
Alternative to #463. Fixes #462 

The same solution, but without an additional render.

* Update `focusableInputHOC` to unregister its component before attempting to register again
* Update `registerFocusable()` types + web implementation to match type shape of the native implementation