### PR TITLE
[Issue] add missing "types" property to package.json "exports" maps

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -25,6 +25,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,6 +23,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -25,6 +25,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,6 +20,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/compose-refs/package.json
+++ b/packages/compose-refs/package.json
@@ -29,6 +29,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/config-base/package.json
+++ b/packages/config-base/package.json
@@ -21,6 +21,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,14 +57,17 @@
     "./package.json": "./package.json",
     "./reset.css": "./reset.css",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     },
     "./inject-styles": {
+      "types": "./types/inject-styles.d.ts",
       "import": "./dist/esm/inject-styles.js",
       "require": "./dist/cjs/inject-styles.js"
     },
     "./react-native": {
+      "types": "./types/react-native.d.ts",
       "import": "./dist/esm/react-native.js",
       "require": "./dist/cjs/react-native.js"
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,11 +65,6 @@
       "types": "./types/inject-styles.d.ts",
       "import": "./dist/esm/inject-styles.js",
       "require": "./dist/cjs/inject-styles.js"
-    },
-    "./react-native": {
-      "types": "./types/react-native.d.ts",
-      "import": "./dist/esm/react-native.js",
-      "require": "./dist/cjs/react-native.js"
     }
   },
   "repository": {

--- a/packages/create-themes/package.json
+++ b/packages/create-themes/package.json
@@ -21,6 +21,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -23,6 +23,7 @@
     "./package.json": "./package.json",
     "./photo/*": "./public/*.jpg",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -25,6 +25,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -30,6 +30,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -25,6 +25,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/normalize-css-color/package.json
+++ b/packages/normalize-css-color/package.json
@@ -27,6 +27,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/react-native-web-internals/package.json
+++ b/packages/react-native-web-internals/package.json
@@ -20,6 +20,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -23,6 +23,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/static/types/extractor/extractMediaStyle.d.ts
+++ b/packages/static/types/extractor/extractMediaStyle.d.ts
@@ -1,7 +1,7 @@
 import { NodePath } from '@babel/traverse';
 import * as t from '@babel/types';
 import { TamaguiInternalConfig } from '@tamagui/core-node';
-import type { TamaguiOptionsWithFileInfo, Ternary } from '../types.js';
+import type { StyleObject, TamaguiOptionsWithFileInfo, Ternary } from '../types.js';
 export declare function extractMediaStyle(props: TamaguiOptionsWithFileInfo, ternary: Ternary, jsxPath: NodePath<t.JSXElement>, tamaguiConfig: TamaguiInternalConfig, sourcePath: string, importance?: number, shouldPrintDebug?: boolean | 'verbose'): {
     mediaStyles: StyleObject[];
     ternaryWithoutMedia: Ternary | null;

--- a/packages/tamagui/package.json
+++ b/packages/tamagui/package.json
@@ -28,6 +28,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -26,6 +26,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/theme-base/package.json
+++ b/packages/theme-base/package.json
@@ -21,6 +21,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -23,6 +23,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/use-controllable-state/package.json
+++ b/packages/use-controllable-state/package.json
@@ -22,6 +22,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/use-event/package.json
+++ b/packages/use-event/package.json
@@ -27,6 +27,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/use-force-update/package.json
+++ b/packages/use-force-update/package.json
@@ -20,6 +20,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/vite-plugin-reanimated/package.json
+++ b/packages/vite-plugin-reanimated/package.json
@@ -19,6 +19,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -19,6 +19,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }


### PR DESCRIPTION
Currently, TypeScript fails to find declarations for `tamagui` (and many `@tamagui/*` packages) when using the `Node16` or `NodeNext` [module resolution strategy](https://www.typescriptlang.org/tsconfig#moduleResolution) (i.e. using ES modules). The reason for this is because all `package.json` files are missing the [`types` field within their `exports` maps](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing); this is only necessary when declarations aren't located next to the JavaScript files.

This PR:

- adds the missing field to all relevant `package.json` files
- adds a missing `StyleObject` import to `packages/static/types/extractor/extractMediaStyle.d.ts` (I'm not sure why the `build` action adds this only after making the prior change)
- removes an invalid `./react-native` entry point from the `@tamagui/core` `exports` map (this file no longer exists)

NOTE: I'm happy to create an example repository which demonstrates the issue, if that helps.