### PR TITLE
fix(starter): add note on native toast usage and use new hooks

### DIFF
--- a/starters/next-expo-solito/packages/app/features/home/screen.tsx
+++ b/starters/next-expo-solito/packages/app/features/home/screen.tsx
@@ -1,4 +1,5 @@
 import { Anchor, Button, H1, Paragraph, Separator, Sheet, XStack, YStack, useToast } from '@my/ui'
+import { useToastController } from '@my/ui'
 import { ChevronDown, ChevronUp } from '@tamagui/lucide-icons'
 import React, { useState } from 'react'
 import { useLink } from 'solito/link'
@@ -47,7 +48,8 @@ export function HomeScreen() {
 function SheetDemo() {
   const [open, setOpen] = useState(false)
   const [position, setPosition] = useState(0)
-  const toast = useToast()
+  const toast = useToastController()
+
   return (
     <>
       <Button

--- a/starters/next-expo-solito/packages/app/provider/index.tsx
+++ b/starters/next-expo-solito/packages/app/provider/index.tsx
@@ -1,8 +1,9 @@
 import { CustomToast } from '@my/ui'
-import config from '../tamagui.config'
-import { NavigationProvider } from './navigation'
 import { TamaguiProvider, TamaguiProviderProps, ToastProvider, ToastViewport } from '@my/ui'
 import { useColorScheme } from 'react-native'
+
+import config from '../tamagui.config'
+import { NavigationProvider } from './navigation'
 
 export function Provider({ children, ...rest }: Omit<TamaguiProviderProps, 'config'>) {
   const scheme = useColorScheme()
@@ -13,7 +14,16 @@ export function Provider({ children, ...rest }: Omit<TamaguiProviderProps, 'conf
       defaultTheme={scheme === 'dark' ? 'dark' : 'light'}
       {...rest}
     >
-      <ToastProvider swipeDirection="horizontal" native="mobile">
+      <ToastProvider
+        swipeDirection="horizontal"
+        duration={6000}
+        native={
+          [
+            /* uncomment the next line to do native toasts on mobile. NOTE: it'll require you making a dev build and won't work with Expo Go */
+            // 'mobile'
+          ]
+        }
+      >
         <NavigationProvider>{children}</NavigationProvider>
 
         <CustomToast />

--- a/starters/next-expo-solito/packages/ui/src/CustomToast.tsx
+++ b/starters/next-expo-solito/packages/ui/src/CustomToast.tsx
@@ -1,8 +1,8 @@
+import { Toast, useToastState } from '@tamagui/toast'
 import { YStack } from 'tamagui'
-import { Toast, useToast } from '@tamagui/toast'
 
 export const CustomToast = () => {
-  const { currentToast } = useToast()
+  const currentToast = useToastState()
 
   if (!currentToast || currentToast.isHandledNatively) {
     return null
@@ -12,6 +12,7 @@ export const CustomToast = () => {
     <Toast
       key={currentToast.id}
       duration={currentToast.duration}
+      viewportName={currentToast.viewportName}
       enterStyle={{ opacity: 0, scale: 0.5, y: -25 }}
       exitStyle={{ opacity: 0, scale: 1, y: -20 }}
       y={0}


### PR DESCRIPTION
Should help with the confusion around usage of native toasts and Expo Go. e.g. #1022 