### PR TITLE
fix(component theme): nested theme component now take correct theme a…

### DIFF
--- a/packages/core-test/ThemeManager.web.test.tsx
+++ b/packages/core-test/ThemeManager.web.test.tsx
@@ -171,6 +171,7 @@ describe('ThemeManager', () => {
     expect(newState).toMatchInlineSnapshot(`
       {
         "className": "t_sub_theme t_dark",
+        "componentName": undefined,
         "name": "dark",
         "parentName": "",
         "theme": {

--- a/packages/web/src/helpers/ThemeManager.tsx
+++ b/packages/web/src/helpers/ThemeManager.tsx
@@ -39,6 +39,7 @@ export class ThemeManager {
   parentManager: ThemeManager | null = null
   state: ThemeManagerState = emptyState
   scheme: 'light' | 'dark' | null = null
+  componentName = undefined as undefined | string
 
   constructor(
     public props: ThemeProps = {},
@@ -47,6 +48,9 @@ export class ThemeManager {
     if (parentManagerIn === 'root') {
       this.updateState(props, false)
       return
+    }
+    if (props.componentName) {
+      this.componentName = props.componentName
     }
 
     if (!parentManagerIn) {
@@ -76,6 +80,7 @@ export class ThemeManager {
     props: ThemeProps & { forceTheme?: ThemeParsed } = this.props || {},
     shouldNotify = true
   ) {
+    props = { ...props, componentName: this.componentName }
     const isChanging = (() => {
       if (props.forceTheme) {
         this.state.theme = props.forceTheme

--- a/packages/web/src/helpers/ThemeManager.tsx
+++ b/packages/web/src/helpers/ThemeManager.tsx
@@ -22,6 +22,7 @@ export type ThemeManagerState = {
   theme?: ThemeParsed | null
   className?: string
   parentName?: string
+  componentName?: string
 }
 
 const emptyState: ThemeManagerState = { name: '' }
@@ -39,7 +40,6 @@ export class ThemeManager {
   parentManager: ThemeManager | null = null
   state: ThemeManagerState = emptyState
   scheme: 'light' | 'dark' | null = null
-  componentName = undefined as undefined | string
 
   constructor(
     public props: ThemeProps = {},
@@ -48,9 +48,6 @@ export class ThemeManager {
     if (parentManagerIn === 'root') {
       this.updateState(props, false)
       return
-    }
-    if (props.componentName) {
-      this.componentName = props.componentName
     }
 
     if (!parentManagerIn) {
@@ -80,7 +77,6 @@ export class ThemeManager {
     props: ThemeProps & { forceTheme?: ThemeParsed } = this.props || {},
     shouldNotify = true
   ) {
-    props = { ...props, componentName: this.componentName }
     const isChanging = (() => {
       if (props.forceTheme) {
         this.state.theme = props.forceTheme
@@ -330,6 +326,7 @@ function getState(
         theme: getThemeUnwrapped(themes[found]),
         className: getNextThemeClassName(found, props),
         parentName,
+        componentName,
       }
       break
     }

--- a/packages/web/types/helpers/ThemeManager.d.ts
+++ b/packages/web/types/helpers/ThemeManager.d.ts
@@ -22,6 +22,7 @@ export declare class ThemeManager {
     parentManager: ThemeManager | null;
     state: ThemeManagerState;
     scheme: 'light' | 'dark' | null;
+    componentName: string | undefined;
     constructor(props?: ThemeProps, parentManagerIn?: ThemeManager | 'root' | null | undefined);
     updateState(props?: ThemeProps & {
         forceTheme?: ThemeParsed;

--- a/packages/web/types/helpers/ThemeManager.d.ts
+++ b/packages/web/types/helpers/ThemeManager.d.ts
@@ -12,6 +12,7 @@ export type ThemeManagerState = {
     theme?: ThemeParsed | null;
     className?: string;
     parentName?: string;
+    componentName?: string;
 };
 export declare function getHasThemeUpdatingProps(props: ThemeProps): string | boolean | undefined;
 export declare class ThemeManager {
@@ -22,7 +23,6 @@ export declare class ThemeManager {
     parentManager: ThemeManager | null;
     state: ThemeManagerState;
     scheme: 'light' | 'dark' | null;
-    componentName: string | undefined;
     constructor(props?: ThemeProps, parentManagerIn?: ThemeManager | 'root' | null | undefined);
     updateState(props?: ThemeProps & {
         forceTheme?: ThemeParsed;


### PR DESCRIPTION
Nested component themes ignore their parent after switching light/dark mode.
fixed in this PR
   