### PR TITLE
Update starters URL in Design Systems guide

### DIFF
--- a/apps/site/data/docs/guides/design-systems.mdx
+++ b/apps/site/data/docs/guides/design-systems.mdx
@@ -5,7 +5,7 @@ description: Put together your own design system.
 
 To skip to some real examples:
 
-- `create-tamagui` is itself a [well structured monorepo](https://github.com/tamagui/starters).
+- `create-tamagui` is itself a [well structured monorepo](https://github.com/tamagui/tamagui/tree/master/starters).
 - More complete, the [tamagui](https://github.com/tamagui/tamagui/tree/master/packages/tamagui) package itself.
 
 Tamagui allows you to build our your own set of components that are optimized with the compiler whenever they are used in your app.


### PR DESCRIPTION
The previous URL is pointing to the archived repository.