### PR TITLE
fix(next-plugin): allow `experimental` key in NextJS configs to be `unndefined`

### DIFF
--- a/packages/next-plugin/src/withTamagui.ts
+++ b/packages/next-plugin/src/withTamagui.ts
@@ -24,7 +24,7 @@ export type WithTamaguiProps = TamaguiOptions & {
 
 export const withTamagui = (tamaguiOptions: WithTamaguiProps) => {
   return (nextConfig: any = {}) => {
-    const isAppDir = nextConfig.experimental.appDir
+    const isAppDir = nextConfig.experimental?.appDir
     return {
       ...nextConfig,
       webpack: (webpackConfig: any, options: any) => {


### PR DESCRIPTION
fixes #999