### PR TITLE
fix: remove src on npm tarball

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/adapt/package.json
+++ b/packages/adapt/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -10,7 +10,6 @@
     "*.css"
   ],
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/animate-presence/package.json
+++ b/packages/animate-presence/package.json
@@ -9,7 +9,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/animations-css/package.json
+++ b/packages/animations-css/package.json
@@ -8,7 +8,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/animations-react-native/package.json
+++ b/packages/animations-react-native/package.json
@@ -10,7 +10,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/animations-reanimated/package.json
+++ b/packages/animations-reanimated/package.json
@@ -8,7 +8,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/aria-hidden/package.json
+++ b/packages/aria-hidden/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/avatar/package.json
+++ b/packages/avatar/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/babel-plugin/package.json
+++ b/packages/babel-plugin/package.json
@@ -6,7 +6,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/calc/package.json
+++ b/packages/calc/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,6 @@
     "access": "public"
   },
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/code-to-html/package.json
+++ b/packages/code-to-html/package.json
@@ -6,7 +6,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/compose-refs/package.json
+++ b/packages/compose-refs/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/config-base/package.json
+++ b/packages/config-base/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "sideEffects": false,
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "sideEffects": false,
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs/constants",
   "module": "dist/esm/constants",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/core-node/package.json
+++ b/packages/core-node/package.json
@@ -4,7 +4,6 @@
   "main": "./src/index.js",
   "types": "./types/static.d.ts",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,6 @@
   "files": [
     "types",
     "dist",
-    "src",
     "reset.css"
   ],
   "dependencies": {

--- a/packages/create-context/package.json
+++ b/packages/create-context/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/create-theme/package.json
+++ b/packages/create-theme/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "sideEffects": false,
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/create-themes/package.json
+++ b/packages/create-themes/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "sideEffects": false,
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -10,7 +10,6 @@
     "*.css"
   ],
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/dismissable/package.json
+++ b/packages/dismissable/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/floating/package.json
+++ b/packages/floating/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/focus-scope/package.json
+++ b/packages/focus-scope/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/focusable/package.json
+++ b/packages/focusable/package.json
@@ -9,7 +9,6 @@
   "module:jsx": "dist/jsx",
   "license": "MIT",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/font-size/package.json
+++ b/packages/font-size/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/get-button-sized/package.json
+++ b/packages/get-button-sized/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/get-font-sized/package.json
+++ b/packages/get-font-sized/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/get-size/package.json
+++ b/packages/get-size/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs/index",
   "module": "dist/esm/index",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/group/package.json
+++ b/packages/group/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/helpers-node/package.json
+++ b/packages/helpers-node/package.json
@@ -5,7 +5,6 @@
   "types": "./types/index.d.ts",
   "main": "./dist",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/helpers-tamagui/package.json
+++ b/packages/helpers-tamagui/package.json
@@ -6,7 +6,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -6,7 +6,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/label/package.json
+++ b/packages/label/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/linear-gradient/package.json
+++ b/packages/linear-gradient/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/list-item/package.json
+++ b/packages/list-item/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/logo/package.json
+++ b/packages/logo/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/lucide-icons/package.json
+++ b/packages/lucide-icons/package.json
@@ -8,7 +8,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/next-plugin/package.json
+++ b/packages/next-plugin/package.json
@@ -7,7 +7,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/next-theme/package.json
+++ b/packages/next-theme/package.json
@@ -7,7 +7,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/normalize-css-color/package.json
+++ b/packages/normalize-css-color/package.json
@@ -9,7 +9,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/popper/package.json
+++ b/packages/popper/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -6,7 +6,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/progress/package.json
+++ b/packages/progress/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/react-native-media-driver/package.json
+++ b/packages/react-native-media-driver/package.json
@@ -7,7 +7,6 @@
   "types": "./types/index.d.ts",
   "license": "MIT",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/react-native-use-pressable/package.json
+++ b/packages/react-native-use-pressable/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/react-native-use-responder-events/package.json
+++ b/packages/react-native-use-responder-events/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/remove-scroll/package.json
+++ b/packages/remove-scroll/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/roving-focus/package.json
+++ b/packages/roving-focus/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/scroll-view/package.json
+++ b/packages/scroll-view/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/separator/package.json
+++ b/packages/separator/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/shapes/package.json
+++ b/packages/shapes/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/sheet/package.json
+++ b/packages/sheet/package.json
@@ -11,7 +11,6 @@
   "module:jsx": "dist/jsx",
   "license": "MIT",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/shorthands/package.json
+++ b/packages/shorthands/package.json
@@ -7,7 +7,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/simple-hash/package.json
+++ b/packages/simple-hash/package.json
@@ -6,7 +6,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/stacks/package.json
+++ b/packages/stacks/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/static/package.json
+++ b/packages/static/package.json
@@ -7,7 +7,6 @@
   "module": "dist/esm/index.js",
   "files": [
     "tamagui.tsconfig.json",
-    "src",
     "types",
     "dist"
   ],

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/tamagui/package.json
+++ b/packages/tamagui/package.json
@@ -11,7 +11,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist",
     "linear-gradient"

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/theme-base/package.json
+++ b/packages/theme-base/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "sideEffects": false,
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -6,7 +6,6 @@
   "module": "dist/esm",
   "sideEffects": false,
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -10,7 +10,6 @@
     "*.css"
   ],
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-constant/package.json
+++ b/packages/use-constant/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-controllable-state/package.json
+++ b/packages/use-controllable-state/package.json
@@ -7,7 +7,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-debounce/package.json
+++ b/packages/use-debounce/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-did-finish-ssr/package.json
+++ b/packages/use-did-finish-ssr/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-direction/package.json
+++ b/packages/use-direction/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-event/package.json
+++ b/packages/use-event/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-force-update/package.json
+++ b/packages/use-force-update/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-keyboard-visible/package.json
+++ b/packages/use-keyboard-visible/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-presence/package.json
+++ b/packages/use-presence/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/use-window-dimensions/package.json
+++ b/packages/use-window-dimensions/package.json
@@ -5,7 +5,6 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -10,7 +10,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/vite-plugin-reanimated/package.json
+++ b/packages/vite-plugin-reanimated/package.json
@@ -5,7 +5,6 @@
   "types": "./types/index.d.ts",
   "module": "dist/esm",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -7,7 +7,6 @@
   "type": "module",
   "license": "MIT",
   "files": [
-    "src",
     "types",
     "dist"
   ],

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -23,7 +23,6 @@
   "files": [
     "types",
     "dist",
-    "src",
     "reset.css"
   ],
   "dependencies": {

--- a/takeout/studio/package.json
+++ b/takeout/studio/package.json
@@ -8,7 +8,6 @@
   "module": "dist/esm",
   "module:jsx": "dist/jsx",
   "files": [
-    "src",
     "types",
     "dist"
   ],


### PR DESCRIPTION
Remove src in files field in package json for all packages.

Not import src file in tarball npm
![image](https://user-images.githubusercontent.com/3316940/224101176-78396959-53b9-4a67-bff4-d19ea2906f99.png)


