### PR TITLE
fix: kitchen sink group not getting rounded

### DIFF
--- a/apps/kitchen-sink/src/features/home/screen.tsx
+++ b/apps/kitchen-sink/src/features/home/screen.tsx
@@ -78,12 +78,13 @@ const LinkListItem = ({
   )
 }
 
-const ColorSchemeListItem = () => {
+const ColorSchemeListItem = (props: ListItemProps) => {
   const theme = useThemeControl()
   const checked = theme.value === 'light'
 
   return (
     <ListItem
+      {...props}
       pressTheme
       paddingVertical={0}
       onPress={() => {


### PR DESCRIPTION
Issue: The theme line item was not rounded by the Group wrapper.
<img width="381" alt="image" src="https://user-images.githubusercontent.com/35243344/227602739-7fd6f7ea-5c52-4cb5-84e7-744c39825348.png">


The component wasn't passing down the props. I don't think if this was rounded before the Group changes (#735) either but I might be wrong.