### PR TITLE
fix: Allow a config path to be passed without erroring

### DIFF
--- a/packages/static/src/extractor/loadTamagui.ts
+++ b/packages/static/src/extractor/loadTamagui.ts
@@ -142,7 +142,7 @@ export async function getOptions({
     tsconfigPath,
     tamaguiOptions: {
       components: ['tamagui'],
-      config: await getDefaultTamaguiConfigPath(),
+      config: await getDefaultTamaguiConfigPath(tamaguiOptions?.config ? [tamaguiOptions?.config] : undefined),
       ...tamaguiOptions,
     },
     paths: {
@@ -169,9 +169,10 @@ export function resolveWebOrNativeSpecificEntry(entry: string) {
 const defaultPaths = ['tamagui.config.ts', join('src', 'tamagui.config.ts')]
 let cachedPath = ''
 
-async function getDefaultTamaguiConfigPath() {
+async function getDefaultTamaguiConfigPath(addedPaths?: string[]) {
+  const searchPaths = addedPaths ? defaultPaths.concat(addedPaths) : defaultPaths;
   if (cachedPath) return cachedPath
-  const existingPaths = await Promise.all(defaultPaths.map((path) => pathExists(path)))
+  const existingPaths = await Promise.all(searchPaths.map((path) => pathExists(path)))
   const existing = existingPaths.findIndex((x) => !!x)
   const found = defaultPaths[existing]
   if (!found) {


### PR DESCRIPTION
In our monorepo setup there was an error being thrown that others in the Discord seemed to have hit. It may have solved a lot of users cases with some recent fixes, but I think for monorepos or custom config locations it was still broken because `getDefaultTamaguiConfigPath` would get called and error out despite the config being ignored later.

This should fix it but ultimately to come up with a test environment for this small fix would be more effort then the issue itself. Let me know if I should come up with a test somewhere but ultimately this is a fairly small fix.