### PR TITLE
Fix typo in design systems doc

### DIFF
--- a/apps/site/data/docs/guides/design-systems.mdx
+++ b/apps/site/data/docs/guides/design-systems.mdx
@@ -10,7 +10,7 @@ To skip to some real examples:
 
 Tamagui allows you to build our your own set of components that are optimized with the compiler whenever they are used in your app.
 
-By default, if you just use `styled()` in your app, Tamagui **won't** be able to optimize those components. This is because the compiler needs to be know about those components at build-time.
+By default, if you just use `styled()` in your app, Tamagui **won't** be able to optimize those components. This is because the compiler needs to know about those components at build-time.
 
 Let's break down how to set this up in more detail.
 


### PR DESCRIPTION
Simple fix to typo/grammar in design systems documentation.