### PR TITLE
starter: update starter commands

### DIFF
--- a/starters/next-expo-solito/apps/expo/package.json
+++ b/starters/next-expo-solito/apps/expo/package.json
@@ -4,10 +4,10 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "start": "TAMAGUI_TARGET=native expo start -c",
-    "android": "TAMAGUI_TARGET=native yarn expo run:android",
-    "ios": "TAMAGUI_TARGET=native yarn expo run:ios",
-    "eject": "expo eject"
+    "start": "TAMAGUI_TARGET=native npx expo start -c",
+    "android": "TAMAGUI_TARGET=native npx expo run:android",
+    "ios": "TAMAGUI_TARGET=native npx expo run:ios",
+    "eject": "npx expo eject"
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",


### PR DESCRIPTION
expo documentation uses `npx expo` commands. 

https://docs.expo.dev/get-started/expo-go/

currently a developer could use a legacy version, and possibly cause issues building the app.
