### PR TITLE
Updates outdated link in docs

### DIFF
--- a/apps/site/data/docs/guides/create-tamagui-app.mdx
+++ b/apps/site/data/docs/guides/create-tamagui-app.mdx
@@ -27,7 +27,7 @@ Currently, we have one template available:
 npm create tamagui
 ```
 
-Check out [the source of the templates](https://github.com/tamagui/starters).
+Check out [the source of the templates](https://github.com/tamagui/tamagui/tree/master/starters).
 
 A big shout out to [Fernando Rojo](https://twitter.com/fernandotherojo) for creating [Solito](https://solito.dev), a great library for sharing all your views between Expo and Next.js, and the bootstrap repo we borrowed from.
 


### PR DESCRIPTION
The previous doc link directs to an archived and outdated repo. This change simply updates that to the up-to-date repo link.