### PR TITLE
Bug Report Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -30,3 +30,9 @@ body:
       - For native-only bugs, please fork this repo and use `apps/kitchen-sink` to reproduce the bug. Once reproduced, submit a PR with the title `[Issue] ...`
   validations:
     required: true
+- type: textarea
+  attributes:
+    label: System Info
+    render: markdown
+    description: |
+      - Output of `npx envinfo --system --npmPackages --binaries --browsers`

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,32 @@
+name: Reproducible Bug Report
+description: Get much faster response time by **forking this repo, reproducing the bug, and then submitting it was a PR with the title "[Issue] ..."**
+labels: [Bug]
+body:
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: Describe what's happening in 1-2 sentences.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Tamagui Version
+    render: markdown
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Reproduction
+    render: markdown
+    description: |
+      - If this is a bug with Tamagui, fork this CodeSandbox to reproduce the issue.
+      - If this is a bug with the Starter, fork this CodeSandbox to reproduce the issue.
+      - For native-only bugs, please fork this repo and use `apps/kitchen-sink` to reproduce the bug. Once reproduced, submit a PR with the title `[Issue] ...`
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,8 +25,8 @@ body:
     label: Reproduction
     render: markdown
     description: |
-      - If this is a bug with Tamagui, fork this CodeSandbox to reproduce the issue.
-      - If this is a bug with the Starter, fork this CodeSandbox to reproduce the issue.
+      - If this is a bug with Tamagui, fork [this CodeSandbox](https://codesandbox.io/p/sandbox/github/tamagui/tamagui/starters/expo-next-solito) to reproduce the issue.
+      - If this is a bug with the Starter, fork [this CodeSandbox](https://codesandbox.io/p/sandbox/github/tamagui/tamagui/apps/starter) to reproduce the issue.
       - For native-only bugs, please fork this repo and use `apps/kitchen-sink` to reproduce the bug. Once reproduced, submit a PR with the title `[Issue] ...`
   validations:
     required: true


### PR DESCRIPTION
I've found creating issues/reproductions to be frequent yet difficult. I often don't do it because I don't want to pull the repo, rebase, make a new branch, etc. I think CodeSandbox simplifies this a lot. Just open a link and it's ready.

This PR also uses GitHub's new yml bug report templates, which look like this:

<img width="1091" alt="Screenshot 2023-03-20 at 7 25 22 AM" src="https://user-images.githubusercontent.com/13172299/226353494-49a24091-eab6-498e-9819-38be0a6244c8.png">
