### PR TITLE
fix: check for cssRules nullability

### DIFF
--- a/packages/web/src/helpers/insertStyleRule.tsx
+++ b/packages/web/src/helpers/insertStyleRule.tsx
@@ -98,6 +98,9 @@ function updateSheetStyles(sheet: CSSStyleSheet, remove = false) {
   let rules: CSSRuleList
   try {
     rules = sheet.cssRules
+    if (!rules) {
+      return
+    }
   } catch {
     return
   }


### PR DESCRIPTION
Some old browsers assign null instead of throwing a SecurityError on the accessing cssRules.

<img width="399" alt="errrror" src="https://github.com/tamagui/tamagui/assets/46188784/a2fedc93-32e0-4f68-bbba-44970d59c1b6">
