### PR TITLE
fix(toast): bugs

### DIFF
--- a/packages/demos/src/ToastDemo.tsx
+++ b/packages/demos/src/ToastDemo.tsx
@@ -29,6 +29,7 @@ const CurrentToast = () => {
       opacity={1}
       scale={1}
       animation="100ms"
+      viewportName={currentToast.viewportName}
     >
       <YStack>
         <Toast.Title>{currentToast.title}</Toast.Title>

--- a/packages/toast/src/Toast.tsx
+++ b/packages/toast/src/Toast.tsx
@@ -50,7 +50,7 @@ const ToastTitleFrame = styled(SizableText, {
         size: '$4',
       },
     },
-  },
+  } as const,
   defaultVariants: {
     unstyled: false,
   },
@@ -84,7 +84,7 @@ const ToastDescriptionFrame = styled(SizableText, {
         size: '$1',
       },
     },
-  },
+  } as const,
 
   defaultVariants: {
     unstyled: false,

--- a/packages/toast/src/ToastImperative.tsx
+++ b/packages/toast/src/ToastImperative.tsx
@@ -19,8 +19,13 @@ interface ToastImperativeOptions extends Omit<CreateNativeToastOptions, 'message
 interface ShowOptions extends CreateNativeToastOptions {
   /**
    * Used when need custom data
+   * @deprecated Use `customData` instead
    */
   additionalInfo?: Record<string, any>
+  /**
+   * Used when need custom data
+   */
+  customData?: Record<string, any>
   /**
    * Overrides the native option on `ToastImperativeProvider`
    */
@@ -147,8 +152,6 @@ export const ToastImperativeProvider = ({
       options,
     }
   }, [show, hide, lastNativeToastRef, JSON.stringify(options || null)])
-
-  const currentContextValue = useMemo(() => {}, [])
 
   return (
     <ToastContext.Provider value={contextValue}>

--- a/packages/toast/src/ToastImperative.tsx
+++ b/packages/toast/src/ToastImperative.tsx
@@ -25,9 +25,13 @@ interface ShowOptions extends CreateNativeToastOptions {
    * Overrides the native option on `ToastImperativeProvider`
    */
   native?: ToastNativeValue
+  /**
+   * Which viewport to send this toast to. This is only intended to be used with custom toasts and you should wire it up when creating the toast.
+   */
+  viewportName?: string | 'default'
 }
 
-type ToastData = { title: string; id: string } & CreateNativeToastOptions & {
+type ToastData = { title: string; id: string } & ShowOptions & {
     isHandledNatively: boolean
   }
 
@@ -122,6 +126,7 @@ export const ToastImperativeProvider = ({
       setToast({
         title,
         id: counterRef.current.toString(),
+        viewportName: showOptions?.viewportName ?? 'default',
         ...showOptions,
         isHandledNatively,
       })

--- a/packages/toast/src/ToastImpl.tsx
+++ b/packages/toast/src/ToastImpl.tsx
@@ -34,11 +34,6 @@ const ToastImplFrame = styled(ThemeableStack, {
     unstyled: {
       false: {
         focusable: true,
-        focusStyle: {
-          outlineStyle: 'solid',
-          outlineWidth: 1,
-          outlineColor: 'red',
-        },
         backgroundColor: '$color6',
         borderRadius: '$10',
         paddingHorizontal: '$5',
@@ -194,12 +189,10 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
       [handleClose]
     )
     const handleResume = React.useCallback(() => {
-      console.log('resume')
       startTimer(closeTimerRemainingTimeRef.current)
       onResume?.()
     }, [onResume, startTimer])
     const handlePause = React.useCallback(() => {
-      console.log('pause')
       const elapsedTime = new Date().getTime() - closeTimerStartTimeRef.current
       closeTimerRemainingTimeRef.current =
         closeTimerRemainingTimeRef.current - elapsedTime

--- a/packages/toast/src/ToastImpl.tsx
+++ b/packages/toast/src/ToastImpl.tsx
@@ -153,7 +153,7 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
       onSwipeMove,
       onSwipeCancel,
       onSwipeEnd,
-      viewportName,
+      viewportName = 'default',
       ...toastProps
     } = props
     const isPresent = useIsPresent()
@@ -165,6 +165,11 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
     const closeTimerRemainingTimeRef = React.useRef(duration)
     const closeTimerRef = React.useRef(0)
     const { onToastAdd, onToastRemove } = context
+
+    const viewport = React.useMemo(() => {
+      return context.viewports[viewportName] as HTMLElement | null | undefined
+    }, [context.viewports, viewportName])
+
     const handleClose = useEvent(() => {
       if (!isPresent) {
         // already removed from the react tree
@@ -174,7 +179,7 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
       // count to SR users and ensure focus isn't lost
       if (isWeb) {
         const isFocusInToast = (node as HTMLDivElement)?.contains(document.activeElement)
-        if (isFocusInToast) context.viewport?.focus()
+        if (isFocusInToast) viewport?.focus()
       }
       onClose()
     })
@@ -204,7 +209,7 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
 
     React.useEffect(() => {
       if (!isWeb) return
-      const viewport = context.viewport as HTMLElement
+
       if (viewport) {
         viewport.addEventListener(VIEWPORT_PAUSE, handlePause)
         viewport.addEventListener(VIEWPORT_RESUME, handleResume)
@@ -213,7 +218,7 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
           viewport.removeEventListener(VIEWPORT_RESUME, handleResume)
         }
       }
-    }, [context.viewport, duration, onPause, onResume, startTimer])
+    }, [viewport, duration, onPause, onResume, startTimer])
 
     // start timer when toast opens or duration changes.
     // we include `open` in deps because closed !== unmounted when animating

--- a/packages/toast/src/ToastImpl.tsx
+++ b/packages/toast/src/ToastImpl.tsx
@@ -31,13 +31,9 @@ import { VIEWPORT_PAUSE, VIEWPORT_RESUME } from './ToastViewport'
 const ToastImplFrame = styled(ThemeableStack, {
   name: 'ToastImpl',
   variants: {
-    backgrounded: {
-      true: {
-        backgroundColor: '$color6',
-      },
-    },
     unstyled: {
       false: {
+        backgroundColor: '$color6',
         borderRadius: '$10',
         paddingHorizontal: '$5',
         paddingVertical: '$2',
@@ -45,9 +41,8 @@ const ToastImplFrame = styled(ThemeableStack, {
         marginVertical: '$1',
       },
     },
-  },
+  } as const,
   defaultVariants: {
-    backgrounded: true,
     unstyled: false,
   },
 })

--- a/packages/toast/src/ToastImpl.tsx
+++ b/packages/toast/src/ToastImpl.tsx
@@ -33,6 +33,12 @@ const ToastImplFrame = styled(ThemeableStack, {
   variants: {
     unstyled: {
       false: {
+        focusable: true,
+        focusStyle: {
+          outlineStyle: 'solid',
+          outlineWidth: 1,
+          outlineColor: 'red',
+        },
         backgroundColor: '$color6',
         borderRadius: '$10',
         paddingHorizontal: '$5',
@@ -127,7 +133,7 @@ type ToastImplProps = ToastImplPrivateProps &
      */
     viewportName?: string
     /**
-     * 
+     *
      */
     id?: string
   }
@@ -161,15 +167,15 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
     const { onToastAdd, onToastRemove } = context
     const handleClose = useEvent(() => {
       if (!isPresent) {
-          // already removed from the react tree
-          return
-        }
-        // focus viewport if focus is within toast to read the remaining toast
-        // count to SR users and ensure focus isn't lost
-        if (isWeb) {
-          const isFocusInToast = (node as HTMLDivElement)?.contains(document.activeElement)
-          if (isFocusInToast) context.viewport?.focus()
-        }
+        // already removed from the react tree
+        return
+      }
+      // focus viewport if focus is within toast to read the remaining toast
+      // count to SR users and ensure focus isn't lost
+      if (isWeb) {
+        const isFocusInToast = (node as HTMLDivElement)?.contains(document.activeElement)
+        if (isFocusInToast) context.viewport?.focus()
+      }
       onClose()
     })
 
@@ -183,10 +189,12 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
       [handleClose]
     )
     const handleResume = React.useCallback(() => {
+      console.log('resume')
       startTimer(closeTimerRemainingTimeRef.current)
       onResume?.()
     }, [onResume, startTimer])
     const handlePause = React.useCallback(() => {
+      console.log('pause')
       const elapsedTime = new Date().getTime() - closeTimerStartTimeRef.current
       closeTimerRemainingTimeRef.current =
         closeTimerRemainingTimeRef.current - elapsedTime
@@ -340,7 +348,6 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
                       role="status"
                       aria-live="off"
                       aria-atomic
-                      tabIndex={0}
                       data-state={open ? 'open' : 'closed'}
                       data-swipe-direction={context.swipeDirection}
                       pointerEvents="auto"

--- a/packages/toast/src/ToastProvider.tsx
+++ b/packages/toast/src/ToastProvider.tsx
@@ -106,7 +106,6 @@ const ToastProvider: React.FC<ToastProviderProps> = (
 
   const handleViewportChange = React.useCallback(
     (name: string, viewport: TamaguiElement | null) => {
-      console.log({ name, viewport })
       setViewports((prev) => ({ ...prev, [name]: viewport }))
     },
     []

--- a/packages/toast/src/ToastProvider.tsx
+++ b/packages/toast/src/ToastProvider.tsx
@@ -24,8 +24,8 @@ type ToastProviderContextValue = {
   swipeDirection: SwipeDirection
   swipeThreshold: number
   toastCount: number
-  viewport: TamaguiElement | null
-  onViewportChange(viewport: TamaguiElement): void
+  viewports: Record<string, TamaguiElement | null>
+  onViewportChange(name: string, viewport: TamaguiElement): void
   onToastAdd(): void
   onToastRemove(): void
   isFocusedToastEscapeKeyDownRef: React.MutableRefObject<boolean>
@@ -97,10 +97,20 @@ const ToastProvider: React.FC<ToastProviderProps> = (
     children,
   } = props
   const id = providedId ?? React.useId()
-  const [viewport, setViewport] = React.useState<TamaguiElement | null>(null)
+  const [viewports, setViewports] = React.useState<
+    ToastProviderContextValue['viewports']
+  >({})
   const [toastCount, setToastCount] = React.useState(0)
   const isFocusedToastEscapeKeyDownRef = React.useRef(false)
   const isClosePausedRef = React.useRef(false)
+
+  const handleViewportChange = React.useCallback(
+    (name: string, viewport: TamaguiElement | null) => {
+      console.log({ name, viewport })
+      setViewports((prev) => ({ ...prev, [name]: viewport }))
+    },
+    []
+  )
 
   // memo context to avoid expensive re-renders
   const options = React.useMemo(() => {
@@ -123,8 +133,8 @@ const ToastProvider: React.FC<ToastProviderProps> = (
         swipeDirection={swipeDirection}
         swipeThreshold={swipeThreshold}
         toastCount={toastCount}
-        viewport={viewport}
-        onViewportChange={setViewport}
+        viewports={viewports}
+        onViewportChange={handleViewportChange}
         onToastAdd={React.useCallback(() => {
           setToastCount((prevCount) => prevCount + 1)
         }, [])}

--- a/packages/toast/src/ToastViewport.tsx
+++ b/packages/toast/src/ToastViewport.tsx
@@ -132,8 +132,8 @@ const ToastViewport = React.forwardRef<HTMLDivElement, ToastViewportProps>(
           const isFocusInside = wrapper.contains(document.activeElement)
           if (!isFocusInside) handleResume()
         }
-        // Toasts are not in the viewport React tree so we need to bind DOM events
 
+        // Toasts are not in the viewport React tree so we need to bind DOM events
         wrapper.addEventListener('focusin', handlePause)
         wrapper.addEventListener('focusout', handleFocusOutResume)
         wrapper.addEventListener('pointermove', handlePause)

--- a/packages/toast/src/ToastViewport.tsx
+++ b/packages/toast/src/ToastViewport.tsx
@@ -68,7 +68,7 @@ const ToastViewport = React.forwardRef<HTMLDivElement, ToastViewportProps>(
       __scopeToast,
       hotkey = VIEWPORT_DEFAULT_HOTKEY,
       label = 'Notifications ({hotkey})',
-      name,
+      name = 'default',
       multipleToasts,
       ...viewportProps
     } = props
@@ -78,7 +78,14 @@ const ToastViewport = React.forwardRef<HTMLDivElement, ToastViewportProps>(
     const tailFocusProxyRef = React.useRef<FocusProxyElement>(null)
     const wrapperRef = React.useRef<HTMLDivElement>(null)
     const ref = React.useRef<HTMLDivElement>(null)
-    const composedRefs = useComposedRefs(forwardedRef, ref, context.onViewportChange)
+    const onViewportChange = React.useCallback(
+      (el: TamaguiElement) => {
+        if (context.viewports[name] !== el)
+          context.onViewportChange(name, el)
+      },
+      [name, context.viewports]
+    )
+    const composedRefs = useComposedRefs(forwardedRef, ref, onViewportChange)
     const hotkeyLabel = hotkey.join('+').replace(/Key/g, '').replace(/Digit/g, '')
     const hasToasts = context.toastCount > 0
 

--- a/packages/toast/types/Toast.d.ts
+++ b/packages/toast/types/Toast.d.ts
@@ -4,60 +4,44 @@ import { ToastNativePlatform, ToastNativeValue, useToast, useToastController, us
 import { ToastProps } from './ToastImpl';
 import { ToastProvider, ToastProviderProps, createToastScope } from './ToastProvider';
 import { ToastViewport, ToastViewportProps } from './ToastViewport';
-declare const ToastTitleFrame: import("@tamagui/core").TamaguiComponent<(Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
+declare const ToastTitleFrame: import("@tamagui/core").TamaguiComponent<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-} & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}>>) | (Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}, string | number> & {
-    [x: string]: undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}, string | number> & {
-    [x: string]: undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}, string | number> & {
-    [x: string]: undefined;
-}>>), TamaguiElement, import("@tamagui/core").TextPropsBase, {
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-} | ({
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
+}>>, TamaguiElement, import("@tamagui/core").TextPropsBase, {
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
 } & {
-    [x: string]: undefined;
-}), {
+    readonly unstyled?: boolean | undefined;
+}, {
     displayName: string | undefined;
 }>;
 type PrimitiveDivProps = GetProps<typeof ToastTitleFrame>;
 type ToastTitleProps = PrimitiveDivProps & {};
-declare const ToastDescriptionFrame: import("@tamagui/core").TamaguiComponent<(Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
+declare const ToastDescriptionFrame: import("@tamagui/core").TamaguiComponent<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-} & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}>>) | (Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}, string | number> & {
-    [x: string]: undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}, string | number> & {
-    [x: string]: undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-}, string | number> & {
-    [x: string]: undefined;
-}>>), TamaguiElement, import("@tamagui/core").TextPropsBase, {
-    readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-} | ({
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
+}>>, TamaguiElement, import("@tamagui/core").TextPropsBase, {
     readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
 } & {
-    [x: string]: undefined;
-}), {
+    readonly unstyled?: boolean | undefined;
+}, {
     displayName: string | undefined;
 }>;
 type ToastDescriptionFrameProps = GetProps<typeof ToastDescriptionFrame>;
@@ -190,44 +174,32 @@ declare const ToastCloseFrame: import("@tamagui/core").TamaguiComponent<(Omit<im
 type ToastCloseFrameProps = GetProps<typeof ToastCloseFrame>;
 type ToastCloseProps = ToastCloseFrameProps & {};
 declare const Toast: ((props: Omit<ToastProps & React.RefAttributes<TamaguiElement>, "theme" | "themeInverse"> & import("@tamagui/core").ThemeableProps) => React.ReactElement<any, string | React.JSXElementConstructor<any>> | null) & {
-    Title: React.ForwardRefExoticComponent<((Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
+    Title: React.ForwardRefExoticComponent<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
         readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-        readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-        readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }>>) | Omit<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
-        readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }, string | number> & {
-        [x: string]: undefined;
+    }, "unstyled"> & {
+        readonly unstyled?: boolean | undefined;
     } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
         readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }, string | number> & {
-        [x: string]: undefined;
+    }, "unstyled"> & {
+        readonly unstyled?: boolean | undefined;
     }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
         readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }, string | number> & {
-        [x: string]: undefined;
-    }>>, "ref">) & React.RefAttributes<TamaguiElement>>;
-    Description: React.ForwardRefExoticComponent<((Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
+    }, "unstyled"> & {
+        readonly unstyled?: boolean | undefined;
+    }>> & React.RefAttributes<TamaguiElement>>;
+    Description: React.ForwardRefExoticComponent<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
         readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-        readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{}, "size"> & {
-        readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }>>) | Omit<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
-        readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }, string | number> & {
-        [x: string]: undefined;
+    }, "unstyled"> & {
+        readonly unstyled?: boolean | undefined;
     } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
         readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }, string | number> & {
-        [x: string]: undefined;
+    }, "unstyled"> & {
+        readonly unstyled?: boolean | undefined;
     }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").TextProps, "children" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/core").ExtendsBaseTextProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").TextStylePropsBase>> & Omit<{
         readonly size?: import("@tamagui/core").FontSizeTokens | undefined;
-    }, string | number> & {
-        [x: string]: undefined;
-    }>>, "ref">) & React.RefAttributes<TamaguiElement>>;
+    }, "unstyled"> & {
+        readonly unstyled?: boolean | undefined;
+    }>> & React.RefAttributes<TamaguiElement>>;
     Action: React.ForwardRefExoticComponent<((Omit<import("react-native").ViewProps, "children" | "display" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendBaseStackProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & import("@tamagui/core/types/reactNativeTypes").RNViewProps & Omit<{
         readonly fullscreen?: boolean | undefined;
         readonly elevation?: import("@tamagui/core").SizeTokens | undefined;

--- a/packages/toast/types/ToastImperative.d.ts
+++ b/packages/toast/types/ToastImperative.d.ts
@@ -15,11 +15,15 @@ interface ShowOptions extends CreateNativeToastOptions {
      * Overrides the native option on `ToastImperativeProvider`
      */
     native?: ToastNativeValue;
+    /**
+     * Which viewport to send this toast to. This is only intended to be used with custom toasts and you should wire it up when creating the toast.
+     */
+    viewportName?: string | 'default';
 }
 type ToastData = {
     title: string;
     id: string;
-} & CreateNativeToastOptions & {
+} & ShowOptions & {
     isHandledNatively: boolean;
 };
 interface ToastContextI {

--- a/packages/toast/types/ToastImperative.d.ts
+++ b/packages/toast/types/ToastImperative.d.ts
@@ -9,8 +9,13 @@ interface ToastImperativeOptions extends Omit<CreateNativeToastOptions, 'message
 interface ShowOptions extends CreateNativeToastOptions {
     /**
      * Used when need custom data
+     * @deprecated Use `customData` instead
      */
     additionalInfo?: Record<string, any>;
+    /**
+     * Used when need custom data
+     */
+    customData?: Record<string, any>;
     /**
      * Overrides the native option on `ToastImperativeProvider`
      */

--- a/packages/toast/types/ToastImpl.d.ts
+++ b/packages/toast/types/ToastImpl.d.ts
@@ -17,9 +17,8 @@ declare const ToastImplFrame: import("@tamagui/core").TamaguiComponent<Omit<impo
     readonly bordered?: number | boolean | undefined;
     readonly transparent?: boolean | undefined;
     readonly chromeless?: boolean | "all" | undefined;
-}, "backgrounded" | "unstyled"> & {
-    backgrounded?: boolean | undefined;
-    unstyled?: boolean | undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").ViewProps, "children" | "display" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendBaseStackProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & import("@tamagui/core/types/reactNativeTypes").RNViewProps & Omit<{
     readonly fullscreen?: boolean | undefined;
     readonly elevation?: import("@tamagui/core").SizeTokens | undefined;
@@ -35,9 +34,8 @@ declare const ToastImplFrame: import("@tamagui/core").TamaguiComponent<Omit<impo
     readonly bordered?: number | boolean | undefined;
     readonly transparent?: boolean | undefined;
     readonly chromeless?: boolean | "all" | undefined;
-}, "backgrounded" | "unstyled"> & {
-    backgrounded?: boolean | undefined;
-    unstyled?: boolean | undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").ViewProps, "children" | "display" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendBaseStackProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & import("@tamagui/core/types/reactNativeTypes").RNViewProps & Omit<{
     readonly fullscreen?: boolean | undefined;
     readonly elevation?: import("@tamagui/core").SizeTokens | undefined;
@@ -53,9 +51,8 @@ declare const ToastImplFrame: import("@tamagui/core").TamaguiComponent<Omit<impo
     readonly bordered?: number | boolean | undefined;
     readonly transparent?: boolean | undefined;
     readonly chromeless?: boolean | "all" | undefined;
-}, "backgrounded" | "unstyled"> & {
-    backgrounded?: boolean | undefined;
-    unstyled?: boolean | undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 }>>, TamaguiElement, Omit<import("react-native").ViewProps, "children" | "display" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendBaseStackProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & import("@tamagui/core/types/reactNativeTypes").RNViewProps, {
     readonly fullscreen?: boolean | undefined;
     readonly elevation?: import("@tamagui/core").SizeTokens | undefined;
@@ -72,8 +69,7 @@ declare const ToastImplFrame: import("@tamagui/core").TamaguiComponent<Omit<impo
     readonly transparent?: boolean | undefined;
     readonly chromeless?: boolean | "all" | undefined;
 } & {
-    backgrounded?: boolean | undefined;
-    unstyled?: boolean | undefined;
+    readonly unstyled?: boolean | undefined;
 }, {
     displayName: string | undefined;
 }>;
@@ -180,9 +176,8 @@ declare const ToastImpl: React.ForwardRefExoticComponent<ToastImplPrivateProps &
     readonly bordered?: number | boolean | undefined;
     readonly transparent?: boolean | undefined;
     readonly chromeless?: boolean | "all" | undefined;
-}, "backgrounded" | "unstyled"> & {
-    backgrounded?: boolean | undefined;
-    unstyled?: boolean | undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 } & import("@tamagui/core").MediaProps<Partial<Omit<import("react-native").ViewProps, "children" | "display" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendBaseStackProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & import("@tamagui/core/types/reactNativeTypes").RNViewProps & Omit<{
     readonly fullscreen?: boolean | undefined;
     readonly elevation?: import("@tamagui/core").SizeTokens | undefined;
@@ -198,9 +193,8 @@ declare const ToastImpl: React.ForwardRefExoticComponent<ToastImplPrivateProps &
     readonly bordered?: number | boolean | undefined;
     readonly transparent?: boolean | undefined;
     readonly chromeless?: boolean | "all" | undefined;
-}, "backgrounded" | "unstyled"> & {
-    backgrounded?: boolean | undefined;
-    unstyled?: boolean | undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 }>> & import("@tamagui/core").PseudoProps<Partial<Omit<import("react-native").ViewProps, "children" | "display" | "onLayout" | keyof import("react-native").GestureResponderHandlers> & import("@tamagui/core").ExtendBaseStackProps & import("@tamagui/core").TamaguiComponentPropsBase & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase> & import("@tamagui/core").WithShorthands<import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStylePropsBase>> & import("@tamagui/core/types/reactNativeTypes").RNViewProps & Omit<{
     readonly fullscreen?: boolean | undefined;
     readonly elevation?: import("@tamagui/core").SizeTokens | undefined;
@@ -216,9 +210,8 @@ declare const ToastImpl: React.ForwardRefExoticComponent<ToastImplPrivateProps &
     readonly bordered?: number | boolean | undefined;
     readonly transparent?: boolean | undefined;
     readonly chromeless?: boolean | "all" | undefined;
-}, "backgrounded" | "unstyled"> & {
-    backgrounded?: boolean | undefined;
-    unstyled?: boolean | undefined;
+}, "unstyled"> & {
+    readonly unstyled?: boolean | undefined;
 }>> & {
     /**
      * Control the sensitivity of the toast for accessibility purposes.

--- a/packages/toast/types/ToastProvider.d.ts
+++ b/packages/toast/types/ToastProvider.d.ts
@@ -24,8 +24,8 @@ type ToastProviderContextValue = {
     swipeDirection: SwipeDirection;
     swipeThreshold: number;
     toastCount: number;
-    viewport: TamaguiElement | null;
-    onViewportChange(viewport: TamaguiElement): void;
+    viewports: Record<string, TamaguiElement | null>;
+    onViewportChange(name: string, viewport: TamaguiElement): void;
     onToastAdd(): void;
     onToastRemove(): void;
     isFocusedToastEscapeKeyDownRef: React.MutableRefObject<boolean>;


### PR DESCRIPTION
fixes:
- events and multiple viewports where only the last viewport's events work
- variant types not being correctly inferred
- `additionalInfo` not being typed on `useToastState()`
- ability to pass `viewportName` to `useToastController()` 

also deprecates `additionalInfo` in favor of `customData`