### PR TITLE
[fix] Style regression on Switch frame

### DIFF
--- a/packages/switch/src/Switch.tsx
+++ b/packages/switch/src/Switch.tsx
@@ -87,6 +87,7 @@ export const SwitchThumb = SwitchThumbFrame.extractable(
       const size = sizeProp ?? sizeContext
       return (
         <SwitchThumbFrame
+          unstyled={unstyled}
           size={size}
           theme={checked ? 'active' : null}
           data-state={getState(checked)}
@@ -118,11 +119,11 @@ export const SwitchFrame = styled(XStack, {
   variants: {
     unstyled: {
       false: {
-        // size: '$true',
-        // borderRadius: 1000,
-        // borderWidth: 2,
-        // borderColor: 'transparent',
-        // backgroundColor: '$background',
+        size: '$true',
+        borderRadius: 1000,
+        borderWidth: 2,
+        borderColor: 'transparent',
+        backgroundColor: '$background',
 
         focusStyle: {
           borderColor: '$borderColorFocus',


### PR DESCRIPTION
Between version 1.6.3 and version 1.7.0 the styles on Switch frames were commented out as if `unstyled` was always applied. Noticed that an `unstyled` prop also stopped being passed through.

| BEFORE | AFTER |
|---|---|
| <img width="766" alt="Screenshot from Switch page with switch frame not styled" src="https://user-images.githubusercontent.com/1854690/223749325-5a2842f6-2520-4284-be50-adcf422e456f.png">  | <img width="760" alt="Screenshot from Switch page with frame styles returned" src="https://user-images.githubusercontent.com/1854690/223749403-5f9caf81-bb54-4d53-80e9-28be9a23f2a2.png">  |