### PR TITLE
Fix role value

### DIFF
--- a/packages/label/src/Label.tsx
+++ b/packages/label/src/Label.tsx
@@ -108,7 +108,7 @@ const LabelComponent = React.forwardRef<typeof LabelFrame, LabelProps>(
     return (
       <LabelProvider id={id} controlRef={controlRef}>
         <LabelFrame
-          role="label"
+          role="heading"
           id={id}
           // @ts-ignore
           htmlFor={htmlFor}


### PR DESCRIPTION
The valid values for role are listed here:

https://reactnative.dev/docs/accessibility#role

label is not one of them, so it's producing an error in the console that appears to have started with expo 48.

This fixes #761 

Based on the description, heading seemed to be the most fitting.

