### PR TITLE
[Issue] Popover and Sheet do not work on web with the css animation driver

### DIFF
--- a/apps/site/data/docs/components/popover/1.0.0.mdx
+++ b/apps/site/data/docs/components/popover/1.0.0.mdx
@@ -150,6 +150,10 @@ When you want the Trigger to be in another location from where the Popover attac
 
 When used with `Adapt`, Popover will render as a sheet when that breakpoint is active.
 
+<Notice>
+This is only compatible with animation drivers that support `Animated.spring()`. You cannot use this component with `tamagui/animations-css` on web.
+</Notice>
+
 See [Sheet](/docs/components/sheet) for more props.
 
 Must use `Adapt.Contents` inside the `Popover.Sheet.Frame` to insert the contents given to `Popover.Content`

--- a/apps/site/data/docs/components/sheet/1.0.0.mdx
+++ b/apps/site/data/docs/components/sheet/1.0.0.mdx
@@ -145,3 +145,5 @@ Allows scrolling within Sheet. Extends [Scrollview](/docs/components/scroll-view
 ### Notes
 
 For Android you need to manually re-propagate any context when using `modal`. This is because React Native doesn't support portals yet.
+
+This is only compatible with animation drivers that support `Animated.spring()`. You cannot use this component with `tamagui/animations-css` on web.

--- a/apps/starter/packages/app/features/home/screen.tsx
+++ b/apps/starter/packages/app/features/home/screen.tsx
@@ -3,6 +3,8 @@ import { ChevronDown, ChevronUp } from '@tamagui/lucide-icons'
 import React, { useState } from 'react'
 import { useLink } from 'solito/link'
 
+import { PopoverDemo } from '@my/ui/'
+
 export function HomeScreen() {
   const linkProps = useLink({
     href: '/user/nate',
@@ -42,6 +44,8 @@ export function HomeScreen() {
       </XStack>
 
       <SheetDemo />
+
+      <PopoverDemo />
     </YStack>
   )
 }

--- a/apps/starter/packages/ui/src/PopoverDemo.tsx
+++ b/apps/starter/packages/ui/src/PopoverDemo.tsx
@@ -28,7 +28,7 @@ export function Demo({ Icon, ...props }: PopoverProps & { Icon?: any }) {
         <Button icon={Icon} />
       </Popover.Trigger>
 
-      <Adapt when="sm">
+      <Adapt when="sm" platform="touch">
         <Popover.Sheet modal dismissOnSnapToBottom>
           <Popover.Sheet.Frame padding="$4">
             <Adapt.Contents />
@@ -46,7 +46,7 @@ export function Demo({ Icon, ...props }: PopoverProps & { Icon?: any }) {
         y={0}
         o={1}
         animation={[
-          'quick',
+          'bouncy',
           {
             opacity: {
               overshootClamping: true,

--- a/apps/starter/packages/ui/src/PopoverDemo.tsx
+++ b/apps/starter/packages/ui/src/PopoverDemo.tsx
@@ -1,0 +1,81 @@
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp } from '@tamagui/lucide-icons'
+import {
+  Adapt,
+  Button,
+  Input,
+  Label,
+  Popover,
+  PopoverProps,
+  XStack,
+  YGroup,
+} from '@my/ui'
+
+export function PopoverDemo() {
+  return (
+    <XStack space="$2">
+      <Demo placement="left" Icon={ChevronLeft} />
+      <Demo placement="bottom" Icon={ChevronDown} />
+      <Demo placement="top" Icon={ChevronUp} />
+      <Demo placement="right" Icon={ChevronRight} />
+    </XStack>
+  )
+}
+
+export function Demo({ Icon, ...props }: PopoverProps & { Icon?: any }) {
+  return (
+    <Popover size="$5" {...props}>
+      <Popover.Trigger asChild>
+        <Button icon={Icon} />
+      </Popover.Trigger>
+
+      <Adapt when="sm">
+        <Popover.Sheet modal dismissOnSnapToBottom>
+          <Popover.Sheet.Frame padding="$4">
+            <Adapt.Contents />
+          </Popover.Sheet.Frame>
+          <Popover.Sheet.Overlay />
+        </Popover.Sheet>
+      </Adapt>
+
+      <Popover.Content
+        bw={1}
+        boc="$borderColor"
+        enterStyle={{ x: 0, y: -10, o: 0 }}
+        exitStyle={{ x: 0, y: -10, o: 0 }}
+        x={0}
+        y={0}
+        o={1}
+        animation={[
+          'quick',
+          {
+            opacity: {
+              overshootClamping: true,
+            },
+          },
+        ]}
+        elevate
+      >
+        <Popover.Arrow bw={1} boc="$borderColor" />
+
+        <YGroup space="$3">
+          <XStack space="$3">
+            <Label size="$3" htmlFor="name">
+              Name
+            </Label>
+            <Input size="$3" id="name" />
+          </XStack>
+          <Popover.Trigger>
+            <Button
+              size="$3"
+              onPress={() => {
+                /* Custom code goes here, does not interfere with popover closure */
+              }}
+            >
+              Submit
+            </Button>
+          </Popover.Trigger>
+        </YGroup>
+      </Popover.Content>
+    </Popover>
+  )
+}

--- a/apps/starter/packages/ui/src/animations.native.ts
+++ b/apps/starter/packages/ui/src/animations.native.ts
@@ -1,0 +1,22 @@
+import { createAnimations } from '@tamagui/animations-react-native'
+import { AnimationDriver } from '@tamagui/core'
+
+export const animations: AnimationDriver = createAnimations({
+  bouncy: {
+    type: 'spring',
+    damping: 10,
+    mass: 0.9,
+    stiffness: 100,
+  },
+  lazy: {
+    type: 'spring',
+    damping: 20,
+    stiffness: 60,
+  },
+  quick: {
+    type: 'spring',
+    damping: 20,
+    mass: 1.2,
+    stiffness: 250,
+  },
+})

--- a/apps/starter/packages/ui/src/animations.ts
+++ b/apps/starter/packages/ui/src/animations.ts
@@ -1,21 +1,8 @@
-import { createAnimations } from '@tamagui/animations-react-native'
+import { createAnimations } from '@tamagui/animations-css'
+import { AnimationDriver } from '@tamagui/core'
 
-export const animations = createAnimations({
-  bouncy: {
-    type: 'spring',
-    damping: 10,
-    mass: 0.9,
-    stiffness: 100,
-  },
-  lazy: {
-    type: 'spring',
-    damping: 20,
-    stiffness: 60,
-  },
-  quick: {
-    type: 'spring',
-    damping: 20,
-    mass: 1.2,
-    stiffness: 250,
-  },
+export const animations: AnimationDriver = createAnimations({
+    quick: 'ease-in 150ms',
+    bouncy: 'ease-in 300ms',
+    lazy: 'ease-in 450ms'
 })

--- a/apps/starter/packages/ui/src/index.tsx
+++ b/apps/starter/packages/ui/src/index.tsx
@@ -1,3 +1,4 @@
 export * from 'tamagui'
 export * from './MyComponent'
+export * from './PopoverDemo'
 export { config } from './tamagui.config'

--- a/packages/demos/src/PopoverDemo.tsx
+++ b/packages/demos/src/PopoverDemo.tsx
@@ -10,6 +10,7 @@ import {
   YGroup,
 } from 'tamagui'
 
+// This is broken on Native Screens larger than $sm. Tested in IOS Simulator iPad
 export function PopoverDemo() {
   return (
     <XStack space="$2">


### PR DESCRIPTION
This is likely known by Nate but isn't documented anywhere.

Sheet (which Popover Adapt also depends on) assumes the animation driver can handle `Spring` animations. It may even only work with the `animations-react-native` package and not any others.