### PR TITLE
overrided TamaguiCustomConfig interface for typed access to properties

### DIFF
--- a/starters/simple-web/src/tamagui.config.ts
+++ b/starters/simple-web/src/tamagui.config.ts
@@ -75,7 +75,7 @@ const fonts = {
   }),
 }
 
-export default createTamagui({
+const config = createTamagui({
   animations,
   shouldAddPrefersColorThemes: true,
   themeClassNameOnRoot: true,
@@ -100,3 +100,13 @@ export default createTamagui({
     pointerCoarse: { pointer: 'coarse' },
   },
 })
+
+type AppConfig = typeof config;
+
+declare module "tamagui" {
+  // overrides TamaguiCustomConfig so that custom types
+  // work everywhere `tamagui` is imported
+  interface TamaguiCustomConfig extends AppConfig {}
+}
+
+export default config;


### PR DESCRIPTION
Before:

![image](https://github.com/tamagui/tamagui/assets/93455330/8976d557-f9eb-4833-a379-c962298d5013)

After:

![image](https://github.com/tamagui/tamagui/assets/93455330/dfd986e9-3d2a-4383-92ef-e7baea9a9def)
