### PR TITLE
docs: Mini-fix website starter guide

### DIFF
--- a/apps/site/data/docs/guides/create-tamagui-app.mdx
+++ b/apps/site/data/docs/guides/create-tamagui-app.mdx
@@ -22,6 +22,8 @@ To run the app:
 ```bash
 cd myapp
 yarn
+yarn web # Next.js local dev
+yarn native # Expo local dev
 ```
 
 ## 📦 Included packages

--- a/apps/site/data/docs/guides/create-tamagui-app.mdx
+++ b/apps/site/data/docs/guides/create-tamagui-app.mdx
@@ -22,7 +22,6 @@ To run the app:
 ```bash
 cd myapp
 yarn
-yarn dev
 ```
 
 ## 📦 Included packages


### PR DESCRIPTION
Per the website docs one needs to run "yarn dev" which is not an available script. Replaced with "yarn web" and "yarn native" to avoid confusion.