### PR TITLE
fix: tamagui website issue on windows

### DIFF
--- a/apps/site/lib/mdx.ts
+++ b/apps/site/lib/mdx.ts
@@ -27,7 +27,7 @@ export const getAllFrontmatter = (fromPath: string) => {
       const { data, content } = matter(source)
       return {
         ...data,
-        slug: filePath.replace(`${DATA_PATH}/`, '').replace('.mdx', ''),
+        slug: filePath.replace(`${DATA_PATH.replaceAll(`\\`, '/')}/`, '').replace('.mdx', ''),
         readingTime: readingTime(content),
       } as Frontmatter
     })

--- a/apps/site/lib/mdx.ts
+++ b/apps/site/lib/mdx.ts
@@ -27,7 +27,7 @@ export const getAllFrontmatter = (fromPath: string) => {
       const { data, content } = matter(source)
       return {
         ...data,
-        slug: filePath.replace(`${DATA_PATH.replaceAll(`\\`, '/')}/`, '').replace('.mdx', ''),
+        slug: filePath.replace(`${DATA_PATH.replaceAll('\\', '/')}/`, '').replace('.mdx', ''),
         readingTime: readingTime(content),
       } as Frontmatter
     })


### PR DESCRIPTION
certified Windows moment

`DATA_PATH` has backslashes on Windows and slashes on Linux. Tried the fix and it works both on Windows and Linux.

Closes #625 