### PR TITLE
chore: remove leftover lerna config

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,9 +1,0 @@
-{
-  "packages": [
-    "apps/*",
-    "packages/*",
-    "takeout/*",
-    "examples/**"
-  ],
-  "version": "1.5.24"
-}


### PR DESCRIPTION
AFAIK lerna isn't used anymore in the repo