### PR TITLE
fix(build): provide both .mjs and .js

### DIFF
--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -170,7 +170,7 @@ async function buildJs() {
           platform: 'node',
         })
       : null,
-    pkgModule
+      pkgModule
       ? esbuildWriteIfChanged({
           entryPoints: files,
           outdir: flatOut ? 'dist' : 'dist/esm',
@@ -187,7 +187,44 @@ async function buildJs() {
           platform: shouldBundle ? 'node' : 'neutral',
         })
       : null,
+    pkgModule
+      ? esbuildWriteIfChanged({
+          entryPoints: files,
+          outExtension: { '.js': '.mjs' },
+          outdir: flatOut ? 'dist' : 'dist/esm',
+          bundle: shouldBundle,
+          sourcemap: true,
+          target: 'node16',
+          keepNames: false,
+          jsx: 'automatic',
+          allowOverwrite: true,
+          format: 'esm',
+          color: true,
+          logLevel: 'error',
+          minify: false,
+          platform: shouldBundle ? 'node' : 'neutral',
+        })
+      : null,
     pkgModuleJSX
+      ? esbuildWriteIfChanged({
+          // only diff is jsx preserve and outdir
+          jsx: 'preserve',
+          outdir: flatOut ? 'dist' : 'dist/jsx',
+          outExtension: { '.js': '.mjs' },
+          entryPoints: files,
+          bundle: shouldBundle,
+          sourcemap: true,
+          allowOverwrite: true,
+          target: 'es2020',
+          keepNames: false,
+          format: 'esm',
+          color: true,
+          logLevel: 'error',
+          minify: false,
+          platform: 'neutral',
+        })
+      : null,
+      pkgModuleJSX
       ? esbuildWriteIfChanged({
           // only diff is jsx preserve and outdir
           jsx: 'preserve',

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -24,7 +24,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/button/types/Button.d.ts
+++ b/packages/button/types/Button.d.ts
@@ -293,7 +293,9 @@ export declare function useButton(propsIn: ButtonProps, { Text }?: {
             __html: string;
         } | undefined;
         animation?: import("@tamagui/core").AnimationProp | null | undefined;
-        animateOnly?: string[] | undefined;
+        animateOnly?: string[] | undefined; /**
+         *
+         */
         debug?: boolean | "verbose" | undefined;
         disabled?: boolean | undefined;
         className?: string | undefined;

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/compose-refs/package.json
+++ b/packages/compose-refs/package.json
@@ -30,7 +30,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/config-base/package.json
+++ b/packages/config-base/package.json
@@ -22,7 +22,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,12 +49,12 @@
     "./reset.css": "./reset.css",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     },
     "./inject-styles": {
       "types": "./types/inject-styles.d.ts",
-      "import": "./dist/esm/inject-styles.js",
+      "import": "./dist/esm/inject-styles.mjs",
       "require": "./dist/cjs/inject-styles.js"
     }
   },

--- a/packages/create-themes/package.json
+++ b/packages/create-themes/package.json
@@ -22,7 +22,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -24,7 +24,7 @@
     "./photo/*": "./public/*.jpg",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/floating/package.json
+++ b/packages/floating/package.json
@@ -16,7 +16,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -31,7 +31,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/list-item/types/ListItem.d.ts
+++ b/packages/list-item/types/ListItem.d.ts
@@ -306,7 +306,9 @@ export declare const useListItem: (props: ListItemProps, { Text, Subtitle, Title
 }) => {
     props: {
         children: JSX.Element;
-        hitSlop?: import("react-native").Insets | (import("react-native").Insets & number) | undefined;
+        hitSlop?: import("react-native").Insets | (import("react-native").Insets & number) | undefined; /**
+         * adjust icon relative to size
+         */
         pointerEvents?: "box-none" | "none" | "box-only" | "auto" | undefined;
         removeClippedSubviews?: boolean | undefined;
         style?: import("react-native").StyleProp<import("react-native").ViewStyle>;
@@ -363,25 +365,22 @@ export declare const useListItem: (props: ListItemProps, { Text, Subtitle, Title
         onMagicTap?: (() => void) | undefined;
         accessibilityIgnoresInvertColors?: boolean | undefined;
         target?: string | undefined;
-        asChild?: boolean | undefined;
-        spaceDirection?: import("@tamagui/core").SpaceDirection | undefined; /**
-         * make the spacing elements flex
+        /**
+         * default: -1
          */
+        asChild?: boolean | undefined;
+        spaceDirection?: import("@tamagui/core").SpaceDirection | undefined;
         separator?: React.ReactNode;
         dangerouslySetInnerHTML?: {
             __html: string;
-        } | undefined; /**
-         * adjust internal space relative to icon size
-         */
+        } | undefined;
         animation?: import("@tamagui/core").AnimationProp | null | undefined;
         animateOnly?: string[] | undefined;
         debug?: boolean | "verbose" | undefined;
         disabled?: boolean | undefined;
         className?: string | undefined;
         themeShallow?: boolean | undefined;
-        id?: string | undefined; /**
-         * will not wrap text around `children` only, "all" will not wrap title or subTitle
-         */
+        id?: string | undefined;
         tag?: string | undefined;
         componentName?: string | undefined;
         forceStyle?: "focus" | "hover" | "press" | undefined;

--- a/packages/normalize-css-color/package.json
+++ b/packages/normalize-css-color/package.json
@@ -28,7 +28,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/react-native-web-internals/package.json
+++ b/packages/react-native-web-internals/package.json
@@ -21,7 +21,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/react-native-web-lite/package.json
+++ b/packages/react-native-web-lite/package.json
@@ -19,7 +19,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     },
     "./dist/modules/*": "./dist/esm/modules/*/index.js",

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -24,7 +24,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/tamagui/package.json
+++ b/packages/tamagui/package.json
@@ -30,12 +30,12 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     },
     "./linear-gradient": {
       "types": "./types/linear-gradient.d.ts",
-      "import": "./dist/esm/linear-gradient.js",
+      "import": "./dist/esm/linear-gradient.mjs",
       "require": "./dist/cjs/linear-gradient.js"
     }
   },

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -26,7 +26,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/theme-base/package.json
+++ b/packages/theme-base/package.json
@@ -22,7 +22,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -24,7 +24,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/use-controllable-state/package.json
+++ b/packages/use-controllable-state/package.json
@@ -23,7 +23,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/use-event/package.json
+++ b/packages/use-event/package.json
@@ -28,7 +28,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/use-force-update/package.json
+++ b/packages/use-force-update/package.json
@@ -21,7 +21,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     }
   },

--- a/packages/vite-plugin-internal/package.json
+++ b/packages/vite-plugin-internal/package.json
@@ -8,7 +8,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/esm/vite.config.js",
+      "import": "./dist/esm/vite.config.mjs",
       "require": "./dist/cjs/vite.config.js"
     }
   },

--- a/packages/vite-plugin-reanimated/package.json
+++ b/packages/vite-plugin-reanimated/package.json
@@ -20,7 +20,7 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js"
+      "import": "./dist/esm/index.mjs"
     }
   },
   "dependencies": {

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -22,7 +22,7 @@
     ".": {
       "types": "./types/index.d.ts",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
+      "import": "./dist/esm/index.mjs"
     }
   },
   "dependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -53,12 +53,12 @@
     "./reset.css": "./reset.css",
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js"
     },
     "./inject-styles": {
       "types": "./types/inject-styles.d.ts",
-      "import": "./dist/esm/inject-styles.js",
+      "import": "./dist/esm/inject-styles.mjs",
       "require": "./dist/cjs/inject-styles.js"
     }
   },


### PR DESCRIPTION
In this PR we offer both a `.mjs` as well as a js build, this so that we can put mjs in the export-maps so we can adhere to strict node resolution for all node-versions which need mjs to show them that we are using import/export. The reason for also supplying a js here is because tamagui uses dist/esm in the module property. This will make it so that older webpack/.. versions can still automatically pick what they can resolve according to their configuration.

Resolves https://github.com/tamagui/tamagui/issues/619
CC @tazsingh