### PR TITLE
build: add missing react-native-media-driver dependency to config-base

### DIFF
--- a/packages/config-base/package.json
+++ b/packages/config-base/package.json
@@ -32,6 +32,7 @@
     "@tamagui/core": "^1.0.3",
     "@tamagui/font-inter": "^1.0.3",
     "@tamagui/font-silkscreen": "^1.0.3",
+    "@tamagui/react-native-media-driver": "^1.0.3",
     "@tamagui/shorthands": "^1.0.3",
     "@tamagui/theme-base": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4617,6 +4617,7 @@ __metadata:
     "@tamagui/core": ^1.0.3
     "@tamagui/font-inter": ^1.0.3
     "@tamagui/font-silkscreen": ^1.0.3
+    "@tamagui/react-native-media-driver": ^1.0.3
     "@tamagui/shorthands": ^1.0.3
     "@tamagui/theme-base": ^1.0.3
   languageName: unknown


### PR DESCRIPTION
While building a design kit - we imported `@tamagui/config-base` and built and it crashed with:

```
error: Error: Unable to resolve module @tamagui/react-native-media-driver from /Users/xxx/iOSProjects/xxx-app/node_modules/@tamagui/config-base/dist/cjs/media.js: @tamagui/react-native-media-driver could not be found within the project or in these directories:
  node_modules
  25 | });
  26 | module.exports = __toCommonJS(media_exports);
> 27 | var import_react_native_media_driver = require("@tamagui/react-native-media-driver");
```

The project seems to use that import - https://github.com/tamagui/tamagui/blob/master/packages/config-base/src/media.ts#L1, but is missing it in the scoped `package.json`.