### PR TITLE
docs: remove invalid link reference

### DIFF
--- a/apps/site/data/docs/core/configuration.mdx
+++ b/apps/site/data/docs/core/configuration.mdx
@@ -396,7 +396,7 @@ This will change all special style properties that map to token/theme values to 
 
 Themes live one level below tokens. Tokens are your variables, where themes use those tokens to create consistent, generic properties that you then typically use in shareable components. Themes should generally only deal with colors.
 
-Tamagui components in general expect a set of theme keys to be defined like the following, but you can deviate if you create your own design system. See [the source for the website](https://github.com/tamagui/tamagui/blob/master/apps/site/constants/themes.ts) for a fuller example.
+Tamagui components in general expect a set of theme keys to be defined like the following, but you can deviate if you create your own design system.
 
 ```tsx
 const light = {


### PR DESCRIPTION
The link leads to nowhere. I couldn't find any equivalent to [the old file that has been removed](https://github.com/tamagui/tamagui/blob/c3beeff4902388a420549abc608f1af7607658c9/packages/site/constants/themes.ts) in the site app. 