### PR TITLE
fix(text): `Text` and `SizableText` not getting correct color on native

### DIFF
--- a/packages/web/src/views/Text.tsx
+++ b/packages/web/src/views/Text.tsx
@@ -17,6 +17,7 @@ export const Text = createComponent<TextProps, React.Component<TextProps>, TextP
     isText: true,
 
     defaultProps: {
+      color: '$color',
       // @ts-ignore
       display: 'flex',
       fontFamily: 'System',


### PR DESCRIPTION
Possibly related https://github.com/tamagui/tamagui/issues/1088#issuecomment-1529808972