### PR TITLE
fix(docs): resolve typo

### DIFF
--- a/apps/site/data/docs/core/configuration.mdx
+++ b/apps/site/data/docs/core/configuration.mdx
@@ -167,7 +167,7 @@ const config = createTamagui({
   // optional:
 
   // add custom shorthand props
-  // note: as const in important, without it you may see breaking types
+  // note: as const is important, without it you may see breaking types
   shorthands: {
     px: 'paddingHorizontal',
     f: 'flex',


### PR DESCRIPTION
Resolve typo in [configuration](https://tamagui.dev/docs/core/configuration) docs

<img width="745" alt="Screenshot 2023-05-20 at 23 27 08" src="https://github.com/tamagui/tamagui/assets/2429708/c3a085a8-fc65-4b30-957a-a3428c0dc14d">
