### PR TITLE
fix(lucide-icons): size token not getting resolved

### DIFF
--- a/packages/lucide-icons/package.json
+++ b/packages/lucide-icons/package.json
@@ -21,7 +21,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@tamagui/core": "^1.1.13"
+    "@tamagui/core": "^1.1.13",
+    "@tamagui/get-size": "^1.1.13"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/lucide-icons/src/themed.tsx
+++ b/packages/lucide-icons/src/themed.tsx
@@ -1,4 +1,5 @@
 import { getVariable, useTheme } from '@tamagui/core'
+import { getSize } from '@tamagui/get-size'
 import React from 'react'
 
 export function themed<A extends React.FC>(Component: A) {
@@ -8,19 +9,11 @@ export function themed<A extends React.FC>(Component: A) {
       (props.color in theme ? theme[props.color] : undefined) ||
         props.color ||
         (!props.disableTheme ? theme.color : null) ||
-        '#000',
+        '#000'
     )
-    return (
-      <Component
-        {...props}
-        color={color}
-        size={
-          typeof props.size === 'string'
-            ? getVariable(theme[props.size] || props.size)
-            : props.size
-        }
-      />
-    )
+    const size = typeof props.size === 'string' ? getSize(props.size).val : props.size
+
+    return <Component {...props} color={color} size={size} />
   }
   return wrapped as unknown as A
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5428,6 +5428,7 @@ __metadata:
   dependencies:
     "@tamagui/build": ^1.1.13
     "@tamagui/core": ^1.1.13
+    "@tamagui/get-size": ^1.1.13
     camelcase: ^6.0.0
     cheerio: ^1.0.0-rc.5
     glob: ^7.1.6


### PR DESCRIPTION
`getVariable()` was used to resolve a size token. Assuming that's the wrong function I went ahead and used `getSize()` from `@tamagui/get-size` instead.

Closes https://github.com/tamagui/tamagui/issues/632 and fixes the issue with Safari on the Checkbox PR (https://github.com/tamagui/tamagui/pull/618)