### PR TITLE
expo guide: use themes instead of theme-base

### DIFF
--- a/apps/site/data/docs/guides/expo.mdx
+++ b/apps/site/data/docs/guides/expo.mdx
@@ -76,7 +76,7 @@ import { createAnimations } from '@tamagui/animations-react-native'
 import { createInterFont } from '@tamagui/font-inter'
 import { createMedia } from '@tamagui/react-native-media-driver'
 import { shorthands } from '@tamagui/shorthands'
-import { themes, tokens } from '@tamagui/theme-base'
+import { themes, tokens } from '@tamagui/themes'
 import { createTamagui } from 'tamagui'
 
 const animations = createAnimations({


### PR DESCRIPTION
As `@tamagui/theme-base` is now deprecated.