### PR TITLE
Idea: `unstyled` prop

### DIFF
--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -99,6 +99,7 @@ export const ButtonFrame = styled(ThemeableStack, {
     },
       
     unstyled: {
+      // reset all styles
       true: {
         focusable: false,
         hoverTheme: false,

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -97,6 +97,22 @@ export const ButtonFrame = styled(ThemeableStack, {
         pointerEvents: 'none',
       },
     },
+      
+    unstyled: {
+      focusable: false,
+      hoverTheme: false,
+      pressTheme: false,
+      backgrounded: false,
+      borderWidth: 0,
+      borderColor: 'transparent',
+      justifyContent: 'flex-start',
+      alignItems: 'flex-start',
+      flexWrap: 'nowrap',
+      flexDirection: 'column',
+      pressStyle: {},
+      focusStyle: {},
+      hoverStyle: {}
+    }
   } as const,
 
   defaultVariants: {

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -99,19 +99,21 @@ export const ButtonFrame = styled(ThemeableStack, {
     },
       
     unstyled: {
-      focusable: false,
-      hoverTheme: false,
-      pressTheme: false,
-      backgrounded: false,
-      borderWidth: 0,
-      borderColor: 'transparent',
-      justifyContent: 'flex-start',
-      alignItems: 'flex-start',
-      flexWrap: 'nowrap',
-      flexDirection: 'column',
-      pressStyle: {},
-      focusStyle: {},
-      hoverStyle: {}
+      true: {
+        focusable: false,
+        hoverTheme: false,
+        pressTheme: false,
+        backgrounded: false,
+        borderWidth: 0,
+        borderColor: 'transparent',
+        justifyContent: 'flex-start',
+        alignItems: 'flex-start',
+        flexWrap: 'nowrap',
+        flexDirection: 'column',
+        pressStyle: {},
+        focusStyle: {},
+        hoverStyle: {},
+      }
     }
   } as const,
 


### PR DESCRIPTION
I feel that the styles/colors on many elements are too tailored to the Tamagui website. It takes a lot of guessing and checking to undo them and build them from scratch. Rather than implement a massive feature, I think an easy solution is an `unstyled` variant that "undoes" default styles set by pre-styled elements. 

This PR serves as a draft of how that might look.

A key element for me here is the colors. I don't know what each color corresponds to or where to edit them properly. I find that the `borderFocus` and `$color` and `$backgroundStrong` etc colors are meant for the Tamagui site, but I don't exactly know the right way to configure them for my own.

Thus, I prefer to only use the `$color1`-`$color12` scales from Radix, and to override the built-in `light` and `dark` themes from Tamagui which do not follow the Radix spec. 

I think a studio will also help in general for understanding the color themes better. But an `unstyled` prop would go a long way.