### PR TITLE
fix: update starters to use transition in next theme change handler

### DIFF
--- a/apps/starter/apps/next/pages/_app.tsx
+++ b/apps/starter/apps/next/pages/_app.tsx
@@ -1,13 +1,13 @@
 import '@tamagui/core/reset.css'
 import '@tamagui/font-inter/css/400.css'
 import '@tamagui/font-inter/css/700.css'
+import 'raf/polyfill'
 
 import { NextThemeProvider, useRootTheme } from '@tamagui/next-theme'
 import { Provider } from 'app/provider'
 import Head from 'next/head'
-import React, { useMemo } from 'react'
+import React, { startTransition } from 'react'
 import type { SolitoAppProps } from 'solito'
-import 'raf/polyfill'
 
 function MyApp({ Component, pageProps }: SolitoAppProps) {
   return (
@@ -28,7 +28,13 @@ function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useRootTheme()
 
   return (
-    <NextThemeProvider onChangeTheme={setTheme}>
+    <NextThemeProvider
+      onChangeTheme={(next) => {
+        startTransition(() => {
+          setTheme(next)
+        })
+      }}
+    >
       <Provider disableRootThemeClass defaultTheme={theme}>
         {children}
       </Provider>

--- a/apps/starter/package.json
+++ b/apps/starter/package.json
@@ -14,7 +14,6 @@
   },
   "resolutions": {
     "esbuild": "0.15.6",
-    "@types/react": "17.0.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-refresh": "^0.14.0",

--- a/starters/next-expo-solito/apps/next/pages/_app.tsx
+++ b/starters/next-expo-solito/apps/next/pages/_app.tsx
@@ -1,13 +1,13 @@
 import '@tamagui/core/reset.css'
 import '@tamagui/font-inter/css/400.css'
 import '@tamagui/font-inter/css/700.css'
+import 'raf/polyfill'
 
 import { NextThemeProvider, useRootTheme } from '@tamagui/next-theme'
 import { Provider } from 'app/provider'
 import Head from 'next/head'
-import React, { useMemo } from 'react'
+import React, { startTransition } from 'react'
 import type { SolitoAppProps } from 'solito'
-import 'raf/polyfill'
 
 function MyApp({ Component, pageProps }: SolitoAppProps) {
   return (
@@ -28,7 +28,13 @@ function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useRootTheme()
 
   return (
-    <NextThemeProvider onChangeTheme={setTheme}>
+    <NextThemeProvider
+      onChangeTheme={(next) => {
+        startTransition(() => {
+          setTheme(next)
+        })
+      }}
+    >
       <Provider disableRootThemeClass defaultTheme={theme}>
         {children}
       </Provider>

--- a/starters/next-expo-solito/package.json
+++ b/starters/next-expo-solito/package.json
@@ -18,7 +18,6 @@
   },
   "resolutions": {
     "esbuild": "0.15.6",
-    "@types/react": "17.0.21",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-refresh": "^0.14.0",

--- a/starters/next-expo-solito/yarn.lock
+++ b/starters/next-expo-solito/yarn.lock
@@ -3993,14 +3993,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:17.0.21":
-  version: 17.0.21
-  resolution: "@types/react@npm:17.0.21"
+"@types/react@npm:*":
+  version: 18.0.26
+  resolution: "@types/react@npm:18.0.26"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: a590bd2e50e4ec0b1957388e198cf248bac3051e525e036901dea10f7d12203bf1c58350aa899e66494cbf8a60ee56402522273866c29748217f72552bb27d04
+  checksum: b62f0ea3cdfa68e106391728325057ad36f1bde7ba2dfae029472c47e01e482bc77c6ba4f1dad59f3f04ee81cb597618ff7c30a33c157c0a20462b6dd6aa2d4d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #504

* Update the theme provider examples in the starter projects to call `startTransition` in their change handlers
  * Here is the fix as applied to the bug reproduction repo: https://github.com/nderscore/tamagui-suspense-demo/tree/fix
  * (the `site` app for the tamagui homepage already does this)
* Remove package resolution locking `@types/react` to an old 17.x version which predates the existence of `startTransition`
  * I might be missing some prior knowledge as to why this was there in the first place, but I didn't notice any issues after removing it.