### PR TITLE
fix(site): change all possible imports to `tamagui`

### DIFF
--- a/apps/site/data/blog/version-one.mdx
+++ b/apps/site/data/blog/version-one.mdx
@@ -79,7 +79,7 @@ One novel feature is **deterministic, easy to reason about style merging**. Core
 Here's an example of the `styled` function with a few variants:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const Circle = styled(Stack, {
   // access your tokens and theme values easily with $ props
@@ -127,7 +127,7 @@ It works with well-optimized and easy to use hooks like [useMedia](/docs/core/us
 Here's a stripped down configuration:
 
 ```tsx
-import { createFont, createTamagui, createTokens } from '@tamagui/core'
+import { createFont, createTamagui, createTokens } from 'tamagui' // or '@tamagui/core'
 
 const interFont = createFont({
   family: 'Inter, Helvetica, Arial, sans-serif',
@@ -261,7 +261,7 @@ export const config = createTamagui({
 Then you can change the family to Mandarin at any point in your React tree, with types working as expected:
 
 ```tsx
-import { FontLanguage, Text } from '@tamagui/core'
+import { FontLanguage, Text } from 'tamagui' // or '@tamagui/core'
 
 export default () => (
   <FontLanguage body="mandarin">
@@ -297,7 +297,7 @@ This hook is useful for authoring your own custom components built on Tamagui. T
 The `useMediaPropsActive` is an important part of that functionality, making it easy to properly access the "currently active" set of styles given the current screen size. Here's an example:
 
 ```tsx
-import { Stack, StackProps, useMediaPropsActive } from '@tamagui/core'
+import { Stack, StackProps, useMediaPropsActive } from 'tamagui' // or '@tamagui/core'
 
 const CustomWidget = (props: StackProps) => {
   const activeProps = useMediaPropsActive(props)

--- a/apps/site/data/docs/components/alert-dialog/1.0.0.mdx
+++ b/apps/site/data/docs/components/alert-dialog/1.0.0.mdx
@@ -29,7 +29,7 @@ package: alert-dialog
 ### Anatomy
 
 ```tsx
-import { AlertDialog } from '@tamagui/alert-dialog' // or from 'tamagui'
+import { AlertDialog } from 'tamagui' // or from '@tamagui/alert-dialog'
 
 export default () => (
   <AlertDialog>

--- a/apps/site/data/docs/components/card/1.0.0.mdx
+++ b/apps/site/data/docs/components/card/1.0.0.mdx
@@ -29,7 +29,7 @@ package: card
 ### Anatomy
 
 ```tsx
-import { Card } from 'tamagui' // or @tamagui/card
+import { Card } from 'tamagui' // or from '@tamagui/card'
 
 export default () => (
   <Card>

--- a/apps/site/data/docs/components/dialog/1.0.0.mdx
+++ b/apps/site/data/docs/components/dialog/1.0.0.mdx
@@ -29,7 +29,7 @@ package: dialog
 ### Anatomy
 
 ```tsx
-import { Dialog } from '@tamagui/dialog' // or from 'tamagui'
+import { Dialog } from 'tamagui' // or from '@tamagui/dialog'
 
 export default () => (
   <Dialog>
@@ -176,7 +176,7 @@ See [Sheet](/docs/components/sheet) for more props.
 Must use `Adapt.Contents` inside the `Dialog.Sheet.Frame` to insert the contents given to `Dialog.Content`
 
 ```tsx
-import { Dialog } from '@tamagui/dialog' // or from 'tamagui'
+import { Dialog } from 'tamagui' // or from '@tamagui/dialog'
 
 export default () => (
   <Dialog>

--- a/apps/site/data/docs/components/form/1.3.0.mdx
+++ b/apps/site/data/docs/components/form/1.3.0.mdx
@@ -32,7 +32,7 @@ package: form
 ### Anatomy
 
 ```tsx
-import { Form } from '@tamagui/form' // or from 'tamagui'
+import { Form } from 'tamagui' // or from '@tamagui/form'
 
 export default () => (
   <Form>

--- a/apps/site/data/docs/components/headings/1.0.0.mdx
+++ b/apps/site/data/docs/components/headings/1.0.0.mdx
@@ -48,7 +48,7 @@ Note that Heading, and H1-H6 all default to the `heading` font family that must 
 Because [Paragraph](/docs/components/text#paragraph) extends [SizableText](/docs/components/text#sizabletext), you get automatic styles based on your font theme. Let's see how `SizableText` defines the size variant, roughly, which gives a good idea of how Tamagui works, and how you could create or change your own headings at a lower level.
 
 ```tsx
-import { Text } from '@tamagui/core'
+import { Text } from 'tamagui' // or '@tamagui/core'
 
 const SizableText = styled(Text, {
   name: 'SizableText',

--- a/apps/site/data/docs/components/popover/1.0.0.mdx
+++ b/apps/site/data/docs/components/popover/1.0.0.mdx
@@ -29,7 +29,7 @@ package: popover
 ### Anatomy
 
 ```tsx
-import { Popover } from '@tamagui/popover'
+import { Popover } from 'tamagui' // or @tamagui/popover
 
 export default () => (
   <Popover>

--- a/apps/site/data/docs/components/select/1.0.0.mdx
+++ b/apps/site/data/docs/components/select/1.0.0.mdx
@@ -29,7 +29,7 @@ package: select
 ### Anatomy
 
 ```tsx
-import { Select } from '@tamagui/select' // or from 'tamagui'
+import { Select } from 'tamagui' // or from '@tamagui/select'
 
 export default () => (
   <Select defaultValue="">
@@ -209,7 +209,7 @@ See [Sheet](/docs/components/sheet) for more props.
 Must use `Select.SheetContents` inside the `Select.Sheet.Frame` to insert the contents given to `Select.Content`
 
 ```tsx
-import { Select } from '@tamagui/select' // or from 'tamagui'
+import { Select } from 'tamagui' // or from '@tamagui/select'
 
 export default () => (
   <Select defaultValue="">

--- a/apps/site/data/docs/components/sheet/1.0.0.mdx
+++ b/apps/site/data/docs/components/sheet/1.0.0.mdx
@@ -30,7 +30,7 @@ package: sheet
 ### Anatomy
 
 ```tsx
-import { Sheet } from '@tamagui/sheet' // or from 'tamagui'
+import { Sheet } from 'tamagui' // or from '@tamagui/sheet'
 
 export default () => (
   <Sheet>

--- a/apps/site/data/docs/components/sheet/1.9.18.mdx
+++ b/apps/site/data/docs/components/sheet/1.9.18.mdx
@@ -30,7 +30,7 @@ package: sheet
 ### Anatomy
 
 ```tsx
-import { Sheet } from '@tamagui/sheet' // or from 'tamagui'
+import { Sheet } from 'tamagui' // or from '@tamagui/sheet'
 
 export default () => (
   <Sheet>

--- a/apps/site/data/docs/components/stacks/1.0.0.mdx
+++ b/apps/site/data/docs/components/stacks/1.0.0.mdx
@@ -107,8 +107,8 @@ Beyond the [Tamagui Props](/docs/intro/props), stacks have two variants
 Adds a variety of helpers that automatically apply theme values when set to true. Useful for creating higher level components by wrapping with `styled()`:
 
 ```tsx
-import { styled } from '@tamagui/core'
-import { ThemeableStack } from '@tamagui/stacks' // or tamagui
+import { styled } from 'tamagui' // or @tamagui/core
+import { ThemeableStack } from 'tamagui' // or @tamagui/stacks
 
 const MyCard = styled(ThemeableStack, {
   hoverTheme: true,

--- a/apps/site/data/docs/components/toast/1.8.0.mdx
+++ b/apps/site/data/docs/components/toast/1.8.0.mdx
@@ -35,7 +35,7 @@ For native support, run `yarn add burnt` to add `burnt`, then rebuild your React
 ## Anatomy
 
 ```tsx
-import { Toast, ToastProvider, ToastViewport } from '@tamagui/toast'
+import { Toast, ToastProvider, ToastViewport } from 'tamagui' // or @tamagui/toast
 
 export default () => (
   <ToastProvider>
@@ -130,8 +130,8 @@ export default () => {
 ### Using `createToast`
 
 ```tsx
-import { Button } from '@tamagui/button'
-import { Toast, ToastProvider, createToast } from '@tamagui/toast'
+import { Button } from 'tamagui' // or @tamagui/button
+import { Toast, ToastProvider, createToast } from 'tamagui' // or @tamagui/toast
 
 export const { ImperativeToastProvider, useToast } = createToast()
 

--- a/apps/site/data/docs/components/toast/1.9.1.mdx
+++ b/apps/site/data/docs/components/toast/1.9.1.mdx
@@ -43,8 +43,8 @@ For native support on mobile, run `yarn add burnt` to add `burnt`, then rebuild 
 To display the toast natively, you should either pass an array of native platforms (`native: ["ios", "web"]`), a single platform or `true` for all platforms.
 
 ```tsx
-import { Button } from '@tamagui/button'
-import { Toast, ToastProvider, ToastImperativeProvider, useToast } from '@tamagui/toast'
+import { Button } from 'tamagui' // or @tamagui/button
+import { Toast, ToastProvider, ToastImperativeProvider, useToast } from 'tamagui' // or @tamagui/toast
 
 export default () => (
   <ToastProvider>

--- a/apps/site/data/docs/components/tooltip/1.0.0.mdx
+++ b/apps/site/data/docs/components/tooltip/1.0.0.mdx
@@ -29,7 +29,7 @@ package: tooltip
 ### Anatomy
 
 ```tsx
-import { Tooltip } from '@tamagui/tooltip'
+import { Tooltip } from 'tamagui' // or @tamagui/tooltip
 
 export default () => (
   <Tooltip>

--- a/apps/site/data/docs/core/configuration.mdx
+++ b/apps/site/data/docs/core/configuration.mdx
@@ -11,7 +11,7 @@ You can use `@tamagui/config` a totally complete config out of the box, the same
 
 ```tsx
 import { config } from '@tamagui/config'
-import { createTamagui, setupReactNative } from '@tamagui/core'
+import { createTamagui, setupReactNative } from 'tamagui' // or '@tamagui/core'
 import * as ReactNative from 'react-native'
 
 // if using only @tamagui/core with `react-native` components
@@ -38,7 +38,7 @@ export default appConfig
 Another quick start that gives a bit more customization is using `@tamagui/shorthands` for our preset shorthands, and `@tamagui/themes` for the same themes and tokens used for this site. Then you'll just want to bring along any fonts, media queries, and animations you need.
 
 ```tsx
-import { createTamagui } from '@tamagui/core'
+import { createTamagui } from 'tamagui' // or '@tamagui/core'
 import { shorthands } from '@tamagui/shorthands'
 import { themes, tokens } from '@tamagui/themes'
 
@@ -76,7 +76,7 @@ And if you want even shorter, like this:
 You can achieve that by writing variants (see [an example at bottom of page](#example-of-shorthands-an-variants)).
 
 ```tsx
-import { createFont, createTamagui, createTokens } from '@tamagui/core'
+import { createFont, createTamagui, createTokens } from 'tamagui' // or '@tamagui/core'
 import { createMedia } from '@tamagui/react-native-media-driver'
 
 const interFont = createFont({

--- a/apps/site/data/docs/core/font-language.mdx
+++ b/apps/site/data/docs/core/font-language.mdx
@@ -55,7 +55,7 @@ export default createTamagui({
 You'll then need to load the `Inter` and `Inter-CN` fonts for the platforms you support. Once you do, you'll get fully typed support for changing any `body` font to `cn` in a component:
 
 ```tsx
-import { FontLanguage, Text } from '@tamagui/core'
+import { FontLanguage, Text } from 'tamagui' // or @tamagui/core
 
 export default (
   <FontLanguage body="cn">
@@ -71,7 +71,7 @@ The name you choose for the suffix is up to you, and Tamagui will treat any font
 To reset your font back to your base `body` font, you can use the reserved key `default`:
 
 ```tsx
-import { FontLanguage, Text } from '@tamagui/core'
+import { FontLanguage, Text } from 'tamagui' // or @tamagui/core
 
 export default (
   <FontLanguage body="cn">

--- a/apps/site/data/docs/core/stack-and-text.mdx
+++ b/apps/site/data/docs/core/stack-and-text.mdx
@@ -14,7 +14,7 @@ See [the Props docs](/docs/intro/props) for the full list of properties.
 You can use them directly:
 
 ```tsx
-import { Stack, Text } from '@tamagui/core'
+import { Stack, Text } from 'tamagui' // or '@tamagui/core'
 
 export default () => (
   <Stack margin={10}>
@@ -26,7 +26,7 @@ export default () => (
 Or use them [with styled](/docs/core/styled) to create your own base level design system:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const Circle = styled(Stack, {
   borderRadius: 100_000_000,

--- a/apps/site/data/docs/core/styled.mdx
+++ b/apps/site/data/docs/core/styled.mdx
@@ -6,7 +6,7 @@ description: Extend and build custom and optimizable components.
 Create a new component by extending an existing one:
 
 ```tsx
-import { GetProps, Stack, styled } from '@tamagui/core'
+import { GetProps, Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const Circle = styled(Stack, {
   name: 'Circle', // useful for debugging, and Component themes
@@ -28,7 +28,7 @@ Note, `tamagui` and `@tamagui/core` both export many of the same helpers, like s
 If using just `core` but passing in React Native components, be sure to run `setupReactNative` once first, typically near your entry file:
 
 ```tsx
-import { setupReactNative, styled } from '@tamagui/core'
+import { setupReactNative, styled } from 'tamagui' // or '@tamagui/core'
 import { Image } from 'react-native'
 
 // this allows tamagui to optimize for react-native components
@@ -51,7 +51,7 @@ You can pass any prop that is supported by the component you are extending, even
 Let's add some variants:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const Circle = styled(Stack, {
   borderRadius: 100_000_000,
@@ -103,7 +103,7 @@ The `styled()` function supports Tamagui views, React Native views, and any othe
 If it does accept `className`, you can opt-in to className, CSS media queries, and compile-time optimization by adding `acceptsClassName`:
 
 ```tsx
-import { styled } from '@tamagui/core'
+import { styled } from 'tamagui' // or '@tamagui/core'
 import { SomeCustomComponent } from 'some-library'
 
 export const TamaguiCustomComponent = styled(SomeCustomComponent, {

--- a/apps/site/data/docs/core/theme.mdx
+++ b/apps/site/data/docs/core/theme.mdx
@@ -15,7 +15,7 @@ Changing themes in Tamagui is as easy as passing their name to the Theme compone
 Change themes anywhere in your app like so:
 
 ```tsx
-import { Button, Theme } from '@tamagui/core'
+import { Button, Theme } from 'tamagui' // or @tamagui/core
 
 export default () => (
   <Theme name="dark">

--- a/apps/site/data/docs/core/variants.mdx
+++ b/apps/site/data/docs/core/variants.mdx
@@ -8,7 +8,7 @@ Variants let you create typed props quickly on your styled() components.
 Here's an example:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const Circle = styled(Stack, {
   borderRadius: 100_000_000,
@@ -59,7 +59,7 @@ We're showing off a few different styles of variants here. We'll expand on them 
 If you need more complex types, or simply prefer a shorter syntax, you can use a single function instead of using the object syntax for variants:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const MyStack = styled(Stack, {
   variants: {
@@ -89,7 +89,7 @@ You can use a pseudo Typescript syntax for other variants:
 Example:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const ColorfulStack = styled(Stack, {
   variants: {
@@ -231,7 +231,7 @@ const Square = styled(Stack, {
 Much like a dynamic variant, except it lets you use it alongside the other typed variants you need. Use '...' and it will grab all variants that don't match:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 export const ColorfulStack = styled(Stack, {
   variants: {

--- a/apps/site/data/docs/intro/introduction.mdx
+++ b/apps/site/data/docs/intro/introduction.mdx
@@ -15,7 +15,7 @@ The highest level part of Tamagui is `tamagui` itself, a complete UI kit built o
 After [configuring](/docs/core/configuration), use `@tamagui/core` as simply as:
 
 ```tsx
-import { Stack, Text } from '@tamagui/core'
+import { Stack, Text } from 'tamagui' // or '@tamagui/core'
 
 export const App = () => (
   <Stack backgroundColor="red" borderRadius={10}>
@@ -28,7 +28,7 @@ Core also includes a `styled` utility with a `variants` field that is a very qui
 props by letting you quickly type both the key and the value of the prop you expect:
 
 ```tsx
-import { Stack, Theme, styled } from '@tamagui/core'
+import { Stack, Theme, styled } from 'tamagui' // or '@tamagui/core'
 
 export const AvatarCircle = styled(Stack, {
   // use direct values
@@ -71,7 +71,7 @@ Variants can also take functions to catch either all values or specific types of
 You can nest styled components multiple times:
 
 ```tsx
-import { styled, Stack } from '@tamagui/core'
+import { styled, Stack } from 'tamagui' // or '@tamagui/core'
 
 const const SizedHorizontal = styled(Stack, {
   variants: {
@@ -106,7 +106,7 @@ const const SizedButton = styled(SizedHorizontal, {
 Tamagui has the nice feature of fully-deterministic rendering based on the order of their definition, where the last key of the style object wins. This works both on props and styled() calls:
 
 ```tsx
-import { styled } from '@tamagui/core'
+import { styled } from 'tamagui' // or '@tamagui/core'
 
 import { SizedButton } from './example-above'
 

--- a/apps/site/data/docs/intro/props.mdx
+++ b/apps/site/data/docs/intro/props.mdx
@@ -6,7 +6,7 @@ description: All the properties supported on base Tamagui components.
 Tamagui uses a superset of the style properties that are supported in React Native and React Native Web, and flattens them onto the direct properties of Stack and Text ([see why below](#why-its-important)). So you can write:
 
 ```tsx
-import { Stack } from '@tamagui/core'
+import { Stack } from 'tamagui' // or '@tamagui/core'
 
 export default () => <Stack padding={10} backgroundColor="red" />
 ```

--- a/apps/site/data/docs/intro/themes.mdx
+++ b/apps/site/data/docs/intro/themes.mdx
@@ -80,7 +80,7 @@ You can also access a specific subset more directly:
 Every Tamagui `styled()` component looks for it's own specific theme if you pass it the `name` property. For example:
 
 ```tsx
-import { Stack, styled } from '@tamagui/core'
+import { Stack, styled } from 'tamagui' // or '@tamagui/core'
 
 const Circle = styled(Stack, {
   name: 'Circle',
@@ -131,7 +131,7 @@ You can of course do all of this yourself in your own design system with `styled
 If you are building a component with more than one sub-components, you can follow this pattern:
 
 ```tsx
-import { GetProps, Stack, Text, styled } from '@tamagui/core'
+import { GetProps, Stack, Text, styled } from 'tamagui' // or '@tamagui/core'
 
 const ButtonFrame = styled(Stack, {
   name: 'Button',


### PR DESCRIPTION
Figured would be easier for newbies. Will prevent version mismatch (which has happened before in the issues), when user has a version of `tamagui` and installs another version of a component and gets errors. 
Not sure about the `@tamagui/core` changes and if having `tamagui` as the default would be better for that case too but went ahead and changed those too.