### PR TITLE
docs: Update compiler-install.mdx

### DIFF
--- a/apps/site/data/docs/intro/compiler-install.mdx
+++ b/apps/site/data/docs/intro/compiler-install.mdx
@@ -211,7 +211,7 @@ module.exports = {
     ],
     // be sure to set TAMAGUI_TARGET
     ['transform-inline-environment-variables', {
-      include: 'TAMAGUI_TARGET'
+      include: ['TAMAGUI_TARGET']
     }]
   ]
 }


### PR DESCRIPTION
Per [the docs](https://github.com/babel/minify/tree/master/packages/babel-plugin-transform-inline-environment-variables), the `include` property takes an array of string values, not a string.