### PR TITLE
(fix)starter: expo on initial load

### DIFF
--- a/starters/next-expo-solito/apps/expo/app.json
+++ b/starters/next-expo-solito/apps/expo/app.json
@@ -30,9 +30,6 @@
     "web": {
       "favicon": "./assets/favicon.png"
     },
-    "runtimeVersion": {
-      "policy": "sdkVersion"
-    },
     "extra": {
       "eas": {
         "projectId": "[your_project_id]"


### PR DESCRIPTION
https://stackoverflow.com/questions/71888858/no-launchable-updates-found-in-database-expo-go


Need to omit the runtime for the expo go app to load on `yarn native`

repro:
- `npm create tamagui`
- `yarn`
- `yarn native`
- choose ios

default starter should load


