### PR TITLE
Fixed visual error in the installation page

### DIFF
--- a/apps/site/data/docs/intro/compiler-install.mdx
+++ b/apps/site/data/docs/intro/compiler-install.mdx
@@ -21,7 +21,7 @@ Install on most platforms is as easy as configuring a library:
 
 ### Setup
 
-Be sure to set `TAMAGUI_TARGET` to `"native"` when targeting native platforms`, set it to `web` for web apps. For babel-based apps you'll then want to use
+Be sure to set `TAMAGUI_TARGET` to `"native"` when targeting native platforms, and set it to `"web"` for web apps.
 
 ### Webpack
 


### PR DESCRIPTION
I removed the babel part too since it was left halfway through. I imagine it has to do with `@tamagui/babel-plugin` but I'm not sure how you'd want that worded. Can push an update to this branch if you'd rather update that wording with something specific.