### PR TITLE
Add `tsx` for better syntax highlighting

### DIFF
--- a/apps/site/data/docs/guides/next-js.mdx
+++ b/apps/site/data/docs/guides/next-js.mdx
@@ -131,7 +131,7 @@ Animations that run through JS drivers and have `enterStyle` set will want to ad
 
 Add this to your `_app.tsx` render output:
 
-```
+```tsx
 <NextHead>
   <script
     key="tamagui-animations-mount"


### PR DESCRIPTION
![CleanShot 2022-12-30 at 14 23 14@2x](https://user-images.githubusercontent.com/1231836/210109297-1521b063-388d-4956-9c01-e1b8ded7d24f.png)

Location: https://tamagui.dev/docs/guides/next-js (bottom of page)

The top code block uses `tsx` syntax highlighting, and the bottom code block is not. This PR adds `tsx` to the code block to present the code block with better formatting.