### PR TITLE
remove .js extension form ToastImperative import in Toast.tsx

### DIFF
--- a/packages/toast/src/Toast.tsx
+++ b/packages/toast/src/Toast.tsx
@@ -21,7 +21,7 @@ import {
   useToast,
   useToastController,
   useToastState,
-} from './ToastImperative.js'
+} from './ToastImperative'
 import {
   ToastImpl,
   ToastImplFrame,


### PR DESCRIPTION
Is "ToastImperative" import with .js is explicit for a reason? if not it broke my mono repo setup on web for some reason toast controller was returning empty object.