### PR TITLE
fix(group): stop counting null children as group items

### DIFF
--- a/packages/group/src/Group.tsx
+++ b/packages/group/src/Group.tsx
@@ -120,7 +120,7 @@ function createGroup(verticalDefault: boolean) {
 
       const childrenArray = Children.toArray(childrenProp)
       const children = isUsingItems
-        ? childrenProp
+        ? Children.toArray(childrenProp).filter(isValidElement)
         : childrenArray.map((child, i) => {
             if (!isValidElement(child)) {
               return child


### PR DESCRIPTION
fixes the bug where first/last element wouldn't get the correct border radius cause of conditionally hidden (null) nodes