### PR TITLE
fix: [#559] ensure keysOrdered is tokenized

### DIFF
--- a/packages/get-size/src/index.ts
+++ b/packages/get-size/src/index.ts
@@ -12,7 +12,8 @@ export const stepTokenUpOrDown = (
   bounds = [0]
 ): Variable<number> => {
   const tokens = getTokens({ prefixed: true })[type]
-  const keysOrdered = tokensKeysOrdered.get(tokens) || Object.keys(tokens)
+  const maybeTokenizedKeysOrdered = tokensKeysOrdered.get(tokens) || Object.keys(tokens);
+  const keysOrdered = maybeTokenizedKeysOrdered.map((maybeTokenizedKey) => maybeTokenizedKey.charAt(0) === "$" ? maybeTokenizedKey : `$${maybeTokenizedKey}`);
   const min = bounds[0] ?? 0
   const max = bounds[1] ?? keysOrdered.length - 1
   const currentIndex = keysOrdered.indexOf(name)


### PR DESCRIPTION
Fixes #559

Ensures that `keysOrdered` is tokenized (each `key` is prefixed with `"$"`).

Admittedly, this patches a side effect from a separate issue:

- `createVariables` _always_ removes the `"$"` prefix
- `tokensKeysOrdered` stores `size` and `space` tokens without the prefix

So, I'm not sure what the better approach is:

- the fix in this PR
- changing how `tokensKeysOrdered` [is set here](https://github.com/tamagui/tamagui/blob/master/packages/web/src/createVariables.ts#L51) by doing

```
tokensKeysOrdered.set(res, Object.keys(tokens).map((tokenWithoutPrefix) => `${tokenWithoutPrefix}`))
```