### PR TITLE
feat(web): styled components now inherent the name from the parent they

### DIFF
--- a/apps/site/data/docs/intro/benchmarks.mdx
+++ b/apps/site/data/docs/intro/benchmarks.mdx
@@ -5,7 +5,7 @@ description: Performance tests and comparisons.
 
 ## React Native
 
-In [this benchmark](https://github.com/tamagui/tamagui/blob/master/starters/benchmark/README.md) Tamagui is within 10% of the speed of vanilla React Native, even when using nearly all of Tamagui's features. We render list of 28 items with a few sections, text and images. Average of 5 runs on a Apple M2 Air:
+In [this benchmark](https://github.com/tamagui/benchmarks) Tamagui is within 10% of the speed of vanilla React Native, even when using nearly all of Tamagui's features. We render list of 28 items with a few sections, text and images. Average of 5 runs on a Apple M2 Air:
 
 <BenchmarkChartNative />
 

--- a/packages/get-size/src/index.ts
+++ b/packages/get-size/src/index.ts
@@ -12,7 +12,8 @@ export const stepTokenUpOrDown = (
   bounds = [0]
 ): Variable<number> => {
   const tokens = getTokens({ prefixed: true })[type]
-  const keysOrdered = tokensKeysOrdered.get(tokens) || Object.keys(tokens)
+  const maybeTokenizedKeysOrdered = tokensKeysOrdered.get(tokens) || Object.keys(tokens);
+  const keysOrdered = maybeTokenizedKeysOrdered.map((maybeTokenizedKey) => maybeTokenizedKey.charAt(0) === "$" ? maybeTokenizedKey : `$${maybeTokenizedKey}`);
   const min = bounds[0] ?? 0
   const max = bounds[1] ?? keysOrdered.length - 1
   const currentIndex = keysOrdered.indexOf(name)

--- a/packages/web/src/styled.tsx
+++ b/packages/web/src/styled.tsx
@@ -117,7 +117,7 @@ export function styled<
         variants,
         defaultProps,
         defaultVariants,
-        componentName: name,
+        componentName: name || parentStaticConfig?.componentName,
         isReactNative,
         isText,
         acceptsClassName,


### PR DESCRIPTION
extend automatically

BREAKING CHANGE: Technically this is a breaking change, though likely not one you'll run into any issues with. Nonetheless, we'll bump the minor version to make it a bit clearer and easier to downgrade.