### PR TITLE
chore(starter): move .vscode dir to the monorepo root

### DIFF
--- a/starters/next-expo-solito/.vscode/settings.json
+++ b/starters/next-expo-solito/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/starters/next-expo-solito/apps/next/.vscode/settings.json
+++ b/starters/next-expo-solito/apps/next/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "typescript.tsdk": "../../node_modules/typescript/lib",
-  "typescript.enablePromptUseWorkspaceTsdk": true
-}


### PR DESCRIPTION
I _think_ it's more appropriate to have that directory in the root of the monorepo because usually people open the entire repo when developing and that setting and prompt only works if VSCode finds `.vscode` in the root.