### PR TITLE
docs: missing api + consistency across pages

### DIFF
--- a/apps/site/data/docs/components/alert-dialog/1.0.0.mdx
+++ b/apps/site/data/docs/components/alert-dialog/1.0.0.mdx
@@ -27,10 +27,10 @@ demoName: AlertDialog
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { AlertDialog } from 'tamagui' // or from '@tamagui/alert-dialog'
+import { AlertDialog } from 'tamagui' // or '@tamagui/alert-dialog'
 
 export default () => (
   <AlertDialog>
@@ -48,9 +48,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### &lt;AlertDialog /&gt;
+### AlertDialog
 
 Contains every component for the AlertDialog. Shares all [Dialog Props](/docs/components/dialog#api), except modal which is on by default. Adds:
 
@@ -65,11 +65,11 @@ Contains every component for the AlertDialog. Shares all [Dialog Props](/docs/co
   ]}
 />
 
-#### &lt;Trigger /&gt;
+### AlertDialog.Trigger
 
 Just [Tamagui Props](/docs/intro/props).
 
-#### &lt;Portal /&gt;
+### AlertDialog.Portal
 
 Renders AlertDialog into appropriate container. Beyond [Tamagui Props](/docs/intro/props), adds:
 
@@ -84,7 +84,7 @@ Renders AlertDialog into appropriate container. Beyond [Tamagui Props](/docs/int
   ]}
 />
 
-#### &lt;Content /&gt;
+### AlertDialog.Content
 
 Main container for AlertDialog content, this is where you should apply animations.
 
@@ -101,7 +101,7 @@ Beyond [Tamagui Props](/docs/intro/props), adds:
   ]}
 />
 
-#### &lt;Overlay /&gt;
+### AlertDialog.Overlay
 
 Displays behind Content. Beyond [Tamagui Props](/docs/intro/props), adds:
 
@@ -116,19 +116,19 @@ Displays behind Content. Beyond [Tamagui Props](/docs/intro/props), adds:
   ]}
 />
 
-#### &lt;Title /&gt;
+### AlertDialog.Title
 
 Required. Can wrap in VisuallyHidden to hide.
 
 Defaults to H2, see [Headings](/docs/components/headings).
 
-#### &lt;Description /&gt;
+### AlertDialog.Description
 
 Required. Can wrap in VisuallyHidden to hide.
 
 Defaults to Paragraph, see [Paragraph](/docs/components/text).
 
-#### &lt;Cancel /&gt;
+### AlertDialog.Cancel
 
 Closes the AlertDialog, accepts all YStack props. Recommended to use with your own component and `asChild`.
 

--- a/apps/site/data/docs/components/anchor/1.0.0.mdx
+++ b/apps/site/data/docs/components/anchor/1.0.0.mdx
@@ -13,15 +13,17 @@ component: Anchor
   features={['Supports SSR.', 'Works on native and web.', 'Accepts Tamagui style props.']}
 />
 
-### Usage
+## Usage
 
 The Anchor component provides a way to link to external websites. It extends [SizableText](/docs/components/text#sizable-text), adding the `href`, `target`, and `rel` attributes.
 
 On native, it will use React Native `Linking.openURL`, on web it will render to an `a` element with `href` set appropriately.
 
-### Props
+## API Reference
 
-[Tamagui props](/docs/intro/props) as well as:
+## Anchor
+
+Inherits [Tamagui props](/docs/intro/props) as well as:
 
 <PropsTable
   data={[

--- a/apps/site/data/docs/components/avatar/1.0.0.mdx
+++ b/apps/site/data/docs/components/avatar/1.0.0.mdx
@@ -27,7 +27,7 @@ demoName: Avatar
   ]}
 />
 
-### Usage
+## Usage
 
 ```tsx
 import { Avatar } from 'tamagui'
@@ -40,13 +40,13 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### &lt;Avatar /&gt;
+### Avatar
 
 Avatar extends [Square](/docs/components/shapes#shape-props), giving it all the [Tamagui standard props](/docs/intro/props) as well as `size` and `circular`.
 
-#### &lt;Avatar.Fallback /&gt;
+### Avatar.Fallback
 
 Avatar.Fallback extends [YStack](/docs/components/stacks), plus:
 
@@ -61,6 +61,6 @@ Avatar.Fallback extends [YStack](/docs/components/stacks), plus:
   ]}
 />
 
-#### &lt;Avatar.Image /&gt;
+### Avatar.Image
 
 Avatar.Fallback extends [Image](/docs/components/image).

--- a/apps/site/data/docs/components/button/1.28.0.mdx
+++ b/apps/site/data/docs/components/button/1.28.0.mdx
@@ -27,7 +27,7 @@ demoName: Button
   ]}
 />
 
-### Usage
+## Usage
 
 When using the simple Button API, it's as simple as this:
 
@@ -37,7 +37,7 @@ import { Button } from 'tamagui'
 export default () => <Button>Lorem ipsum</Button>
 ```
 
-### Sizing
+## Sizing
 
 Sizing buttons provides a unique challenge especially for a compiler, because you need to adjust many different properties - not just on the outer frame, but on the text wrapped inside. Tamagui supports adjusting the padding, border radius, font size and icons sizes all in one with the `size` prop.
 
@@ -49,13 +49,13 @@ export default () => <Button size="$6">Lorem ipsum</Button>
 
 Given your theme defines a size `6`, the button will adjust all of the properties appropriately. You can also pass a plain number to get an arbitrary size.
 
-### Icon Theming
+## Icon Theming
 
 You can pass icons as either elements or components. If passing components, Tamagui will automatically pass the `size` and `color` prop to them based on your theme.
 
 You can [use the source of Button itself](https://github.com/tamagui/tamagui/blob/master/packages/button/src/Button.tsx) to see in more detail what variants you can override, and how we use this pattern internally to create our Button component.
 
-### Creating your own Button
+## Creating your own Button
 
 Tamagui now has all the features necessary to make creating a custom Button easy enough that you don't really need to use our Button at all as a base.
 
@@ -67,7 +67,9 @@ Learn how to do it with our dedicated guide, [How to Build a Button](/docs/guide
   the guide.
 </Notice>
 
-### Button props
+## API Reference
+
+### Button
 
 Buttons extend Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
 

--- a/apps/site/data/docs/components/card/1.0.0.mdx
+++ b/apps/site/data/docs/components/card/1.0.0.mdx
@@ -27,10 +27,10 @@ demoName: Card
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { Card } from 'tamagui' // or from '@tamagui/card'
+import { Card } from 'tamagui' // or '@tamagui/card'
 
 export default () => (
   <Card>
@@ -42,9 +42,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### Card
+### Card
 
 Frame of the card, extends [ThemeableStack props](/docs/components/stacks#themeablestack), adding:
 
@@ -65,7 +65,7 @@ Frame of the card, extends [ThemeableStack props](/docs/components/stacks#themea
   ]}
 />
 
-#### Card.Header
+### Card.Header
 
 Extends [ThemeableStack](/docs/components/stacks#themeablestack), adding:
 
@@ -80,7 +80,7 @@ Extends [ThemeableStack](/docs/components/stacks#themeablestack), adding:
   ]}
 />
 
-#### Card.Footer
+### Card.Footer
 
 Extends [ThemeableStack](/docs/components/stacks#themeablestack), adding:
 
@@ -95,7 +95,7 @@ Extends [ThemeableStack](/docs/components/stacks#themeablestack), adding:
   ]}
 />
 
-#### Card.Background
+### Card.Background
 
 Extends [YStack](/docs/components/stacks), set to `fullscreen` and zIndex below Header/Footer.
 

--- a/apps/site/data/docs/components/checkbox/1.3.0.mdx
+++ b/apps/site/data/docs/components/checkbox/1.3.0.mdx
@@ -28,7 +28,7 @@ demoName: Checkbox
   ]}
 />
 
-### Usage
+## Usage
 
 ```tsx
 import { Check } from '@tamagui/lucide-icons'
@@ -43,11 +43,11 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### Checkbox
+### Checkbox
 
-`Checkbox` extend Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
+`Checkbox` extend ThemeableStack inheriting all the [props](/docs/components/stacks#themeablestack), plus:
 
 <PropsTable
   data={[
@@ -112,6 +112,27 @@ export default () => (
       required: false,
       type: `boolean`,
       description: `Removes all default Tamagui styles.`,
+    },
+  ]}
+/>
+
+### Checkbox.Indicator
+
+`Checkbox.Indicator` extend ThemeableStack inheriting all the [props](/docs/components/stacks#themeablestack), plus:
+
+<PropsTable
+  data={[
+    {
+      name: 'forceMount',
+      required: false,
+      type: `boolean`,
+      description: `Used to force mounting when more control is needed.`,
+    },
+    {
+      name: 'disablePassStyles',
+      required: false,
+      type: 'boolean',
+      description: `Used to disable passing styles down to children.`,
     },
   ]}
 />

--- a/apps/site/data/docs/components/dialog/1.0.0.mdx
+++ b/apps/site/data/docs/components/dialog/1.0.0.mdx
@@ -27,10 +27,10 @@ demoName: Dialog
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { Dialog } from 'tamagui' // or from '@tamagui/dialog'
+import { Dialog } from 'tamagui' // or '@tamagui/dialog'
 
 export default () => (
   <Dialog>
@@ -48,9 +48,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### &lt;Dialog /&gt;
+### Dialog
 
 Contains every component for the dialog. Beyond [Tamagui Props](/docs/intro/props), adds:
 
@@ -95,11 +95,11 @@ Contains every component for the dialog. Beyond [Tamagui Props](/docs/intro/prop
   ]}
 />
 
-#### &lt;Trigger /&gt;
+### Dialog.Trigger
 
 Just [Tamagui Props](/docs/intro/props).
 
-#### &lt;Portal /&gt;
+### Dialog.Portal
 
 Renders Dialog into appropriate container. Beyond [Tamagui Props](/docs/intro/props), adds:
 
@@ -120,7 +120,7 @@ Renders Dialog into appropriate container. Beyond [Tamagui Props](/docs/intro/pr
   ]}
 />
 
-#### &lt;Content /&gt;
+### Dialog.Content
 
 Main container for Dialog content, this is where you should apply animations.
 
@@ -143,7 +143,7 @@ Beyond [Tamagui Props](/docs/intro/props), adds:
   ]}
 />
 
-#### &lt;Overlay /&gt;
+### Dialog.Overlay
 
 Displays behind Content. Beyond [Tamagui Props](/docs/intro/props), adds:
 
@@ -158,19 +158,19 @@ Displays behind Content. Beyond [Tamagui Props](/docs/intro/props), adds:
   ]}
 />
 
-#### &lt;Title /&gt;
+### Dialog.Title
 
 Required. Can wrap in VisuallyHidden to hide.
 
 Defaults to H2, see [Headings](/docs/components/headings).
 
-#### &lt;Description /&gt;
+### Dialog.Description
 
 Required. Can wrap in VisuallyHidden to hide.
 
 Defaults to Paragraph, see [Paragraph](/docs/components/text).
 
-#### &lt;Close /&gt;
+### Dialog.Close
 
 Closes the Dialog, accepts the same props as YStack. Recommended to use with your own component and `asChild`.
 
@@ -186,7 +186,7 @@ Closes the Dialog, accepts the same props as YStack. Recommended to use with you
 
 Just [Tamagui Props](/docs/intro/props).
 
-#### &lt;Sheet /&gt;
+### Dialog.Sheet
 
 When used with `Adapt`, Dialog will render as a sheet when that breakpoint is active.
 
@@ -195,7 +195,7 @@ See [Sheet](/docs/components/sheet) for more props.
 Must use `Adapt.Contents` inside the `Dialog.Sheet.Frame` to insert the contents given to `Dialog.Content`
 
 ```tsx
-import { Dialog } from 'tamagui' // or from '@tamagui/dialog'
+import { Dialog } from 'tamagui' // or '@tamagui/dialog'
 
 export default () => (
   <Dialog>

--- a/apps/site/data/docs/components/form/1.3.0.mdx
+++ b/apps/site/data/docs/components/form/1.3.0.mdx
@@ -30,10 +30,10 @@ demoName: Form
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { Form } from 'tamagui' // or from '@tamagui/form'
+import { Form } from 'tamagui' // or '@tamagui/form'
 
 export default () => (
   <Form>
@@ -45,9 +45,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### &lt;Form /&gt;
+### Form
 
 <PropsTable
   data={[
@@ -60,7 +60,7 @@ export default () => (
   ]}
 />
 
-#### &lt;Trigger /&gt;
+### Form.Trigger
 
 Wrap this around your submitting element to make the form submit. We recommend using `asChild` to a child element of your choosing for more control.
 

--- a/apps/site/data/docs/components/group/1.11.2.mdx
+++ b/apps/site/data/docs/components/group/1.11.2.mdx
@@ -99,7 +99,7 @@ The `disabled` property will pass to children
   <GroupDisabledDemo />
 </HeroContainer>
 
-## Group API
+## API Reference
 
 ### Group
 

--- a/apps/site/data/docs/components/headings/1.0.0.mdx
+++ b/apps/site/data/docs/components/headings/1.0.0.mdx
@@ -26,11 +26,29 @@ demoName: Headings
   ]}
 />
 
+## Usage
+
+```tsx
+import { H1, H2, H3, H4, H5, H6, Heading } from 'tamagui'
+
+export default () => (
+  <>
+    <H1>Heading 1</H1>
+    <H2>Heading 2</H2>
+    <H3>Heading 3</H3>
+    <H4>Heading 4</H4>
+    <H5>Heading 5</H5>
+    <H6>Heading 6</H6>
+    <Heading>Heading</Heading>
+  </>
+)
+```
+
 The headings all extend from the base `Heading` component. Note, this is just our own theme for Inter headings, but you can customize the styles yourself for any font completely.
 
 Tamagui expects for your [font.size](/docs/core/configuration#font-tokens) to have the keys 1-10 so headings work with your font tokens automatically.
 
-### How it works
+## How it works
 
 The `Heading` component is defined as follows:
 
@@ -89,6 +107,8 @@ const SizableText = styled(Text, {
 })
 ```
 
-### Heading props
+## API Reference
+
+### Heading
 
 Headings extend [SizableText props](/docs/components/text#sizabletext) inheriting all the [Tamagui standard props](/docs/intro/props).

--- a/apps/site/data/docs/components/html-elements/1.0.0.mdx
+++ b/apps/site/data/docs/components/html-elements/1.0.0.mdx
@@ -21,6 +21,6 @@ To assist in creating accessible web apps, the following components are exported
 
 On native, these elements will render the same.
 
-### HTML element props
+## HTML element props
 
 All HTML components extend YStack, inheriting all the [Tamagui standard props](/docs/intro/props).

--- a/apps/site/data/docs/components/image/1.13.0.mdx
+++ b/apps/site/data/docs/components/image/1.13.0.mdx
@@ -23,7 +23,7 @@ demoName: Image
   features={['Supports SSR.', 'Works on native and web.', 'Accepts Tamagui style props.']}
 />
 
-### Usage
+## Usage
 
 Note that you need to set `source` like so - the `width` and `height` properties apply as styles around the image, but the actual image needs `source.width` and `source.height` for React Native:
 
@@ -37,6 +37,8 @@ export default () => (
 )
 ```
 
-### Props
+## API Reference
+
+### Image
 
 [Tamagui props](/docs/intro/props) + [React Native Web Image props](https://necolas.github.io/react-native-web/docs/image/).

--- a/apps/site/data/docs/components/inputs/1.0.0.mdx
+++ b/apps/site/data/docs/components/inputs/1.0.0.mdx
@@ -17,7 +17,7 @@ demoName: Inputs
 
 Using the same base component [TextInput](https://necolas.github.io/react-native-web/docs/text-input/), from react-native-web, Tamagui simply wraps these components to allow the full set of style props, as well as scaling all the styles up or down using the `size` property, much like Button.
 
-### Input
+## Input
 
 A one-line input field:
 
@@ -30,7 +30,7 @@ export const App = () => (
 )
 ```
 
-### TextArea
+## TextArea
 
 For multi-line inputs:
 

--- a/apps/site/data/docs/components/label/1.0.0.mdx
+++ b/apps/site/data/docs/components/label/1.0.0.mdx
@@ -27,7 +27,7 @@ demoName: Label
   ]}
 />
 
-### Usage
+## Usage
 
 ```tsx
 import { Label } from 'tamagui'
@@ -40,11 +40,13 @@ export default () => (
 )
 ```
 
-### Accessibility
+## Accessibility
 
 Use with Input or other form elements to automatically get correct labelling by id and aria-labelledby. You can also use the provided `useLabelContext` hook to build your own controls.
 
-### Label props
+## API Reference
+
+### Label
 
 Labels extend Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
 

--- a/apps/site/data/docs/components/linear-gradient/1.0.0.mdx
+++ b/apps/site/data/docs/components/linear-gradient/1.0.0.mdx
@@ -26,11 +26,11 @@ demoName: LinearGradient
   ]}
 />
 
-### Installation
+## Installation
 
 To use this package you'll need to add `expo-linear-gradient` to your app. This works [with vanilla React Native](https://github.com/expo/expo/tree/sdk-47/packages/expo-linear-gradient) or Expo.
 
-### Usage
+## Usage
 
 Because LinearGradient requires a more complex to install native package, we've left it out of the `tamagui` export until Metro supports async import. Import it either separately or using the path `/linear-gradient`:
 
@@ -41,7 +41,9 @@ import { LinearGradient } from 'tamagui/linear-gradient'
 
 LinearGradient is a YStack that accepts all Tamagui style props as well as theme colors, that places `expo-linear-gradient` inside it set to absoluteFill.
 
-### LinearGradient props
+## API Reference
+
+### LinearGradient
 
 See the [expo docs](https://docs.expo.dev/versions/latest/sdk/linear-gradient/) for more complete information.
 

--- a/apps/site/data/docs/components/list-item/1.0.0.mdx
+++ b/apps/site/data/docs/components/list-item/1.0.0.mdx
@@ -27,7 +27,7 @@ demoName: ListItem
   ]}
 />
 
-### Usage
+## Usage
 
 ```tsx
 import { ListItem } from 'tamagui'
@@ -35,7 +35,7 @@ import { ListItem } from 'tamagui'
 export default () => <ListItem>Lorem ipsum</ListItem>
 ```
 
-### Sizing
+## Sizing
 
 Sizing listItems provides a unique challenge especially for a compiler, because you need to adjust many different properties - not just on the outer frame, but on the text wrapped inside. Tamagui supports adjusting the padding, border radius, font size and icons sizes all in one with the `size` prop.
 
@@ -47,11 +47,11 @@ export default () => <ListItem size="$6">Lorem ipsum</ListItem>
 
 Given your theme defines a size `6`, the listItem will adjust all of the properties appropriately. You can also pass a plain number to get an arbitrary size.
 
-### Icon Theming
+## Icon Theming
 
 You can pass icons as either elements or components. If passing components, Tamagui will automatically pass the `size` and `color` prop to them based on your theme.
 
-### Customization
+## Customization
 
 ListItem only supports a limited subset of text props directly, and doesn't accept `hoverStyle` text props. If you need more control, you can do a simple customization:
 
@@ -114,7 +114,9 @@ export const ListItem = themeable(
 )
 ```
 
-### ListItem props
+## API Reference
+
+### ListItem
 
 ListItems extend Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
 
@@ -218,3 +220,15 @@ ListItems extend Stack views inheriting all the [Tamagui standard props](/docs/i
     },
   ]}
 />
+
+{/* ### ListItem.Title
+
+`ListItem.Title` extend `SizableText` inheriting all the [props](/docs/components/text#sizabletext).
+
+### ListItem.Subtitle
+
+`ListItem.Subtitle` extend `SizableText` inheriting all the [props](/docs/components/text#sizabletext).
+
+### ListItem.Text
+
+`ListItem.Text` extend `SizableText` inheriting all the [props](/docs/components/text#sizabletext). */}

--- a/apps/site/data/docs/components/lucide-icons/1.0.0.mdx
+++ b/apps/site/data/docs/components/lucide-icons/1.0.0.mdx
@@ -12,7 +12,7 @@ demoName: LucideIcons
   <LucideIconsDemo />
 </HeroContainer>
 
-### Usage
+## Usage
 
 Add `@tamagui/lucide-icons` to your package.json and import them directly for use as React elements:
 
@@ -35,6 +35,6 @@ export default () => (
 )
 ```
 
-### Credit
+## Credit
 
 The great [Lucide Icons](https://lucide.dev/), a superset of the wonderful [Feather Icons](https://feathericons.com/).

--- a/apps/site/data/docs/components/popover/1.0.0.mdx
+++ b/apps/site/data/docs/components/popover/1.0.0.mdx
@@ -27,10 +27,10 @@ demoName: Popover
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { Popover } from 'tamagui' // or @tamagui/popover
+import { Popover } from 'tamagui' // or '@tamagui/popover'
 
 export default () => (
   <Popover>
@@ -59,9 +59,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### Popover
+### Popover
 
 Contains every component for the popover.
 
@@ -129,23 +129,23 @@ Contains every component for the popover.
   ]}
 />
 
-#### &lt;Trigger /&gt;
+### Popover.Trigger
 
 Used to trigger opening of the popover when uncontrolled, just renders a YStack, see [Stacks](/docs/components/stacks).
 
-#### &lt;Content /&gt;
+### Popover.Content
 
 Renders as SizableStack which is just a YStack (see [Stacks](/docs/components/stacks)) with an extra `size` prop that accepts any `SizeTokens`.
 
 Used to display the content of the popover.
 
-#### &lt;Anchor /&gt;
+### Popover.Anchor
 
 Renders as YStack, see [Stacks](/docs/components/stacks).
 
 When you want the Trigger to be in another location from where the Popover attaches, use Anchor. When used, Anchor is where the Popover will attach, while Trigger will open it.
 
-#### &lt;Sheet /&gt;
+### Popover.Sheet
 
 When used with `Adapt`, Popover will render as a sheet when that breakpoint is active.
 
@@ -153,6 +153,6 @@ See [Sheet](/docs/components/sheet) for more props.
 
 Must use `Adapt.Contents` inside the `Popover.Sheet.Frame` to insert the contents given to `Popover.Content`
 
-#### &lt;ScrollView /&gt;
+### Popover.ScrollView
 
 Must be nested inside Content. Renders as a plain React Native ScrollView. If used alongside `<Adapt />` and Sheet, Tamagui will automatically know to remove this ScrollView when swapping into the Sheet, as the Sheet must use it's own ScrollView that handles special logic for interactions with dragging.

--- a/apps/site/data/docs/components/progress/1.0.0.mdx
+++ b/apps/site/data/docs/components/progress/1.0.0.mdx
@@ -25,12 +25,14 @@ demoName: Progress
     'Composable component API for complete control.',
     <span>
       Adheres to the{' '}
-      <a href="https://www.w3.org/TR/wai-aria-1.2/#progressbar">progressbar role requirements</a>
+      <a href="https://www.w3.org/TR/wai-aria-1.2/#progressbar">
+        progressbar role requirements
+      </a>
     </span>,
   ]}
 />
 
-### Usage
+## Usage
 
 The `value` property controls the percent, but you can override it by adjusting the `x` property.
 
@@ -44,9 +46,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### Progress
+### Progress
 
 Progress extends [ThemeableStack](/docs/components/stacks#themeablestack), getting [Tamagui standard props](/docs/intro/props), plus:
 
@@ -71,6 +73,6 @@ Progress extends [ThemeableStack](/docs/components/stacks#themeablestack), getti
   ]}
 />
 
-#### Indicator
+### Progress.Indicator
 
-Progress.Indicator extends [ThemeableStack](/docs/components/stacks#themeablestack), getting [Tamagui standard props](/docs/intro/props).
+`Progress.Indicator` extends [ThemeableStack](/docs/components/stacks#themeablestack), getting [Tamagui standard props](/docs/intro/props).

--- a/apps/site/data/docs/components/radio-group/1.3.0.mdx
+++ b/apps/site/data/docs/components/radio-group/1.3.0.mdx
@@ -27,23 +27,26 @@ demoName: RadioGroup
   ]}
 />
 
-### Usage
+## Usage
 
 ```tsx
 import { RadioGroup } from 'tamagui'
+
 export default () => (
-  <RadioGroup size="$4" value="foo" space="$1">
-    <RadioGroup.Item id="dummy" value="foo">
+  <RadioGroup value="foo" size="$4" space="$2">
+    <RadioGroup.Item value="foo" id="foo-radio-item">
       <RadioGroup.Indicator />
     </RadioGroup.Item>
-    <RadioGroup.Item id="other" value="bar">
+    <RadioGroup.Item value="bar" id="bar-radio-item">
       <RadioGroup.Indicator />
     </RadioGroup.Item>
   </RadioGroup>
 )
 ```
 
-### RadioGroup props
+## API Reference
+
+### RadioGroup
 
 RadioGroup extend Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
 
@@ -87,7 +90,7 @@ RadioGroup extend Stack views inheriting all the [Tamagui standard props](/docs/
   ]}
 />
 
-### RadioGroup.Item props
+### RadioGroup.Item
 
 <PropsTable
   data={[
@@ -126,7 +129,7 @@ RadioGroup extend Stack views inheriting all the [Tamagui standard props](/docs/
   ]}
 />
 
-### RadioGroup.Indicator props
+### RadioGroup.Indicator
 
 RadioGroup.Indicator appears only when the parent Item is checked. it extends [ThemeableStack](/docs/components/stacks#themeablestack), getting [Tamagui standard props](/docs/intro/props) adding:
 

--- a/apps/site/data/docs/components/scroll-view/1.0.0.mdx
+++ b/apps/site/data/docs/components/scroll-view/1.0.0.mdx
@@ -26,6 +26,25 @@ demoName: ScrollView
   ]}
 />
 
-### API
+## Usage
+
+```tsx
+import { ScrollView, YStack, ListItem } from 'tamagui'
+
+export default () => (
+  <ScrollView>
+    <YStack>
+      <ListItem>1</ListItem>
+      <ListItem>2</ListItem>
+      <ListItem>3</ListItem>
+      <ListItem>4</ListItem>
+    </YStack>
+  </ScrollView>
+)
+```
+
+## API Reference
+
+### ScrollView
 
 See [React Native ScrollView](https://reactnative.dev/docs/scrollview) and [Tamagui style props](https://tamagui.dev/docs/intro/props).

--- a/apps/site/data/docs/components/select/1.0.0.mdx
+++ b/apps/site/data/docs/components/select/1.0.0.mdx
@@ -30,7 +30,7 @@ demoName: Select
 ### Anatomy
 
 ```tsx
-import { Select } from 'tamagui' // or from '@tamagui/select'
+import { Select } from 'tamagui' // or '@tamagui/select'
 
 export default () => (
   <Select defaultValue="">
@@ -217,7 +217,7 @@ See [Sheet](/docs/components/sheet) for more props.
 Must use `Select.SheetContents` inside the `Select.Sheet.Frame` to insert the contents given to `Select.Content`
 
 ```tsx
-import { Select } from 'tamagui' // or from '@tamagui/select'
+import { Select } from 'tamagui' // or '@tamagui/select'
 
 export default () => (
   <Select defaultValue="">

--- a/apps/site/data/docs/components/select/1.19.0.mdx
+++ b/apps/site/data/docs/components/select/1.19.0.mdx
@@ -27,10 +27,10 @@ demoName: Select
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { Select } from 'tamagui' // or from '@tamagui/select'
+import { Select } from 'tamagui' // or '@tamagui/select'
 
 export default () => (
   <Select defaultValue="">
@@ -58,9 +58,9 @@ export default () => (
   See below for docs.
 </Notice>
 
-### API
+## API Reference
 
-#### &lt;Select /&gt;
+### Select
 
 Contains every component for the select:
 
@@ -129,11 +129,11 @@ Contains every component for the select:
   ]}
 />
 
-#### &lt;Trigger /&gt;
+### Select.Trigger
 
 Extends [ListItem](/docs/components/list-item) to give sizing, icons, and more.
 
-#### &lt;Value /&gt;
+#### Select.Value
 
 Extends [Paragraph](/docs/components/text), adding:
 
@@ -147,23 +147,23 @@ Extends [Paragraph](/docs/components/text), adding:
   ]}
 />
 
-#### &lt;Content /&gt;
+#### SelectContent
 
 Main container for Select content, used to contain the up/down arrows, no API beyond children.
 
-#### &lt;ScrollUpButton /&gt;
+#### Select.ScrollUpButton
 
 Inside Content first, displays when you can scroll up, stuck to the top.
 
 Extends [YStack](/docs/components/stacks).
 
-#### &lt;ScrollDownButton /&gt;
+### Select.ScrollDownButton
 
 Inside Content last, displays when you can scroll down, stuck to the bottom.
 
 Extends [YStack](/docs/components/stacks).
 
-#### &lt;Viewport /&gt;
+### Select.Viewport
 
 Extends [ThemeableStack](/docs/components/stacks#themeablestack). Contains scrollable content items as children.
 
@@ -177,15 +177,15 @@ Extends [ThemeableStack](/docs/components/stacks#themeablestack). Contains scrol
   ]}
 />
 
-#### &lt;Group /&gt;
+### Select.Group
 
 Extends [YStack](/docs/components/stacks). Use only when grouping together items, alongside a Label as the first child.
 
-#### &lt;Label /&gt;
+### Select.Label
 
 Extends [ListItem](/docs/components/list-item). Used to label Groups.
 
-#### &lt;Item /&gt;
+### Select.Item
 
 Extends [ListItem](/docs/components/list-item). Used to add selectable values ot the list. Must provide an index as React Native doesn't give any escape hatch for us to configure that automatically.
 
@@ -207,11 +207,11 @@ Extends [ListItem](/docs/components/list-item). Used to add selectable values ot
 ]}
 />
 
-#### &lt;ItemText /&gt;
+### Select.ItemText
 
 Extends [Paragraph](/docs/components/text). Used inside Item to provide unselectable text that will show above once selected in the parent Select.
 
-#### &lt;Sheet /&gt;
+### Select.Sheet
 
 When used alongside `<Adapt />`, Select will render as a sheet when that breakpoint is active.
 
@@ -222,7 +222,7 @@ See [Sheet](/docs/components/sheet) for more props.
 Must use `Select.SheetContents` inside the `Select.Sheet.Frame` to insert the contents given to `Select.Content`
 
 ```tsx
-import { Select } from 'tamagui' // or from '@tamagui/select'
+import { Select } from 'tamagui' // or '@tamagui/select'
 
 export default () => (
   <Select defaultValue="">

--- a/apps/site/data/docs/components/separator/1.0.0.mdx
+++ b/apps/site/data/docs/components/separator/1.0.0.mdx
@@ -21,7 +21,24 @@ demoName: Separator
 
 <Highlights features={[`Supports horizontal and vertical orientation.`]} />
 
+## Usage
+
 Separator uses the `borderWidth` and `borderColor` attribute for its style, so be sure to override those when extending it.
+
+```tsx
+export default () => (
+  <XStack alignItems="center">
+    <Paragraph>Blog</Paragraph>
+    <Separator alignSelf="stretch" vertical />
+    <Paragraph>Docs</Paragraph>
+    <Separator alignSelf="stretch" vertical />
+    <Paragraph>Source</Paragraph>
+  </XStack>
+)
+
+```
+
+## API Reference
 
 ### Separator props
 

--- a/apps/site/data/docs/components/shapes/1.0.0.mdx
+++ b/apps/site/data/docs/components/shapes/1.0.0.mdx
@@ -20,10 +20,13 @@ demoName: Shapes
 ```
 
 <Highlights
-  features={['Accepts size props as number or token value.', 'Sets min and max width and height.']}
+  features={[
+    'Accepts size props as number or token value.',
+    'Sets min and max width and height.',
+  ]}
 />
 
-### Usage
+## Usage
 
 Tamagui supports sizing shapes using your `size` tokens, or plain numbers.
 
@@ -40,9 +43,11 @@ export default () => (
 )
 ```
 
-### Shape props
+## API Reference
 
-Buttons extend Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
+### Square
+
+`Square` extends Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
 
 <PropsTable
   data={[
@@ -60,3 +65,7 @@ Buttons extend Stack views inheriting all the [Tamagui standard props](/docs/int
     },
   ]}
 />
+
+### Circle
+
+`Circle` extends [Square](#square), setting `circular` to `true`.

--- a/apps/site/data/docs/components/sheet/1.0.0.mdx
+++ b/apps/site/data/docs/components/sheet/1.0.0.mdx
@@ -31,7 +31,7 @@ demoName: Sheet
 ### Anatomy
 
 ```tsx
-import { Sheet } from 'tamagui' // or from '@tamagui/sheet'
+import { Sheet } from 'tamagui' // or '@tamagui/sheet'
 
 export default () => (
   <Sheet>

--- a/apps/site/data/docs/components/sheet/1.21.0.mdx
+++ b/apps/site/data/docs/components/sheet/1.21.0.mdx
@@ -31,7 +31,7 @@ demoName: Sheet
 ### Anatomy
 
 ```tsx
-import { Sheet } from 'tamagui' // or from '@tamagui/sheet'
+import { Sheet } from 'tamagui' // or '@tamagui/sheet'
 
 export default () => (
   <Sheet>

--- a/apps/site/data/docs/components/sheet/1.27.0.mdx
+++ b/apps/site/data/docs/components/sheet/1.27.0.mdx
@@ -28,10 +28,10 @@ demoName: Sheet
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { Sheet } from 'tamagui' // or from '@tamagui/sheet'
+import { Sheet } from 'tamagui' // or '@tamagui/sheet'
 
 export default () => (
   <Sheet>
@@ -42,11 +42,11 @@ export default () => (
 )
 ```
 
-### Unstyled
+## Unstyled
 
 Adding the `unstyled` prop to your Handle, Overlay or Frame will turn off the default styles allowing you to customize without having to override any of the built-in styling.
 
-### Headless with `createSheet`
+## Headless with `createSheet`
 
 Using the `createSheet` export, you can create a fully custom sheet without using any of the default styles. This is similar to `unstyled`, but it lets you also control the `open` variant.
 
@@ -96,7 +96,7 @@ export const Sheet = createSheet({
 })
 ```
 
-### Native support
+## Native support
 
 Sheets now support rendering to a native iOS sheet, while still rendering any of your React Native content inside of them.
 
@@ -123,9 +123,9 @@ export default (
 )
 ```
 
-### API
+## API Reference
 
-#### &lt;Sheet /&gt;
+### Sheet
 
 Contains every component for the sheet.
 
@@ -216,11 +216,11 @@ Contains every component for the sheet.
   ]}
 />
 
-#### &lt;Overlay /&gt;
+### Sheet.Overlay
 
 Displays behind Frame. Extends [YStack](/docs/components/stacks).
 
-#### &lt;Frame /&gt;
+### Sheet.Frame
 
 Contains the content. Extends [YStack](/docs/components/stacks).
 
@@ -234,13 +234,13 @@ Contains the content. Extends [YStack](/docs/components/stacks).
   ]}
 />
 
-#### &lt;Handle /&gt;
+### Sheet.Handle
 
 Shows a handle above the frame by default, on tap it will cycle between `snapPoints` but this can be overridden with `onPress`.
 
 Extends [XStack](/docs/components/stacks).
 
-#### &lt;ScrollView /&gt;
+### Sheet.ScrollView
 
 Allows scrolling within Sheet. Extends [Scrollview](/docs/components/scroll-view).
 
@@ -264,6 +264,6 @@ Use this to control the sheet programatically.
   ]}
 />
 
-### Notes
+## Notes
 
 For Android you need to manually re-propagate any context when using `modal`. This is because React Native doesn't support portals yet.

--- a/apps/site/data/docs/components/sheet/1.9.18.mdx
+++ b/apps/site/data/docs/components/sheet/1.9.18.mdx
@@ -31,7 +31,7 @@ demoName: Sheet
 ### Anatomy
 
 ```tsx
-import { Sheet } from 'tamagui' // or from '@tamagui/sheet'
+import { Sheet } from 'tamagui' // or '@tamagui/sheet'
 
 export default () => (
   <Sheet>

--- a/apps/site/data/docs/components/slider/1.0.0.mdx
+++ b/apps/site/data/docs/components/slider/1.0.0.mdx
@@ -28,7 +28,7 @@ demoName: Slider
   ]}
 />
 
-### Usage
+## Usage
 
 Slider comes as multiple components that ship with default styles and are sizable. The `size` prop on `<Slider />` will automatically pass size down to all the sub-components.
 
@@ -64,9 +64,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### Slider
+### Slider
 
 Contains every component for the slider.
 
@@ -144,6 +144,29 @@ Contains every component for the slider.
       required: false,
       type: 'number',
       description: `Minimum steps between thumbs.`,
+    },
+  ]}
+/>
+
+### Slider.Track
+
+`Slider.Track` Inherits `SizableStack`, extending all the default [props](/docs/intro/props).
+
+### Slider.TrackActive
+
+`Slider.Track` Inherits `Stack`, extending all the default [props](/docs/intro/props).
+
+### Slider.Thumb
+
+`Slider.Track` Inherits `SizableStack`, extending all the default [props](/docs/intro/props), adding:
+
+<PropsTable
+  data={[
+    {
+      name: 'index',
+      required: true,
+      type: 'number',
+      description: `Corresponds to the index of \`value\` or \`defaultValue\`. Use to correlate thumbs to each value in the array.`,
     },
   ]}
 />

--- a/apps/site/data/docs/components/spinner/1.0.0.mdx
+++ b/apps/site/data/docs/components/spinner/1.0.0.mdx
@@ -26,7 +26,7 @@ demoName: Spinner
   ]}
 />
 
-### Usage
+## Usage
 
 Note that due to the fact that Spinner is an extension of React Native [ActivityIndicator](https://reactnative.dev/docs/activityindicator), and that only accepts size `small` or `large`, we are currently limited to just these sizes.
 
@@ -36,7 +36,9 @@ import { Button, Spinner } from 'tamagui'
 export default () => <Spinner size="large" color="$green10" />
 ```
 
-### Spinner API
+## API Reference
+
+### Spinner
 
 Spinner extends [YStack](/docs/components/stacks), getting [Tamagui standard props](/docs/intro/props), plus:
 

--- a/apps/site/data/docs/components/stacks/1.0.0.mdx
+++ b/apps/site/data/docs/components/stacks/1.0.0.mdx
@@ -29,7 +29,7 @@ demoName: Stacks
   ]}
 />
 
-### Usage
+## Usage
 
 XStack, YStack and ZStack are the base views in Tamagui, they both extend directly off the simple [Stack](/docs/core/stack-and-text) view from `@tamagui/core`.
 
@@ -80,7 +80,9 @@ export default () => (
 )
 ```
 
-### Stacks Props
+## API Reference
+
+### Stack
 
 Beyond the [Tamagui Props](/docs/intro/props), stacks have two variants
 
@@ -112,8 +114,8 @@ Beyond the [Tamagui Props](/docs/intro/props), stacks have two variants
 Adds a variety of helpers that automatically apply theme values when set to true. Useful for creating higher level components by wrapping with `styled()`:
 
 ```tsx
-import { styled } from 'tamagui' // or @tamagui/core
-import { ThemeableStack } from 'tamagui' // or @tamagui/stacks
+import { styled } from 'tamagui' // or '@tamagui/core'
+import { ThemeableStack } from 'tamagui' // or '@tamagui/stacks'
 
 const MyCard = styled(ThemeableStack, {
   hoverTheme: true,

--- a/apps/site/data/docs/components/switch/1.28.0.mdx
+++ b/apps/site/data/docs/components/switch/1.28.0.mdx
@@ -28,10 +28,10 @@ demoName: Switch
   ]}
 />
 
-### Usage
+## Usage
 
 ```tsx
-import { Switch } from 'tamagui'
+import { Switch } from 'tamagui' // or '@tamagui/switch'
 
 export default () => (
   <Switch size="$4">
@@ -40,7 +40,9 @@ export default () => (
 )
 ```
 
-### Switch props
+## API Reference
+
+### Switch
 
 Switchs extend Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
 
@@ -95,6 +97,21 @@ Switchs extend Stack views inheriting all the [Tamagui standard props](/docs/int
       name: 'nativeProps',
       type: 'SwitchProps (from `react-native`)',
       description: `Props to pass to the native Switch;`,
+    },
+  ]}
+/>
+
+### Switch.Thumb
+
+`Switch.Thumb` extends Stack views inheriting all the [Tamagui standard props](/docs/intro/props), plus:
+
+<PropsTable
+  data={[
+    {
+      name: 'unstyled',
+      type: 'boolean',
+      default: 'false',
+      description: `When true, remove all default tamagui styling.`,
     },
   ]}
 />

--- a/apps/site/data/docs/components/tabs/1.7.0.mdx
+++ b/apps/site/data/docs/components/tabs/1.7.0.mdx
@@ -52,19 +52,7 @@ export default () => (
 )
 ```
 
-## Advanced Demo
-
-Here is a demo with more advanced animations using [AnimatePresence](/docs/core/animations#animatepresence-and-exitstyle) and [Trigger](#trigger)'s `onInteraction` prop.
-
-<HeroContainer noPad showAnimationDriverControl>
-  <TabsAdvancedDemo />
-</HeroContainer>
-
-```tsx hero template=TabsAdvanced
-
-```
-
-## API
+## API Reference
 
 ### Tabs
 
@@ -107,7 +95,7 @@ Root tabs component. Extends [Stack](/docs/components/stack). Passing the `size`
   ]}
 />
 
-### List
+### Tabs.List
 
 Container for the trigger buttons. Supports scrolling by extending [Group](/docs/components/group). You can disable passing border radius to children by passing `disablePassBorderRadius`.
 
@@ -122,7 +110,7 @@ Container for the trigger buttons. Supports scrolling by extending [Group](/docs
   ]}
 />
 
-### Trigger
+### Tabs.Trigger
 
 Extends [Button](/docs/components/button), adding:
 
@@ -146,7 +134,7 @@ Extends [Button](/docs/components/button), adding:
   ]}
 />
 
-### Content
+### Tabs.Content
 
 Where each tab's content will be shown. Extends [ThemeableStack](/docs/components/stacks#themeablestack), adding:
 
@@ -165,3 +153,17 @@ Where each tab's content will be shown. Extends [ThemeableStack](/docs/component
     },
   ]}
 />
+
+## Examples
+
+### Animations
+
+Here is a demo with more advanced animations using [AnimatePresence](/docs/core/animations#animatepresence-and-exitstyle) and [Trigger](#trigger)'s `onInteraction` prop.
+
+<HeroContainer noPad showAnimationDriverControl>
+  <TabsAdvancedDemo />
+</HeroContainer>
+
+```tsx hero template=TabsAdvanced
+
+```

--- a/apps/site/data/docs/components/text/1.0.0.mdx
+++ b/apps/site/data/docs/components/text/1.0.0.mdx
@@ -27,7 +27,19 @@ demoName: Text
   ]}
 />
 
-### Usage
+## Usage
+
+```tsx
+export default () => (
+  <>
+    <Text>Text</Text>
+    <SizableText>Sizable Text</SizableText>
+    <Paragraph>Paragraph</Paragraph>
+  </>
+)
+```
+
+## Text
 
 Text in Tamagui matches to Text in react-native-web, just with the added [Tamagui Props](/docs/intro/props).
 

--- a/apps/site/data/docs/components/toast/1.11.3.mdx
+++ b/apps/site/data/docs/components/toast/1.11.3.mdx
@@ -44,7 +44,7 @@ then, rebuild your React Native app. React Native requires sub-dependencies with
 To display the toast natively, you should either pass an array of native platforms (`native: ["ios", "web"]`), a single platform or `true` for all platforms.
 
 ```tsx
-import { Button } from 'tamagui' // or @tamagui/button
+import { Button } from 'tamagui' // or '@tamagui/button'
 import { Toast, ToastProvider, useToast } from '@tamagui/toast'
 
 export default () => (

--- a/apps/site/data/docs/components/toast/1.13.0.mdx
+++ b/apps/site/data/docs/components/toast/1.13.0.mdx
@@ -45,7 +45,7 @@ To display the toast natively, you should either pass an array of native platfor
 
 ```tsx
 import { Toast, ToastProvider, useToastController, useToastState } from '@tamagui/toast'
-import { Button } from 'tamagui' // or @tamagui/button
+import { Button } from 'tamagui' // or '@tamagui/button'
 
 export default () => (
   <ToastProvider native={['mobile']}>

--- a/apps/site/data/docs/components/toast/1.8.0.mdx
+++ b/apps/site/data/docs/components/toast/1.8.0.mdx
@@ -36,7 +36,7 @@ For native support, run `yarn add burnt` to add `burnt`, then rebuild your React
 ## Anatomy
 
 ```tsx
-import { Toast, ToastProvider, ToastViewport } from 'tamagui' // or @tamagui/toast
+import { Toast, ToastProvider, ToastViewport } from 'tamagui' // or '@tamagui/toast'
 
 export default () => (
   <ToastProvider>
@@ -131,8 +131,8 @@ export default () => {
 ### Using `createToast`
 
 ```tsx
-import { Button } from 'tamagui' // or @tamagui/button
-import { Toast, ToastProvider, createToast } from 'tamagui' // or @tamagui/toast
+import { Button } from 'tamagui' // or '@tamagui/button'
+import { Toast, ToastProvider, createToast } from 'tamagui' // or '@tamagui/toast'
 
 export const { ImperativeToastProvider, useToast } = createToast()
 

--- a/apps/site/data/docs/components/toast/1.9.1.mdx
+++ b/apps/site/data/docs/components/toast/1.9.1.mdx
@@ -44,8 +44,8 @@ For native support on mobile, run `yarn add burnt` to add `burnt`, then rebuild 
 To display the toast natively, you should either pass an array of native platforms (`native: ["ios", "web"]`), a single platform or `true` for all platforms.
 
 ```tsx
-import { Button } from 'tamagui' // or @tamagui/button
-import { Toast, ToastImperativeProvider, ToastProvider, useToast } from 'tamagui' // or @tamagui/toast
+import { Button } from 'tamagui' // or '@tamagui/button'
+import { Toast, ToastImperativeProvider, ToastProvider, useToast } from 'tamagui' // or '@tamagui/toast'
 
 const options = { native: 'mobile' }
 

--- a/apps/site/data/docs/components/toggle-group/1.10.0.mdx
+++ b/apps/site/data/docs/components/toggle-group/1.10.0.mdx
@@ -28,7 +28,7 @@ demoName: ToggleGroup
   ]}
 />
 
-### Usage
+## Usage
 
 ```tsx
 import { ToggleGroup } from 'tamagui'
@@ -36,16 +36,18 @@ import { ToggleGroup } from 'tamagui'
 export default () => {
   return (
     <ToggleGroup type="single">
-      <ToggleGroup.Item value="dummy"></ToggleGroup.Item>
-      <ToggleGroup.Item value="other"></ToggleGroup.Item>
+      <ToggleGroup.Item value="foo"></ToggleGroup.Item>
+      <ToggleGroup.Item value="bar"></ToggleGroup.Item>
     </ToggleGroup>
   )
 }
 ```
 
-### ToggleGroup props
+## API Reference
 
-ToggleGroup extends the [Group](/docs/components/group) component. You can disable passing border radius to children by passing `disablePassBorderRadius`. plus:
+### ToggleGroup
+
+`ToggleGroup` extends the [Group](/docs/components/group) component. You can disable passing border radius to children by passing `disablePassBorderRadius`. plus:
 
 <PropsTable
   data={[
@@ -114,9 +116,9 @@ ToggleGroup extends the [Group](/docs/components/group) component. You can disab
   ]}
 />
 
-### ToggleGroup Item props
+### ToggleGroup.Item
 
-ToggleGroup extend Stack views inheriting all the [Tamagui standard props](notion://www.notion.so/docs/intro/props), plus:
+`ToggleGroup.Item` extend Stack views inheriting all the [Tamagui standard props](notion://www.notion.so/docs/intro/props), plus:
 
 <PropsTable
   data={[

--- a/apps/site/data/docs/components/tooltip/1.0.0.mdx
+++ b/apps/site/data/docs/components/tooltip/1.0.0.mdx
@@ -27,10 +27,10 @@ demoName: Tooltip
   ]}
 />
 
-### Anatomy
+## Anatomy
 
 ```tsx
-import { Tooltip } from 'tamagui' // or @tamagui/tooltip
+import { Tooltip } from 'tamagui' // or '@tamagui/tooltip'
 
 export default () => (
   <Tooltip>
@@ -43,9 +43,9 @@ export default () => (
 )
 ```
 
-### API
+## API Reference
 
-#### &lt;Tooltip /&gt;
+### Tooltip
 
 Contains every component for the tooltip.
 
@@ -125,15 +125,15 @@ Contains every component for the tooltip.
   ]}
 />
 
-#### Trigger
+### Tooltip.Trigger
 
 Used to trigger opening of the popover when uncontrolled, see YStack in [Stacks](/docs/components/stacks).
 
-#### Content
+### Tooltip.Content
 
 Renders as SizableStack (see [Stacks](/docs/components/stacks)) with an extra `size` prop that accepts any `SizeTokens`.
 
-#### Anchor
+### Tooltip.Anchor
 
 Renders as YStack, see [Stacks](/docs/components/stacks).
 

--- a/apps/site/data/docs/components/unspaced/1.0.0.mdx
+++ b/apps/site/data/docs/components/unspaced/1.0.0.mdx
@@ -9,7 +9,7 @@ component: Unspaced
 
 <Description>Avoids spacing for children inside a spacing container.</Description>
 
-### Usage
+## Usage
 
 When using `space`, you sometimes want certain children to not contribute to spacing. Use Unspaced to achieve this:
 

--- a/apps/site/data/docs/components/visually-hidden/1.0.0.mdx
+++ b/apps/site/data/docs/components/visually-hidden/1.0.0.mdx
@@ -16,7 +16,7 @@ component: VisuallyHidden
   ]}
 />
 
-### Usage
+## Usage
 
 Simply wrap the content you want hidden in VisuallyHidden:
 

--- a/apps/site/data/docs/core/font-language.mdx
+++ b/apps/site/data/docs/core/font-language.mdx
@@ -55,7 +55,7 @@ export default createTamagui({
 You'll then need to load the `Inter` and `Inter-CN` fonts for the platforms you support. Once you do, you'll get fully typed support for changing any `body` font to `cn` in a component:
 
 ```tsx
-import { FontLanguage, Text } from 'tamagui' // or @tamagui/core
+import { FontLanguage, Text } from 'tamagui' // or '@tamagui/core'
 
 export default (
   <FontLanguage body="cn">
@@ -71,7 +71,7 @@ The name you choose for the suffix is up to you, and Tamagui will treat any font
 To reset your font back to your base `body` font, you can use the reserved key `default`:
 
 ```tsx
-import { FontLanguage, Text } from 'tamagui' // or @tamagui/core
+import { FontLanguage, Text } from 'tamagui' // or '@tamagui/core'
 
 export default (
   <FontLanguage body="cn">

--- a/apps/site/data/docs/core/theme.mdx
+++ b/apps/site/data/docs/core/theme.mdx
@@ -15,7 +15,7 @@ Changing themes in Tamagui is as easy as passing their name to the Theme compone
 Change themes anywhere in your app like so:
 
 ```tsx
-import { Button, Theme } from 'tamagui' // or @tamagui/core
+import { Button, Theme } from 'tamagui' // or '@tamagui/core'
 
 export default () => (
   <Theme name="dark">

--- a/apps/site/data/docs/guides/design-systems.mdx
+++ b/apps/site/data/docs/guides/design-systems.mdx
@@ -70,7 +70,7 @@ Now, create and export the components. You can re-export components from `tamagu
 `Circle.tsx`:
 
 ```tsx
-import { GetProps, YStack, styled } from 'tamagui' // or @tamagui/core if extending just that
+import { GetProps, YStack, styled } from 'tamagui' // or '@tamagui/core' if extending just that
 
 export const Circle = styled(YStack, {
   alignItems: 'center',

--- a/apps/site/lib/docsRoutes.ts
+++ b/apps/site/lib/docsRoutes.ts
@@ -69,7 +69,7 @@ export const docsRoutes = [
     pages: [
       { title: 'Stacks', route: '/docs/components/stacks' },
       { title: 'Headings', route: '/docs/components/headings' },
-      { title: 'Paragraph', route: '/docs/components/text' },
+      { title: 'Text', route: '/docs/components/text' },
     ],
   },
 

--- a/packages/slider/src/Slider.tsx
+++ b/packages/slider/src/Slider.tsx
@@ -456,8 +456,8 @@ SliderThumb.displayName = THUMB_NAME
  * Slider
  * -----------------------------------------------------------------------------------------------*/
 
-const Slider = withStaticProperties(
-  React.forwardRef<View, SliderProps>((props: ScopedProps<SliderProps>, forwardedRef) => {
+const SliderComponent = React.forwardRef<View, SliderProps>(
+  (props: ScopedProps<SliderProps>, forwardedRef) => {
     const {
       name,
       min = 0,
@@ -581,22 +581,23 @@ const Slider = withStaticProperties(
           }}
         />
         {/* {isFormControl &&
-          values.map((value, index) => (
-            <BubbleInput
-              key={index}
-              name={name ? name + (values.length > 1 ? '[]' : '') : undefined}
-              value={value}
-            />
-          ))} */}
+        values.map((value, index) => (
+          <BubbleInput
+            key={index}
+            name={name ? name + (values.length > 1 ? '[]' : '') : undefined}
+            value={value}
+          />
+        ))} */}
       </SliderProvider>
     )
-  }),
-  {
-    Track: SliderTrack,
-    TrackActive: SliderTrackActive,
-    Thumb: SliderThumb,
   }
 )
+
+const Slider = withStaticProperties(SliderComponent, {
+  Track: SliderTrack,
+  TrackActive: SliderTrackActive,
+  Thumb: SliderThumb,
+})
 
 Slider.displayName = SLIDER_NAME
 

--- a/packages/switch/src/Switch.tsx
+++ b/packages/switch/src/Switch.tsx
@@ -172,135 +172,132 @@ export type SwitchProps = SwitchButtonProps & {
   onCheckedChange?(checked: boolean): void
 }
 
-export const Switch = withStaticProperties(
-  SwitchFrame.extractable(
-    React.forwardRef<HTMLButtonElement | View, SwitchProps>(
-      (props: ScopedProps<SwitchProps, 'Switch'>, forwardedRef) => {
-        const {
-          __scopeSwitch,
-          labeledBy: ariaLabelledby,
-          name,
-          checked: checkedProp,
-          defaultChecked,
-          required,
-          disabled,
-          value = 'on',
-          onCheckedChange,
-          size = '$true',
-          unstyled = false,
-          native: nativeProp,
-          nativeProps,
-          ...switchProps
-        } = props
-        const native = Array.isArray(nativeProp) ? nativeProp : [nativeProp]
-        const shouldRenderMobileNative =
-          (!isWeb && nativeProp === true) ||
-          native.includes('mobile') ||
-          (native.includes('android') && Platform.OS === 'android') ||
-          (native.includes('ios') && Platform.OS === 'ios')
-        if (shouldRenderMobileNative) {
-          return (
-            <NativeSwitch
-              value={checkedProp}
-              onValueChange={onCheckedChange}
-              {...nativeProps}
-            />
-          )
-        }
-        const [button, setButton] = React.useState<HTMLButtonElement | null>(null)
-        const composedRefs = useComposedRefs(forwardedRef, (node) =>
-          setButton(node as any)
-        )
-        const labelId = useLabelContext(button)
-        const labelledBy = ariaLabelledby || labelId
-        const hasConsumerStoppedPropagationRef = React.useRef(false)
-        // We set this to true by default so that events bubble to forms without JS (SSR)
-        const isFormControl = isWeb
-          ? button
-            ? Boolean(button.closest('form'))
-            : true
-          : false
-        const [checked = false, setChecked] = useControllableState({
-          prop: checkedProp,
-          defaultProp: defaultChecked || false,
-          onChange: onCheckedChange,
-          transition: true,
-        })
-
-        if (!isWeb) {
-          // eslint-disable-next-line react-hooks/rules-of-hooks
-          React.useEffect(() => {
-            if (!props.id) return
-            return registerFocusable(props.id, {
-              focus: () => {
-                setChecked((x) => !x)
-              },
-            })
-          }, [props.id, setChecked])
-        }
-
+const SwitchComponent = SwitchFrame.extractable(
+  React.forwardRef<HTMLButtonElement | View, SwitchProps>(
+    (props: ScopedProps<SwitchProps, 'Switch'>, forwardedRef) => {
+      const {
+        __scopeSwitch,
+        labeledBy: ariaLabelledby,
+        name,
+        checked: checkedProp,
+        defaultChecked,
+        required,
+        disabled,
+        value = 'on',
+        onCheckedChange,
+        size = '$true',
+        unstyled = false,
+        native: nativeProp,
+        nativeProps,
+        ...switchProps
+      } = props
+      const native = Array.isArray(nativeProp) ? nativeProp : [nativeProp]
+      const shouldRenderMobileNative =
+        (!isWeb && nativeProp === true) ||
+        native.includes('mobile') ||
+        (native.includes('android') && Platform.OS === 'android') ||
+        (native.includes('ios') && Platform.OS === 'ios')
+      if (shouldRenderMobileNative) {
         return (
-          <SwitchProvider
-            scope={__scopeSwitch}
-            checked={checked}
-            disabled={disabled}
-            size={size}
-            unstyled={unstyled}
-          >
-            <SwitchFrame
-              unstyled={unstyled}
-              size={size}
-              theme={checked ? 'active' : null}
-              // @ts-ignore
-              role="switch"
-              aria-checked={checked}
-              aria-labelledby={labelledBy}
-              aria-required={required}
-              data-state={getState(checked)}
-              data-disabled={disabled ? '' : undefined}
-              disabled={disabled}
-              // @ts-ignore
-              tabIndex={disabled ? undefined : 0}
-              // @ts-ignore
-              value={value}
-              {...switchProps}
-              ref={composedRefs}
-              onPress={(event) => {
-                props.onPress?.(event)
-                setChecked((prevChecked) => !prevChecked)
-                if (isWeb && isFormControl) {
-                  hasConsumerStoppedPropagationRef.current = event.isPropagationStopped()
-                  // if switch is in a form, stop propagation from the button so that we only propagate
-                  // one click event (from the input). We propagate changes from an input so that native
-                  // form validation works and form events reflect switch updates.
-                  if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation()
-                }
-              }}
-            />
-            {isWeb && isFormControl && (
-              <BubbleInput
-                control={button}
-                bubbles={!hasConsumerStoppedPropagationRef.current}
-                name={name}
-                value={value}
-                checked={checked}
-                required={required}
-                disabled={disabled}
-                // We transform because the input is absolutely positioned but we have
-                // rendered it **after** the button. This pulls it back to sit on top
-                // of the button.
-                style={{ transform: 'translateX(-100%)' }}
-              />
-            )}
-          </SwitchProvider>
+          <NativeSwitch
+            value={checkedProp}
+            onValueChange={onCheckedChange}
+            {...nativeProps}
+          />
         )
       }
-    )
-  ),
-  {
-    Thumb: SwitchThumb,
-  }
+      const [button, setButton] = React.useState<HTMLButtonElement | null>(null)
+      const composedRefs = useComposedRefs(forwardedRef, (node) => setButton(node as any))
+      const labelId = useLabelContext(button)
+      const labelledBy = ariaLabelledby || labelId
+      const hasConsumerStoppedPropagationRef = React.useRef(false)
+      // We set this to true by default so that events bubble to forms without JS (SSR)
+      const isFormControl = isWeb
+        ? button
+          ? Boolean(button.closest('form'))
+          : true
+        : false
+      const [checked = false, setChecked] = useControllableState({
+        prop: checkedProp,
+        defaultProp: defaultChecked || false,
+        onChange: onCheckedChange,
+        transition: true,
+      })
+
+      if (!isWeb) {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        React.useEffect(() => {
+          if (!props.id) return
+          return registerFocusable(props.id, {
+            focus: () => {
+              setChecked((x) => !x)
+            },
+          })
+        }, [props.id, setChecked])
+      }
+
+      return (
+        <SwitchProvider
+          scope={__scopeSwitch}
+          checked={checked}
+          disabled={disabled}
+          size={size}
+          unstyled={unstyled}
+        >
+          <SwitchFrame
+            unstyled={unstyled}
+            size={size}
+            theme={checked ? 'active' : null}
+            // @ts-ignore
+            role="switch"
+            aria-checked={checked}
+            aria-labelledby={labelledBy}
+            aria-required={required}
+            data-state={getState(checked)}
+            data-disabled={disabled ? '' : undefined}
+            disabled={disabled}
+            // @ts-ignore
+            tabIndex={disabled ? undefined : 0}
+            // @ts-ignore
+            value={value}
+            {...switchProps}
+            ref={composedRefs}
+            onPress={(event) => {
+              props.onPress?.(event)
+              setChecked((prevChecked) => !prevChecked)
+              if (isWeb && isFormControl) {
+                hasConsumerStoppedPropagationRef.current = event.isPropagationStopped()
+                // if switch is in a form, stop propagation from the button so that we only propagate
+                // one click event (from the input). We propagate changes from an input so that native
+                // form validation works and form events reflect switch updates.
+                if (!hasConsumerStoppedPropagationRef.current) event.stopPropagation()
+              }
+            }}
+          />
+          {isWeb && isFormControl && (
+            <BubbleInput
+              control={button}
+              bubbles={!hasConsumerStoppedPropagationRef.current}
+              name={name}
+              value={value}
+              checked={checked}
+              required={required}
+              disabled={disabled}
+              // We transform because the input is absolutely positioned but we have
+              // rendered it **after** the button. This pulls it back to sit on top
+              // of the button.
+              style={{ transform: 'translateX(-100%)' }}
+            />
+          )}
+        </SwitchProvider>
+      )
+    }
+  )
 )
+
+export const Switch = withStaticProperties(SwitchComponent, {
+  Thumb: SwitchThumb,
+})
 
 /* ---------------------------------------------------------------------------------------------- */
 


### PR DESCRIPTION
- missing api references on several component docs
- make heading levels descend one by one
- more consistent heading titles
- more consistent hierarchy and conventions
