### PR TITLE
(fix) EAS update / build / expo go compatibility in solito starter

### DIFF
--- a/starters/next-expo-solito/apps/expo/app.json
+++ b/starters/next-expo-solito/apps/expo/app.json
@@ -1,8 +1,8 @@
 {
   "expo": {
-    "name": "myapp",
-    "slug": "myapp",
-    "scheme": "myapp",
+    "name": "[yourprojectsname]",
+    "slug": "[yourprojectsname]",
+    "scheme": "[yourprojectsname]",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -18,22 +18,24 @@
     "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.tamagui.myapp"
+      "bundleIdentifier": "com.[yourprojectsname].app"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#FFFFFF"
       },
-      "package": "com.tamagui.myapp"
+      "package": "com.[yourprojectsname].app"
     },
     "web": {
-      "favicon": "./assets/favicon.png",
-      "bundler": "metro"
+      "favicon": "./assets/favicon.png"
+    },
+    "runtimeVersion": {
+      "policy": "sdkVersion"
     },
     "extra": {
       "eas": {
-        "projectId": "061b4470-78c7-4d6a-b850-8167fb0a3434"
+        "projectId": "[your_project_id]"
       }
     }
   }

--- a/starters/next-expo-solito/apps/expo/package.json
+++ b/starters/next-expo-solito/apps/expo/package.json
@@ -21,7 +21,6 @@
     "expo-constants": "^14.2.1",
     "expo-dev-client": "^2.1.5",
     "expo-font": "^11.1.1",
-    "expo-image": "^1.0.0",
     "expo-linear-gradient": "^12.1.2",
     "expo-linking": "^4.0.1",
     "expo-router": "^1.4.3",

--- a/starters/next-expo-solito/packages/ui/src/CustomToast.tsx
+++ b/starters/next-expo-solito/packages/ui/src/CustomToast.tsx
@@ -1,29 +1,12 @@
-import { Toast, useToastState } from '@tamagui/toast'
-import { YStack } from 'tamagui'
+import Constants, { ExecutionEnvironment } from 'expo-constants'
+import { NativeToast as Toast } from './NativeToast'
+
+const isExpo = Constants.executionEnvironment === ExecutionEnvironment.StoreClient
 
 export const CustomToast = () => {
-  const currentToast = useToastState()
-
-  if (!currentToast || currentToast.isHandledNatively) {
+  if (isExpo) {
     return null
+  } else {
+    return <Toast />
   }
-
-  return (
-    <Toast
-      key={currentToast.id}
-      duration={currentToast.duration}
-      viewportName={currentToast.viewportName}
-      enterStyle={{ opacity: 0, scale: 0.5, y: -25 }}
-      exitStyle={{ opacity: 0, scale: 1, y: -20 }}
-      y={0}
-      opacity={1}
-      scale={1}
-      animation="quick"
-    >
-      <YStack>
-        <Toast.Title>{currentToast.title}</Toast.Title>
-        {!!currentToast.message && <Toast.Description>{currentToast.message}</Toast.Description>}
-      </YStack>
-    </Toast>
-  )
 }

--- a/starters/next-expo-solito/packages/ui/src/NativeToast.tsx
+++ b/starters/next-expo-solito/packages/ui/src/NativeToast.tsx
@@ -1,0 +1,29 @@
+import { Toast, useToastState } from '@tamagui/toast'
+import { YStack } from 'tamagui'
+
+export const NativeToast = () => {
+  const currentToast = useToastState()
+
+  if (!currentToast || currentToast.isHandledNatively) {
+    return null
+  }
+
+  return (
+    <Toast
+      key={currentToast.id}
+      duration={currentToast.duration}
+      viewportName={currentToast.viewportName}
+      enterStyle={{ opacity: 0, scale: 0.5, y: -25 }}
+      exitStyle={{ opacity: 0, scale: 1, y: -20 }}
+      y={0}
+      opacity={1}
+      scale={1}
+      animation="quick"
+    >
+      <YStack>
+        <Toast.Title>{currentToast.title}</Toast.Title>
+        {!!currentToast.message && <Toast.Description>{currentToast.message}</Toast.Description>}
+      </YStack>
+    </Toast>
+  )
+}

--- a/starters/next-expo-solito/yarn.lock
+++ b/starters/next-expo-solito/yarn.lock
@@ -9434,7 +9434,6 @@ __metadata:
     expo-constants: ^14.2.1
     expo-dev-client: ^2.1.5
     expo-font: ^11.1.1
-    expo-image: ^1.0.0
     expo-linear-gradient: ^12.1.2
     expo-linking: ^4.0.1
     expo-router: ^1.4.3
@@ -9580,15 +9579,6 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 01648dad7384b04c8eaee22c4b86653cc31230e5f3523bf2082924ccc659f61b031900c55f1f08befaaf1bd1616eecb05ae9767eb111ed9151dd619374581930
-  languageName: node
-  linkType: hard
-
-"expo-image@npm:^1.0.0":
-  version: 1.2.1
-  resolution: "expo-image@npm:1.2.1"
-  peerDependencies:
-    expo: "*"
-  checksum: 8faa095e536836bab80fdc84b3f0950df7bc9df6a4016acc3d50c323f071de279765169f17e383b36b4e654534f761821be4323da05daf7c3ed5abc5fe826b9c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The current next-solito-starter fails in multiple places when creating an update with the expo eas service to view and share your tamagui project in the expo go app.

A couple of things I need to do to get the starter to work on expo go.
- remove expo-image: only works in development builds and sdk47. The starter doesn't use the package anywhere. (https://github.com/expo/expo/tree/main/packages/expo-image#installation)
- update eas with a runtime https://docs.expo.dev/eas-update/runtime-versions/#setting-runtimeversion
- Conditionally add toasts if not in expo go. Expo Go doesn't support native modules. IMO not having toasts in expo go outweigh the cost of not being able to use the starter in expo go.
- updated the app.json my app to `yourprojectname` to be a little bit more on the nose to the developer using the project to change the value.


Reproduce:
- `npm create tamagui` with changes
- add project_id
- `eas update --profile development`
- scan code from the console, open expo go to view starter app.

also fixes:
- fix: #1143 
- fix: (sorta?) #846 https://github.com/nandorojo/solito/blob/18b283a0dbdfdc78f9115a460e4bfbf9b3d57c33/src/image/use-solito-image.ts#L28 depends on `expo-image` which doesn't work with expo-sdk 48
