### PR TITLE
accessibility improvement: native support web `aria-*` and `role`

### DIFF
--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -79,6 +79,7 @@ const ButtonFrame = styled(ThemeableStack, {
   tag: 'button',
   context: ButtonContext,
   focusable: true,
+  role: 'button',
 
   variants: {
     unstyled: {

--- a/packages/button/types/Button.d.ts
+++ b/packages/button/types/Button.d.ts
@@ -485,7 +485,9 @@ declare function useButton(propsIn: ButtonProps, { Text }?: {
         accessible?: boolean | undefined;
         accessibilityActions?: readonly Readonly<{
             name: string;
-            label?: string | undefined;
+            label?: string | undefined; /**
+             * @deprecated Instead of useButton, see the Button docs for the newer and much improved Advanced customization pattern: https://tamagui.dev/docs/components/button
+             */
         }>[] | undefined;
         accessibilityLabel?: string | undefined;
         'aria-label'?: string | undefined;
@@ -698,9 +700,6 @@ declare function useButton(propsIn: ButtonProps, { Text }?: {
         onResponderRelease?: ((event: import("react-native").GestureResponderEvent) => void) | undefined;
         onResponderStart?: ((event: import("react-native").GestureResponderEvent) => void) | undefined;
         onResponderTerminationRequest?: ((event: import("react-native").GestureResponderEvent) => boolean) | undefined;
-        /**
-         * @deprecated Instead of useButton, see the Button docs for the newer and much improved Advanced customization pattern: https://tamagui.dev/docs/components/button
-         */
         onResponderTerminate?: ((event: import("react-native").GestureResponderEvent) => void) | undefined;
         onStartShouldSetResponderCapture?: ((event: import("react-native").GestureResponderEvent) => boolean) | undefined;
         onMoveShouldSetResponderCapture?: ((event: import("react-native").GestureResponderEvent) => boolean) | undefined;

--- a/packages/web/src/constants/accessibilityDirectMap.native.tsx
+++ b/packages/web/src/constants/accessibilityDirectMap.native.tsx
@@ -1,0 +1,57 @@
+export const webToNativeAccessibilityDirectMap = {
+  'aria-label': 'accessibilityLabel',
+  'aria-labelledby': 'accessibilityLabelledBy',
+  'aria-live': 'accessibilityLiveRegion',
+  'aria-modal': 'accessibilityViewIsModal',
+  'aria-hidden': 'accessibilityElementsHidden',
+}
+export const nativeAccessibilityValue = {
+  'aria-valuemin': 'min',
+  'aria-valuemax': 'max',
+  'aria-valuenow': 'now',
+  'aria-valuetext': 'text',
+}
+
+export const nativeAccessibilityState = {
+  'aria-disabled': 'disabled',
+  'aria-selected': 'selected',
+  'aria-checked': 'checked',
+  'aria-busy': 'busy',
+  'aria-expanded': 'expanded',
+}
+
+// Note: left side is not alway web role, for example togglebutton
+export const accessibilityWebRoleToNativeRole = {
+  slider: 'adjustable',
+  heading: 'header',
+  img: 'image',
+  link: 'link',
+  presentation: 'none',
+  region: 'summary',
+  group: 'none',
+  alert: 'alert',
+  button: 'button',
+  checkbox: 'checkbox',
+  combobox: 'combobox',
+  imagebutton: 'imagebutton',
+  keyboardkey: 'keyboardkey',
+  menu: 'menu',
+  menubar: 'menubar',
+  menuitem: 'menuitem',
+  none: 'none',
+  progressbar: 'progressbar',
+  radio: 'radio',
+  radiogroup: 'radiogroup',
+  scrollbar: 'scrollbar',
+  searchbox: 'search',
+  spinbutton: 'spinbutton',
+  grid: 'grid',
+  summary: 'summary',
+  switch: 'switch',
+  tab: 'tab',
+  tablist: 'tablist',
+  text: 'text',
+  timer: 'timer',
+  toolbar: 'toolbar',
+  togglebutton: 'togglebutton',
+}

--- a/packages/web/src/constants/accessibilityDirectMap.tsx
+++ b/packages/web/src/constants/accessibilityDirectMap.tsx
@@ -50,24 +50,8 @@ if (process.env.TAMAGUI_TARGET === 'web') {
   }
 }
 
-export const webToNativeAccessibilityDirectMap = {
-  'aria-label': 'accessibilityLabel',
-  'aria-labelledby': 'accessibilityLabelledBy',
-  'aria-live': 'accessibilityLiveRegion',
-  'aria-modal': 'accessibilityViewIsModal',
-  'aria-hidden': 'accessibilityElementsHidden',
-}
-export const nativeAccessibilityValue = {
-  'aria-valuemin': 'min',
-  'aria-valuemax': 'max',
-  'aria-valuenow': 'now',
-  'aria-valuetext': 'text',
-}
+export const webToNativeAccessibilityDirectMap = null as unknown as Record<string, string>
+export const nativeAccessibilityValue = null as unknown as Record<string, string>
 
-export const nativeAccessibilityState = {
-  'aria-disabled': 'disabled',
-  'aria-selected': 'selected',
-  'aria-checked': 'checked',
-  'aria-busy': 'busy',
-  'aria-expanded': 'expanded',
-}
+export const nativeAccessibilityState = null as unknown as Record<string, string>
+export const accessibilityWebRoleToNativeRole = null as unknown as Record<string, string>

--- a/packages/web/src/constants/accessibilityDirectMap.tsx
+++ b/packages/web/src/constants/accessibilityDirectMap.tsx
@@ -49,3 +49,25 @@ if (process.env.TAMAGUI_TARGET === 'web') {
     accessibilityDirectMap[`accessibility${key}`] = `aria-${val}`
   }
 }
+
+export const webToNativeAccessibilityDirectMap = {
+  'aria-label': 'accessibilityLabel',
+  'aria-labelledby': 'accessibilityLabelledBy',
+  'aria-live': 'accessibilityLiveRegion',
+  'aria-modal': 'accessibilityViewIsModal',
+  'aria-hidden': 'accessibilityElementsHidden',
+}
+export const nativeAccessibilityValue = {
+  'aria-valuemin': 'min',
+  'aria-valuemax': 'max',
+  'aria-valuenow': 'now',
+  'aria-valuetext': 'text',
+}
+
+export const nativeAccessibilityState = {
+  'aria-disabled': 'disabled',
+  'aria-selected': 'selected',
+  'aria-checked': 'checked',
+  'aria-busy': 'busy',
+  'aria-expanded': 'expanded',
+}

--- a/packages/web/src/helpers/getSplitStyles.tsx
+++ b/packages/web/src/helpers/getSplitStyles.tsx
@@ -19,6 +19,7 @@ import { useInsertionEffect } from 'react'
 import { getConfig, getFont } from '../config'
 import {
   accessibilityDirectMap,
+  accessibilityWebRoleToNativeRole,
   nativeAccessibilityState,
   nativeAccessibilityValue,
   webToNativeAccessibilityDirectMap,
@@ -282,8 +283,10 @@ export const getSplitStyles: StyleSplitter = (
           if (valInit === 'list') {
             // role = "list"
             viewProps[keyInit] = valInit
-          } else if (accessibilityAriaRoleToNativeRole[valInit]) {
-            viewProps['accessibilityRole'] = accessibilityAriaRoleToNativeRole[valInit]
+          } else if (accessibilityWebRoleToNativeRole[valInit]) {
+            viewProps['accessibilityRole'] = accessibilityWebRoleToNativeRole[
+              valInit
+            ] as GetStyleResult['viewProps']['AccessibilityRole']
           }
           return
         }
@@ -1346,40 +1349,4 @@ const accessibilityRoleToWebRole = {
   link: 'link',
   none: 'presentation',
   summary: 'region',
-}
-
-// Note: left side is not alway web role, for example togglebutton
-const accessibilityAriaRoleToNativeRole = {
-  slider: 'adjustable',
-  heading: 'header',
-  img: 'image',
-  link: 'link',
-  presentation: 'none',
-  region: 'summary',
-  group: 'none',
-  alert: 'alert',
-  button: 'button',
-  checkbox: 'checkbox',
-  combobox: 'combobox',
-  imagebutton: 'imagebutton',
-  keyboardkey: 'keyboardkey',
-  menu: 'menu',
-  menubar: 'menubar',
-  menuitem: 'menuitem',
-  none: 'none',
-  progressbar: 'progressbar',
-  radio: 'radio',
-  radiogroup: 'radiogroup',
-  scrollbar: 'scrollbar',
-  searchbox: 'search',
-  spinbutton: 'spinbutton',
-  grid: 'grid',
-  summary: 'summary',
-  switch: 'switch',
-  tab: 'tab',
-  tablist: 'tablist',
-  text: 'text',
-  timer: 'timer',
-  toolbar: 'toolbar',
-  togglebutton: 'togglebutton',
 }

--- a/packages/web/types/constants/accessibilityDirectMap.d.ts
+++ b/packages/web/types/constants/accessibilityDirectMap.d.ts
@@ -1,2 +1,22 @@
 export declare const accessibilityDirectMap: Record<string, string>;
+export declare const webToNativeAccessibilityDirectMap: {
+    'aria-label': string;
+    'aria-labelledby': string;
+    'aria-live': string;
+    'aria-modal': string;
+    'aria-hidden': string;
+};
+export declare const nativeAccessibilityValue: {
+    'aria-valuemin': string;
+    'aria-valuemax': string;
+    'aria-valuenow': string;
+    'aria-valuetext': string;
+};
+export declare const nativeAccessibilityState: {
+    'aria-disabled': string;
+    'aria-selected': string;
+    'aria-checked': string;
+    'aria-busy': string;
+    'aria-expanded': string;
+};
 //# sourceMappingURL=accessibilityDirectMap.d.ts.map

--- a/packages/web/types/constants/accessibilityDirectMap.d.ts
+++ b/packages/web/types/constants/accessibilityDirectMap.d.ts
@@ -1,22 +1,6 @@
 export declare const accessibilityDirectMap: Record<string, string>;
-export declare const webToNativeAccessibilityDirectMap: {
-    'aria-label': string;
-    'aria-labelledby': string;
-    'aria-live': string;
-    'aria-modal': string;
-    'aria-hidden': string;
-};
-export declare const nativeAccessibilityValue: {
-    'aria-valuemin': string;
-    'aria-valuemax': string;
-    'aria-valuenow': string;
-    'aria-valuetext': string;
-};
-export declare const nativeAccessibilityState: {
-    'aria-disabled': string;
-    'aria-selected': string;
-    'aria-checked': string;
-    'aria-busy': string;
-    'aria-expanded': string;
-};
+export declare const webToNativeAccessibilityDirectMap: Record<string, string>;
+export declare const nativeAccessibilityValue: Record<string, string>;
+export declare const nativeAccessibilityState: Record<string, string>;
+export declare const accessibilityWebRoleToNativeRole: Record<string, string>;
 //# sourceMappingURL=accessibilityDirectMap.d.ts.map

--- a/packages/web/types/constants/accessibilityDirectMap.native.d.ts
+++ b/packages/web/types/constants/accessibilityDirectMap.native.d.ts
@@ -1,0 +1,55 @@
+export declare const webToNativeAccessibilityDirectMap: {
+    'aria-label': string;
+    'aria-labelledby': string;
+    'aria-live': string;
+    'aria-modal': string;
+    'aria-hidden': string;
+};
+export declare const nativeAccessibilityValue: {
+    'aria-valuemin': string;
+    'aria-valuemax': string;
+    'aria-valuenow': string;
+    'aria-valuetext': string;
+};
+export declare const nativeAccessibilityState: {
+    'aria-disabled': string;
+    'aria-selected': string;
+    'aria-checked': string;
+    'aria-busy': string;
+    'aria-expanded': string;
+};
+export declare const accessibilityWebRoleToNativeRole: {
+    slider: string;
+    heading: string;
+    img: string;
+    link: string;
+    presentation: string;
+    region: string;
+    group: string;
+    alert: string;
+    button: string;
+    checkbox: string;
+    combobox: string;
+    imagebutton: string;
+    keyboardkey: string;
+    menu: string;
+    menubar: string;
+    menuitem: string;
+    none: string;
+    progressbar: string;
+    radio: string;
+    radiogroup: string;
+    scrollbar: string;
+    searchbox: string;
+    spinbutton: string;
+    grid: string;
+    summary: string;
+    switch: string;
+    tab: string;
+    tablist: string;
+    text: string;
+    timer: string;
+    toolbar: string;
+    togglebutton: string;
+};
+//# sourceMappingURL=accessibilityDirectMap.native.d.ts.map


### PR DESCRIPTION
as most of the core Tamagui components are using `aria-*` and `role` for accessibility, it means that accessibility is mostly broken in native, in this PR it's mapping those web-specific aria and role props to its React Native counterpart.