### PR TITLE
Docs: Install react-native-reanimated with expo cli

### DIFF
--- a/apps/site/data/docs/guides/expo.mdx
+++ b/apps/site/data/docs/guides/expo.mdx
@@ -18,7 +18,8 @@ To support dark mode, update your app.json to app.config.ts and set "userInterfa
 ### Update Babel / Metro
 
 ```bash
-yarn add @tamagui/babel-plugin babel-plugin-transform-inline-environment-variables react-native-reanimated
+yarn add @tamagui/babel-plugin babel-plugin-transform-inline-environment-variables
+npx expo install react-native-reanimated
 ```
 
 Update your `babel.config.js` to include the `@tamagui/babel-plugin`,  `transform-inline-environment-variables` and `react-native-reanimated` plugins:


### PR DESCRIPTION
`react-native-reanimated` v3.0.0 has been released two days ago.
This version is not yet compatible with expo.

To be safe, I think we should use `expo install react-native-reanimated` to always install a compatible version of this library.