### PR TITLE
feat: allow string sizes (e.g. rem)

### DIFF
--- a/packages/font-inter/src/index.ts
+++ b/packages/font-inter/src/index.ts
@@ -1,30 +1,36 @@
-import { GenericFont, createFont, getVariableValue, isWeb } from '@tamagui/core'
+import {
+  GenericFont,
+  SizeValue,
+  createFont,
+  getVariableValue,
+  isWeb,
+} from '@tamagui/core'
 
 export const createInterFont = <A extends GenericFont<keyof typeof defaultSizes>>(
   font: {
     [Key in keyof Partial<A>]?: Partial<A[Key]>
   } = {},
   {
-    sizeLineHeight = (size) => size + 10,
-    sizeSize = (size) => size * 1,
+    sizeLineHeight = (size: SizeValue) => (typeof size === 'number' ? size + 10 : size),
+    sizeSize = (size: SizeValue) => size,
   }: {
-    sizeLineHeight?: (fontSize: number) => number
-    sizeSize?: (size: number) => number
-  } = {},
+    sizeLineHeight?: (fontSize: SizeValue, forKey: string) => SizeValue
+    sizeSize?: (size: SizeValue, forKey: string) => SizeValue
+  } = {}
 ): A => {
   // merge to allow individual overrides
   const size = Object.fromEntries(
     Object.entries({
       ...defaultSizes,
       ...font.size,
-    }).map(([k, v]) => [k, sizeSize(+v)])
+    }).map(([k, v]) => [k, sizeSize(v, k)])
   )
   return createFont<A>({
     family: isWeb
       ? 'Inter, -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
       : 'Inter',
     lineHeight: Object.fromEntries(
-      Object.entries(size).map(([k, v]) => [k, sizeLineHeight(getVariableValue(v))])
+      Object.entries(size).map(([k, v]) => [k, sizeLineHeight(getVariableValue(v), k)])
     ),
     weight: {
       4: '300',

--- a/packages/web/src/types.tsx
+++ b/packages/web/src/types.tsx
@@ -453,11 +453,13 @@ export type GetAnimationKeys<A extends GenericTamaguiConfig> = keyof A['animatio
 export type UnionableString = string & {}
 export type UnionableNumber = number & {}
 
+export type SizeValue = number | string | Variable
+
 export type GenericFont<Key extends number | string = number | string> = {
-  size: { [key in Key]: number | Variable }
-  lineHeight: Partial<{ [key in Key]: number | Variable }>
-  letterSpacing: Partial<{ [key in Key]: number | Variable }>
-  weight: Partial<{ [key in Key]: number | string | Variable }>
+  size: { [key in Key]: SizeValue }
+  lineHeight: Partial<{ [key in Key]: SizeValue }>
+  letterSpacing: Partial<{ [key in Key]: SizeValue }>
+  weight: Partial<{ [key in Key]: SizeValue }>
   family: string | Variable
   style?: Partial<{ [key in Key]: TextStyle['fontStyle'] | Variable }>
   transform?: Partial<{ [key in Key]: TextStyle['textTransform'] | Variable }>
@@ -469,7 +471,7 @@ export type GenericFont<Key extends number | string = number | string> = {
 }
 
 // media
-export type MediaQueryObject = { [key: string]: string | number | string }
+export type MediaQueryObject = { [key: string]: string | number }
 export type MediaQueryKey = keyof Media
 export type MediaPropKeys = `$${MediaQueryKey}`
 export type MediaQueryState = { [key in MediaQueryKey]: boolean }


### PR DESCRIPTION
this allows me to specify font size for web using `rem`

I'm not sure if there's a reason tamagui currently prefers everything to be px but I don't see why it should forbid using other units.

Let me know if I should add some docs / tests / whatever

thank you! :)