### PR TITLE
fix turbo dev run expo

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "format": "node -r esbuild-register ./scripts/format.ts",
     "pretty": "pretty-quick",
     "test": "CLEANUP=1 turbo run --concurrency=1 test",
-    "test:ci": "turbo test --concurrency=1",
+    "test:ci": "turbo test --concurrency=2",
     "test:demos": "yarn workspace @tamagui/demos test",
     "release": "node -r esbuild-register ./scripts/release.ts",
     "release:canary": "yarn release --canary --ci",

--- a/starters/next-expo-solito/apps/expo/package.json
+++ b/starters/next-expo-solito/apps/expo/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "start": "TAMAGUI_TARGET=native npx expo start -c",
+    "dev": "TAMAGUI_TARGET=native npx expo start -c",
     "android": "TAMAGUI_TARGET=native npx expo run:android",
     "ios": "TAMAGUI_TARGET=native npx expo run:ios",
     "eject": "npx expo eject"


### PR DESCRIPTION
currently `turbo run dev` doesn't run expo

change start to dev, turbo now runs expo

reproduction:
`turbo run dev` web and expo servers start
