### PR TITLE
replace extends SelectItemProps from YStackProps to ListItemProps

### DIFF
--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -168,7 +168,7 @@ type SelectItemContextValue = {
 const [SelectItemContextProvider, useSelectItemContext] =
   createSelectContext<SelectItemContextValue>(ITEM_NAME)
 
-export interface SelectItemProps extends YStackProps {
+export interface SelectItemProps extends ListItemProps {
   value: string
   index: number
   disabled?: boolean


### PR DESCRIPTION
wrong typescript extends interface for SelectItemProps

![image](https://user-images.githubusercontent.com/3316940/215025357-40aa04c6-bc91-4db1-ade1-cfebce02a227.png)
![image](https://user-images.githubusercontent.com/3316940/215025376-18cee653-db4a-4e62-a9f6-57889a5f4dfd.png)
