### PR TITLE
fix(button) - typo - broken link in comment

### DIFF
--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -183,7 +183,7 @@ export function useButton(
     tag: isNested
       ? 'span'
       : // defaults to <a /> when accessibilityRole = link
-      // see https://github.com/tamagui/issues/505
+      // see https://github.com/tamagui/tamagui/issues/505
       propsIn.accessibilityRole === 'link'
       ? 'a'
       : undefined,


### PR DESCRIPTION
Related to GitHub issue #505 - Fixes broken link in comment.

Insignificant change, but I'd love to become familiar with the project.
