### PR TITLE
Add keys to react-native-web-lite package.json

### DIFF
--- a/packages/react-native-web-lite/package.json
+++ b/packages/react-native-web-lite/package.json
@@ -50,5 +50,13 @@
     "react-component",
     "react-native",
     "web"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tamagui/tamagui.git",
+    "directory": "packages/react-native-web-lite"
+  },
+  "bugs": {
+    "url": "https://github.com/tamagui/tamagui/issues"
+  }
 }


### PR DESCRIPTION
Hi there, first of all, thanks for Tamagui, seems cool!

Just a quick PR to add the repo website and bugs link to [the `react-native-web-lite` npm package](https://www.npmjs.com/package/react-native-web-lite), which is currently not listed:

![Screenshot 2023-01-06 at 18 23 19](https://user-images.githubusercontent.com/1935696/211065152-68d4d017-6a8a-46c1-962c-0829e68a7b0d.png)
