### PR TITLE
feat(native): preferred color scheme

### DIFF
--- a/starters/next-expo-solito/apps/expo/app.json
+++ b/starters/next-expo-solito/apps/expo/app.json
@@ -6,7 +6,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "contain",

--- a/starters/next-expo-solito/packages/app/provider/index.tsx
+++ b/starters/next-expo-solito/packages/app/provider/index.tsx
@@ -1,10 +1,12 @@
 import config from '../tamagui.config'
 import { NavigationProvider } from './navigation'
 import { TamaguiProvider, TamaguiProviderProps } from '@my/ui'
+import { useColorScheme } from 'react-native';
 
 export function Provider({ children, ...rest }: Omit<TamaguiProviderProps, 'config'>) {
+  const scheme = useColorScheme();
   return (
-    <TamaguiProvider config={config} disableInjectCSS defaultTheme="light" {...rest}>
+    <TamaguiProvider config={config} disableInjectCSS defaultTheme={scheme === 'dark' ? 'dark' : 'light'} {...rest}>
       <NavigationProvider>{children}</NavigationProvider>
     </TamaguiProvider>
   )

--- a/starters/next-expo-solito/packages/app/provider/navigation/index.tsx
+++ b/starters/next-expo-solito/packages/app/provider/navigation/index.tsx
@@ -1,14 +1,17 @@
-import { NavigationContainer } from '@react-navigation/native'
+import { NavigationContainer, DarkTheme, DefaultTheme } from '@react-navigation/native'
 import * as Linking from 'expo-linking'
 import { useMemo } from 'react'
+import { useColorScheme } from 'react-native';
 
 export function NavigationProvider({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const scheme = useColorScheme();
   return (
     <NavigationContainer
+    theme={scheme === 'dark' ? DarkTheme : DefaultTheme}
       linking={useMemo(
         () => ({
           prefixes: [Linking.createURL('/')],


### PR DESCRIPTION
Per [discussion](https://discord.com/channels/909986013848412191/1066854123095474186), starter only had light support, and if dark theme was forced, there were visual errors. Changes allow for automatic light/dark theme preference.