### PR TITLE
fix: radio group incorrect sizing

### DIFF
--- a/packages/radio-group/src/RadioGroup.tsx
+++ b/packages/radio-group/src/RadioGroup.tsx
@@ -131,6 +131,7 @@ const RadioGroupItemFrame = styled(ThemeableStack, {
         justifyContent: 'center',
         borderWidth: 1,
         borderColor: '$borderColor',
+        padding: 0,
 
         hoverStyle: {
           borderColor: '$borderColorHover',


### PR DESCRIPTION
The default `button` tag on Web seems to be applying padding horizontally, which is breaking the `RadioGroup.Indicator`'s width. This fixes it.