### PR TITLE
fix: Fix a previous fix for allowing custom config location

### DIFF
--- a/packages/static/src/extractor/loadTamagui.ts
+++ b/packages/static/src/extractor/loadTamagui.ts
@@ -176,7 +176,8 @@ async function getDefaultTamaguiConfigPath(addedPaths?: string[]) {
   if (cachedPath) return cachedPath
   const existingPaths = await Promise.all(searchPaths.map((path) => pathExists(path)))
   const existing = existingPaths.findIndex((x) => !!x)
-  const found = defaultPaths[existing]
+  const found = searchPaths[existing]
+
   if (!found) {
     throw new Error(`No found tamagui.config.ts`)
   }


### PR DESCRIPTION
I tested this one by creating an extra `tamagui.config.ts` in a folder and pointing the `config` field to it.

It was a variable that I just overlooked 🙃 