### PR TITLE
fix(core): add export path for reactNativeTypes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,11 @@
       "types": "./types/inject-styles.d.ts",
       "import": "./dist/esm/inject-styles.js",
       "require": "./dist/cjs/inject-styles.js"
+    },
+    "./reactNativeTypes": {
+      "types": "./types/reactNativeTypes.d.ts",
+      "import": "./dist/esm/reactNativeTypes.js",
+      "require": "./dist/cjs/reactNativeTypes.js"
     }
   },
   "repository": {


### PR DESCRIPTION
After the changes from 5b76e63c, I started seeing this error when trying to build the `@my/ui` package in my project:

> `src/MyComponent.tsx(3,14)`: error TS2742: The inferred type of 'MyComponent' cannot be named without a reference to `'../../node_modules/@tamagui/core/types/reactNativeTypes'`. This is likely not portable. A type annotation is necessary.

I wasn't able to reproduce this error using the starter repo with yarn 3.x, but it happens when using pnpm as the package manager.

---

The error is caused by a missing field in `exports` of the `@tamagui/core` package for this new entry point. 

This PR adds an entry for `./reactNativeTypes` with the correct paths, which fixes the error.

