### PR TITLE
add the remove type module step

### DIFF
--- a/apps/site/data/docs/guides/vite.mdx
+++ b/apps/site/data/docs/guides/vite.mdx
@@ -9,7 +9,9 @@ For a full-featured example, you can reference [the experimental tamagui.dev sit
 
 ### Installation
 
-Add `@tamagui/vite-plugin` and update your `vite.config.ts`:
+1. Remove `"type": "module"` from your `package.json` if you have it. (The type module support was removed beacause it was breaking metro, webpack or something).
+2. Add `@tamagui/vite-plugin` 
+3. And update your `vite.config.ts`:
 
 ```tsx
 import { tamaguiExtractPlugin, tamaguiPlugin } from '@tamagui/vite-plugin'


### PR DESCRIPTION
The support for type module was removed because it was breaking things as discussed here: https://discordapp.com/channels/909986013848412191/1088725438001590282/1100863190579036211

So to get a successfull instalation of the vite plugin the developers must delete that config in their package.json.