### PR TITLE
[Issue] Popover broken for native screens with/without Adapt

### DIFF
--- a/packages/demos/src/PopoverDemo.tsx
+++ b/packages/demos/src/PopoverDemo.tsx
@@ -10,6 +10,7 @@ import {
   YGroup,
 } from 'tamagui'
 
+// This is broken on Native Screens larger than $sm. Tested in IOS Simulator iPad
 export function PopoverDemo() {
   return (
     <XStack space="$2">


### PR DESCRIPTION
The popover demo is broken on native devices (admittedly only tried IOS) when not using an `<Adapt>` for a popover. When using adapt, the popover will correctly display a sheet but only for devices matching `when="$sm"`.

If you click the popover button on a `> $sm` device, nothing renders.