### PR TITLE
fix(slider): allow Thumb size styles to be overridden

### DIFF
--- a/packages/slider/src/Slider.tsx
+++ b/packages/slider/src/Slider.tsx
@@ -408,7 +408,6 @@ const SliderThumb = React.forwardRef<View, SliderThumbProps>(
         data-disabled={context.disabled ? '' : undefined}
         tabIndex={context.disabled ? undefined : 0}
         animateOnly={['transform', 'left', 'right', 'top', 'bottom']}
-        {...thumbProps}
         {...(context.orientation === 'horizontal'
           ? {
               x: thumbInBoundsOffset - size / 2,
@@ -432,6 +431,7 @@ const SliderThumb = React.forwardRef<View, SliderThumbProps>(
           [orientation.startEdge]: `${percent}%`,
         }}
         size={sizeIn}
+        {...thumbProps}
         onLayout={(e) => {
           setSize(e.nativeEvent.layout[orientation.sizeProp])
         }}


### PR DESCRIPTION
Currently, it's not possible to manually define dimension styles on `Slider.Thumb`:

```tsx
<Slider.Thumb
  width="$4"  // this does
  height="$2" // nothing! 😭 
/>
```

This is because inside the wrapper around that component, the `size` prop is always inserted _after_ any custom user-defined props.

This PR moves the spreading of user-defined props to be after any predefined style props, enabling consumers to define or override `width`/`height`/`minWidth`/`minHeight` styles without using the `size` prop.