### PR TITLE
cancelAnimationFrame / floating-ui fixes

### DIFF
--- a/packages/select/src/SelectImpl.tsx
+++ b/packages/select/src/SelectImpl.tsx
@@ -112,7 +112,7 @@ export const SelectInlineImpl = (props: SelectImplProps) => {
   const { x, y, reference, floating, strategy, context, refs } = useFloating({
     open,
     onOpenChange: setOpen,
-    whileElementsMounted: open ? autoUpdate : undefined,
+    whileElementsMounted: autoUpdate,
     placement: 'bottom-start',
     middleware: fallback
       ? [

--- a/packages/select/src/SelectScrollButton.tsx
+++ b/packages/select/src/SelectScrollButton.tsx
@@ -78,6 +78,7 @@ const SelectScrollButtonImpl = React.memo(
       const frameRef = React.useRef<any>()
 
       const { x, y, reference, floating, strategy, update, refs } = useFloating({
+        open: open && isVisible,
         strategy: 'fixed',
         placement: dir === 'up' ? 'top' : 'bottom',
         middleware: [offset(({ rects }) => -rects.floating.height)],

--- a/packages/tamagui/src/setup.ts
+++ b/packages/tamagui/src/setup.ts
@@ -14,8 +14,10 @@ if (typeof requestAnimationFrame === 'undefined') {
   globalThis['requestAnimationFrame'] = setImmediate
 }
 
+const cancelAnimationFrame = globalThis.cancelAnimationFrame
+
 // for vite / Animated.spring()
-global.cancelAnimationFrame = (x) => {
+global.cancelAnimationFrame = (x: number) => {
   try {
     cancelAnimationFrame(x)
   } catch {


### PR DESCRIPTION
Fixes #514
Fixes #519

* Restore native `cancelAnimationFrame` on web
  * The `tamagui` package was adding a `try/catch` wrapper to `cancelAnimationFrame`, but this wrapper referenced itself (it shadows its own variable name) instead of the original `cancelAnimationFrame` method, causing an infinite loop whose error gets swallowed.
  * This fixes the scroll buttons on the select as well as the never-ending `autoUpdate` after close
* Revert the change from cf2951a6
  * Change was not necessary and doesn't seem to follow examples from floating-ui docs
* Pass `open` prop to `useFloating()` hook call in `SelectScrollButton`
  * Not 100% sure this is necessary, but it felt right 😅 