### PR TITLE
Add option --declaration-root to tamagui-build

### DIFF
--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -19,6 +19,8 @@ const shouldBundleNodeModules = !!process.argv.includes('--bundle-modules')
 const shouldClean = !!process.argv.includes('clean')
 const shouldCleanBuildOnly = !!process.argv.includes('clean:build')
 const shouldWatch = process.argv.includes('--watch')
+const declarationToRoot = !!process.argv.includes('--declaration-root')
+
 
 const pkg = fs.readJSONSync('./package.json')
 let shouldSkipInitialTypes = !!process.env.SKIP_TYPES_INITIAL
@@ -127,7 +129,7 @@ async function buildTsc() {
     // typescripts build cache messes up when doing declarationOnly
     await fs.remove('tsconfig.tsbuildinfo')
     await fs.ensureDir(targetDir)
-    const cmd = `tsc --baseUrl . --outDir ${targetDir} --rootDir src --emitDeclarationOnly --declarationMap`
+    const cmd = `tsc --baseUrl . --outDir ${targetDir} --rootDir src {declarationToRoot ? '--declarationDir ./' : ''} --emitDeclarationOnly --declarationMap`
     // console.log('\x1b[2m$', `npx ${cmd}`)
     await exec('npx', cmd.split(' '))
   } catch (err) {


### PR DESCRIPTION
I had the requirement to modify the declarationDir of esbuild. With this PR users can run
```
tamagui-build --declaration-root
```
To create declarations into the root folder. This is specific if library authors wants to export multiple folders of one package like:
```
import {} from 'tamagui-extras '
import {} from 'tamagui-extras/submodule'
```