### PR TITLE
fix(toast): remove native toast ref from public api + add docs

### DIFF
--- a/apps/site/data/docs/components/toast/1.13.0.mdx
+++ b/apps/site/data/docs/components/toast/1.13.0.mdx
@@ -306,6 +306,11 @@ Used to control the display of toasts. Should be used inside [ToastProvider](#to
       type: '(): void',
       description: `Call it to hide the currently displayed toast.`,
     },
+    {
+      name: 'options',
+      type: `ToastImperativeOptions`,
+      descriptions: `The options you've passed to \`ToastProvider\`. You shouldn't try to change this.`
+    }
   ]}
 />
 

--- a/next.md
+++ b/next.md
@@ -2,7 +2,7 @@
   - add `defaultSize`, and `defaultColor`
   - add `relative()` helpers
 
-- missing docs on useToastController().options
+- [x] missing docs on useToastController().options
 
 - bug android 
   - I've been working on integrating our component library to mobile and ran into a snag with the android build. IOS builds seamlessly and Android throws this error when trying to use Select component:

--- a/packages/toast/src/ToastImperative.tsx
+++ b/packages/toast/src/ToastImperative.tsx
@@ -32,8 +32,6 @@ type ToastData = { title: string; id: string } & CreateNativeToastOptions & {
   }
 
 interface ToastContextI {
-  nativeToast: NativeToastRef | null
-
   /**
    * Call it to show a new toast. If you're using native toasts, you can pass native options using \`burntOptions\` or \`notificationOptions\` depending on the native platform (mobile/web).
    */
@@ -48,6 +46,9 @@ interface ToastContextI {
    */
   hide: () => void
 
+  /**
+   * The options you've passed to `ToastProvider`. You shouldn't try to change this.
+   */
   options?: ToastImperativeOptions
 }
 
@@ -87,7 +88,7 @@ export const ToastImperativeProvider = ({
   const [toast, setToast] = React.useState<ToastData | null>(null)
 
   const [lastNativeToastRef, setLastNativeToastRef] =
-    React.useState<ToastContextI['nativeToast']>(null)
+    React.useState<NativeToastRef | null>(null)
 
   const show = React.useCallback<ToastContextI['show']>(
     (title, showOptions) => {
@@ -138,12 +139,9 @@ export const ToastImperativeProvider = ({
     return {
       show,
       hide,
-      nativeToast: lastNativeToastRef,
       options,
     }
   }, [show, hide, lastNativeToastRef, JSON.stringify(options || null)])
-
-  const currentContextValue = useMemo(() => {}, [])
 
   return (
     <ToastContext.Provider value={contextValue}>

--- a/packages/toast/types/ToastImperative.d.ts
+++ b/packages/toast/types/ToastImperative.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CreateNativeToastOptions, NativeToastRef, ToastNativePlatform, ToastNativeValue } from './types';
+import { CreateNativeToastOptions, ToastNativePlatform, ToastNativeValue } from './types';
 interface ToastImperativeOptions extends Omit<CreateNativeToastOptions, 'message'> {
     /**
      * Will show a native toast if is true or is set to the current platform. On iOS, it wraps `SPIndicator` and `SPAlert`. On Android, it wraps `ToastAndroid`. On web, it wraps Notification API. Mobile's native features are handled by `burnt`.
@@ -23,7 +23,6 @@ type ToastData = {
     isHandledNatively: boolean;
 };
 interface ToastContextI {
-    nativeToast: NativeToastRef | null;
     /**
      * Call it to show a new toast. If you're using native toasts, you can pass native options using \`burntOptions\` or \`notificationOptions\` depending on the native platform (mobile/web).
      */
@@ -36,6 +35,9 @@ interface ToastContextI {
      * _NOTE_: hides the last toast on web notification toasts
      */
     hide: () => void;
+    /**
+     * The options you've passed to `ToastProvider`. You shouldn't try to change this.
+     */
     options?: ToastImperativeOptions;
 }
 export declare const useToastController: () => ToastContextI;
@@ -43,7 +45,6 @@ export declare const useToastState: () => ToastData | null;
 /** @deprecated use `useToastController` and `useToastState` instead to avoid performance pitfalls */
 export declare const useToast: () => {
     currentToast: ToastData | null;
-    nativeToast: NativeToastRef | null;
     /**
      * Call it to show a new toast. If you're using native toasts, you can pass native options using \`burntOptions\` or \`notificationOptions\` depending on the native platform (mobile/web).
      */
@@ -56,6 +57,9 @@ export declare const useToast: () => {
      * _NOTE_: hides the last toast on web notification toasts
      */
     hide: () => void;
+    /**
+     * The options you've passed to `ToastProvider`. You shouldn't try to change this.
+     */
     options?: ToastImperativeOptions | undefined;
 };
 interface ToastImperativeProviderProps {


### PR DESCRIPTION
Figured users probably won't need to use the nativeToast property from the toast controller. They might get it in the auto-completion and find it a bit confusing but not super important.