### PR TITLE
fix(animations): add getAnimationDriver as fallback to useAnimationDriver

### DIFF
--- a/packages/web/src/hooks/useAnimationDriver.tsx
+++ b/packages/web/src/hooks/useAnimationDriver.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 
-import { AnimationDriverContext } from '../contexts/AnimationDriverContext'
-import { getAnimationDriver } from '../helpers/getAnimationDriver'
+import { AnimationDriverContext } from '../contexts/AnimationDriverContext.js'
+import { getAnimationDriver } from '../helpers/getAnimationDriver.js'
 
 export const useAnimationDriver = () => {
   return useContext(AnimationDriverContext) ?? getAnimationDriver()

--- a/packages/web/src/hooks/useAnimationDriver.tsx
+++ b/packages/web/src/hooks/useAnimationDriver.tsx
@@ -1,7 +1,8 @@
 import { useContext } from 'react'
 
 import { AnimationDriverContext } from '../contexts/AnimationDriverContext'
+import { getAnimationDriver } from '../helpers/getAnimationDriver'
 
 export const useAnimationDriver = () => {
-  return useContext(AnimationDriverContext)
+  return useContext(AnimationDriverContext) ?? getAnimationDriver()
 }

--- a/packages/web/types/hooks/useAnimationDriver.d.ts
+++ b/packages/web/types/hooks/useAnimationDriver.d.ts
@@ -1,4 +1,4 @@
-export declare const useAnimationDriver: () => import("..").AnimationDriver<{
+export declare const useAnimationDriver: () => import("../types.js").AnimationDriver<{
     [key: string]: any;
 }>;
 //# sourceMappingURL=useAnimationDriver.d.ts.map

--- a/packages/web/types/hooks/useAnimationDriver.d.ts
+++ b/packages/web/types/hooks/useAnimationDriver.d.ts
@@ -1,4 +1,4 @@
 export declare const useAnimationDriver: () => import("..").AnimationDriver<{
     [key: string]: any;
-}> | null;
+}>;
 //# sourceMappingURL=useAnimationDriver.d.ts.map


### PR DESCRIPTION
Users seem to have issues using this and are getting the `Must set animations in tamagui.config.ts at SheetImplementation2 ` .

Not sure why that is happening. Maybe context is not available on the first render and this is throwing? 


P.S. ignore the branch name as it's not a css driver issue, but a general animations one