### PR TITLE
update workspace

### DIFF
--- a/starters/next-expo-solito/apps/expo/package.json
+++ b/starters/next-expo-solito/apps/expo/package.json
@@ -11,10 +11,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.9",
-    "@my/ui": "*",
+    "@my/ui": "workspace:*",
     "@react-navigation/native": "^6.1.6",
     "@types/react-native": "^0.71.3",
-    "app": "*",
+    "app": "workspace:*",
     "babel-plugin-module-resolver": "^4.1.0",
     "burnt": "^0.10.0",
     "expo": "^48.0.7",

--- a/starters/next-expo-solito/apps/next/package.json
+++ b/starters/next-expo-solito/apps/next/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@tamagui/next-theme": "latest",
-    "app": "*",
+    "app": "workspace:*",
     "next": "^13.2.4",
     "raf": "^3.4.1",
     "react": "^18.2.0",

--- a/starters/next-expo-solito/packages/app/package.json
+++ b/starters/next-expo-solito/packages/app/package.json
@@ -7,7 +7,7 @@
     "*.css"
   ],
   "dependencies": {
-    "@my/ui": "*",
+    "@my/ui": "workspace:*",
     "@tamagui/animations-react-native": "latest",
     "@tamagui/colors": "latest",
     "@tamagui/font-inter": "latest",

--- a/starters/next-expo-solito/yarn.lock
+++ b/starters/next-expo-solito/yarn.lock
@@ -3141,7 +3141,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@my/ui@*, @my/ui@workspace:packages/ui":
+"@my/ui@workspace:*, @my/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@my/ui@workspace:packages/ui"
   dependencies:
@@ -6058,11 +6058,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"app@*, app@workspace:packages/app":
+"app@workspace:*, app@workspace:packages/app":
   version: 0.0.0-use.local
   resolution: "app@workspace:packages/app"
   dependencies:
-    "@my/ui": "*"
+    "@my/ui": "workspace:*"
     "@tamagui/animations-react-native": latest
     "@tamagui/colors": latest
     "@tamagui/font-inter": latest
@@ -9607,11 +9607,11 @@ __metadata:
     "@babel/core": ^7.17.9
     "@babel/runtime": ^7.18.9
     "@expo/metro-config": ^0.3.21
-    "@my/ui": "*"
+    "@my/ui": "workspace:*"
     "@react-navigation/native": ^6.1.6
     "@tamagui/babel-plugin": latest
     "@types/react-native": ^0.71.3
-    app: "*"
+    app: "workspace:*"
     babel-plugin-module-resolver: ^4.1.0
     babel-plugin-transform-inline-environment-variables: ^0.4.4
     burnt: ^0.10.0
@@ -14341,7 +14341,7 @@ __metadata:
     "@tamagui/next-plugin": latest
     "@tamagui/next-theme": latest
     "@types/node": ^18.6.4
-    app: "*"
+    app: "workspace:*"
     eslint-config-next: ^13.0.4
     next: ^13.2.4
     raf: ^3.4.1


### PR DESCRIPTION
https://yarnpkg.com/features/workspaces#workspace-ranges-workspace

I had some build issues where yarn was looking for package names in npm registry, when it should have been pulling a workspace.


using `workspaces:*` fixed the issue of npm checking a registry and 404'ing

### Steps
- `yarn` in root dir
-  `yarn watch` in root dir
- `yarn native` in root dir
- `yarn web` in root dir

both native:ios and web compile and run w/o issue.