### PR TITLE
feat(create-tamagui): add initial commit when using git

### DIFF
--- a/packages/create-tamagui/src/index.ts
+++ b/packages/create-tamagui/src/index.ts
@@ -317,6 +317,18 @@ ${chalk.bold(chalk.red(`Please pick a different project name 🥸`))}`
     process.exit(1)
   }
 
+  if (shouldGitInit) {
+    try {
+      execSync('git checkout -b main', { stdio: 'ignore' })
+      execSync('git add -A', { stdio: 'ignore' })
+      execSync('git commit -m "Initial commit from create-tamagui"', {
+        stdio: 'ignore',
+      })
+    } catch (e: any) {
+      console.error('[tamagui] Failed to create initial commit.\n\n', e.message)
+    }
+  }
+
   console.log(`${chalk.green('Success!')} Created ${projectName} at ${projectPath}`)
   console.log('Inside that directory, you can run several commands:')
   console.log()


### PR DESCRIPTION
Small QoL improvement [inspired by](https://github.com/vercel/next.js/blob/canary/packages/create-next-app/helpers/git.ts#L33) create-next-app, this change adds an initial commit when initializing the starter so the user doesn't end up with a bunch of untracked files when opening the code.

Tested with running `yarn test` in the `create-tamagui` package.