### PR TITLE
Allow absolute path to tamagui config

### DIFF
--- a/packages/static/src/extractor/bundleConfig.ts
+++ b/packages/static/src/extractor/bundleConfig.ts
@@ -13,6 +13,7 @@ import { registerRequire } from '../require'
 import { TamaguiOptions } from '../types'
 import { babelParse } from './babelParse'
 import { bundle } from './bundle'
+import { getTamaguiConfigPathFromOptionsConfig } from './getTamaguiConfigPathFromOptionsConfig'
 
 let loggedOutputInfo = false
 
@@ -84,7 +85,9 @@ export async function bundleConfig(props: TamaguiOptions) {
   try {
     isBundling = true
 
-    const configEntry = props.config ? join(process.cwd(), props.config) : ''
+    const configEntry = props.config
+      ? getTamaguiConfigPathFromOptionsConfig(props.config)
+      : ''
     const tmpDir = join(process.cwd(), '.tamagui')
     const configOutPath = join(tmpDir, `tamagui.config.cjs`)
     const baseComponents = props.components.filter((x) => x !== '@tamagui/core')

--- a/packages/static/src/extractor/getTamaguiConfigPathFromOptionsConfig.ts
+++ b/packages/static/src/extractor/getTamaguiConfigPathFromOptionsConfig.ts
@@ -1,0 +1,13 @@
+import { isAbsolute, join } from 'path'
+
+import { TamaguiOptions } from '../types'
+
+export function getTamaguiConfigPathFromOptionsConfig(
+  config: NonNullable<TamaguiOptions['config']>
+) {
+  if (isAbsolute(config)) {
+    return config
+  }
+
+  return join(process.cwd(), config)
+}

--- a/packages/static/src/extractor/loadTamagui.ts
+++ b/packages/static/src/extractor/loadTamagui.ts
@@ -21,6 +21,7 @@ import {
   generateTamaguiStudioConfig,
   generateTamaguiStudioConfigSync,
 } from './generateTamaguiStudioConfig'
+import { getTamaguiConfigPathFromOptionsConfig } from './getTamaguiConfigPathFromOptionsConfig'
 
 const getFilledOptions = (propsIn: Partial<TamaguiOptions>): TamaguiOptions => ({
   // defaults
@@ -82,7 +83,7 @@ export function loadTamaguiSync(propsIn: TamaguiOptions): TamaguiProjectInfo {
       // config
       let tamaguiConfig: TamaguiInternalConfig | null = null
       if (props.config) {
-        const configPath = join(process.cwd(), props.config)
+        const configPath = getTamaguiConfigPathFromOptionsConfig(props.config)
         const exp = require(configPath)
         tamaguiConfig = (exp['default'] || exp) as TamaguiInternalConfig
         if (!tamaguiConfig || !tamaguiConfig.parsed) {

--- a/packages/static/src/require.ts
+++ b/packages/static/src/require.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, relative, sep } from 'path'
+import { relative, sep } from 'path'
 
 const nameToPaths = {}
 const Module = require('module')
@@ -98,7 +98,7 @@ ${err.stack}
 
 You can see if it loads in the node repl:
 
-require(${isAbsolute(path) ? path : `./${relative(process.cwd(), path)}`}").default
+require("./${relative(process.cwd(), path)}").default
 
 `
     )

--- a/packages/static/src/require.ts
+++ b/packages/static/src/require.ts
@@ -1,4 +1,4 @@
-import { relative, sep } from 'path'
+import { isAbsolute, relative, sep } from 'path'
 
 const nameToPaths = {}
 const Module = require('module')
@@ -98,7 +98,7 @@ ${err.stack}
 
 You can see if it loads in the node repl:
 
-require("./${relative(process.cwd(), path)}").default
+require(${isAbsolute(path) ? path : `./${relative(process.cwd(), path)}`}").default
 
 `
     )

--- a/packages/static/types/extractor/getTamaguiConfigPathFromOptionsConfig.d.ts
+++ b/packages/static/types/extractor/getTamaguiConfigPathFromOptionsConfig.d.ts
@@ -1,0 +1,3 @@
+import { TamaguiOptions } from '../types';
+export declare function getTamaguiConfigPathFromOptionsConfig(config: NonNullable<TamaguiOptions['config']>): string;
+//# sourceMappingURL=getTamaguiConfigPathFromOptionsConfig.d.ts.map


### PR DESCRIPTION
Updates logic to check if the path passed into the extractor is an absolute path, if it is, uses that directly instead of prepending the current working directory.

I wasn't able to get kitchen-sink or site running locally so if someone that is able to run those could please double check I didn't break this I would appreciate it 🙇 