### PR TITLE
sandbox example of bug

### DIFF
--- a/apps/kitchen-sink/src/Sandbox.tsx
+++ b/apps/kitchen-sink/src/Sandbox.tsx
@@ -1,4 +1,64 @@
-import { H1 } from 'tamagui'
+import { useState } from 'react'
+import { Button, H1, Stack, styled, useProps } from 'tamagui'
+
+const Frame = styled(Stack, {
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexDirection: 'row',
+  gap: '$1',
+
+  paddingVertical: '$2',
+  paddingHorizontal: '$4',
+
+  outlineWidth: 0,
+
+  // this fixes a flex bug where it overflows container
+  minWidth: 0,
+  height: '$10',
+
+  borderWidth: 5,
+  borderRadius: '$10',
+  variants: {
+    isError: {
+      true: {
+        borderBottomRightRadius: 0,
+        borderBottomLeftRadius: 0,
+        // borderBottomEndRadius: 0,
+        // borderBottomRightRadius: 0,
+        // borderWidth: 0,
+        borderBottomWidth: 0,
+
+        hoverStyle: {
+          borderBottomWidth: 0,
+        },
+      },
+    },
+
+    isInvalid: {
+      true: {
+        borderColor: '$red10',
+        borderWidth: 5,
+
+        hoverStyle: {
+          borderColor: '$red10',
+          borderWidth: 5,
+        },
+      },
+    },
+
+    isFocused: {
+      true: {
+        borderColor: '$green10',
+        borderWidth: 10,
+      },
+    },
+  } as const,
+})
+
+const FrameContainer = Frame.styleable((propsIn, ref) => {
+  const props = useProps(propsIn)
+  return <Frame ref={ref} {...props} />
+})
 
 // TODO this is a great test: media + animation + space (test without animation too)
 // <Stack
@@ -20,5 +80,36 @@ import { H1 } from 'tamagui'
 //     </Stack>
 
 export const Sandbox = () => {
-  return <H1>test things here</H1>
+  const [isError, setIsError] = useState(false)
+  const [isFocus, setIsFocus] = useState(false)
+  const [isInvalid, setIsInvalid] = useState(false)
+  return (
+    <Stack>
+      <Button onPress={() => setIsInvalid(!isInvalid)}>
+        Toggle invalid {isInvalid ? 'true' : 'false'}
+      </Button>
+      <Button onPress={() => setIsError(!isError)}>
+        Toggle error {isError ? 'true' : 'false'}
+      </Button>
+      <Button onPress={() => setIsFocus(!isFocus)}>
+        Toggle focus {isFocus ? 'true' : 'false'}
+      </Button>
+      <FrameContainer
+        width={200}
+        height={200}
+        bg="$blue10"
+        isFocused={isFocus}
+        isInvalid={isInvalid || isError}
+        isError={isError}
+      />
+      <Frame
+        width={200}
+        height={200}
+        bg="$blue10"
+        isFocused={isFocus}
+        isInvalid={isInvalid || isError}
+        isError={isError}
+      />
+    </Stack>
+  )
 }

--- a/apps/kitchen-sink/src/Sandbox.tsx
+++ b/apps/kitchen-sink/src/Sandbox.tsx
@@ -1,11 +1,33 @@
-import { useState } from 'react'
-import { Button, H1, Stack, styled, useProps } from 'tamagui'
+import { forwardRef, useState } from 'react'
+import {
+  Button,
+  GetProps,
+  H1,
+  Stack,
+  TamaguiElement,
+  Text,
+  XStack,
+  createStyledContext,
+  styled,
+  useProps,
+  withStaticProperties,
+} from 'tamagui'
+
+const StyledContext = createStyledContext({
+  isInvalid: false,
+  isError: false,
+  isFocused: false,
+})
 
 const Frame = styled(Stack, {
+  context: StyledContext,
   alignItems: 'center',
   justifyContent: 'center',
   flexDirection: 'row',
   gap: '$1',
+  w: 100,
+  h: 100,
+  bg: '$blue10',
 
   paddingVertical: '$2',
   paddingHorizontal: '$4',
@@ -60,6 +82,18 @@ const FrameContainer = Frame.styleable((propsIn, ref) => {
   return <Frame ref={ref} {...props} />
 })
 
+const ForwardRefContainer = forwardRef<TamaguiElement, GetProps<typeof Frame>>(
+  (propsIn, ref) => {
+    return (
+      <Stack>
+        <Frame ref={ref} {...propsIn} />
+      </Stack>
+    )
+  }
+)
+
+const ContainerWithStaticProperty = withStaticProperties(ForwardRefContainer, {})
+
 // TODO this is a great test: media + animation + space (test without animation too)
 // <Stack
 //       animation="bouncy"
@@ -94,22 +128,48 @@ export const Sandbox = () => {
       <Button onPress={() => setIsFocus(!isFocus)}>
         Toggle focus {isFocus ? 'true' : 'false'}
       </Button>
-      <FrameContainer
-        width={200}
-        height={200}
-        bg="$blue10"
-        isFocused={isFocus}
-        isInvalid={isInvalid || isError}
-        isError={isError}
-      />
-      <Frame
-        width={200}
-        height={200}
-        bg="$blue10"
-        isFocused={isFocus}
-        isInvalid={isInvalid || isError}
-        isError={isError}
-      />
+      <XStack>
+        <Stack>
+          <Text>With Styled Context</Text>
+          <StyledContext.Provider
+            isFocused={isFocus}
+            isInvalid={isInvalid || isError}
+            isError={isError}
+          >
+            <Stack>
+              <FrameContainer />
+              <ContainerWithStaticProperty />
+              <Frame />
+              <ForwardRefContainer />
+            </Stack>
+          </StyledContext.Provider>
+        </Stack>
+        <Stack>
+          <Text>Without Styled Context</Text>
+          <Stack>
+            <FrameContainer
+              isFocused={isFocus}
+              isInvalid={isInvalid || isError}
+              isError={isError}
+            />
+            <ContainerWithStaticProperty
+              isFocused={isFocus}
+              isInvalid={isInvalid || isError}
+              isError={isError}
+            />
+            <Frame
+              isFocused={isFocus}
+              isInvalid={isInvalid || isError}
+              isError={isError}
+            />
+            <ForwardRefContainer
+              isFocused={isFocus}
+              isInvalid={isInvalid || isError}
+              isError={isError}
+            />
+          </Stack>
+        </Stack>
+      </XStack>
     </Stack>
   )
 }


### PR DESCRIPTION
Not sure if this is a bug actually or if I am misunderstanding when I should use `styleable`. 

For the most part, I used `styleable` in place of `forwardRef` where I did not have to type out the props as much but that is probably short sighted.

Anywho, the sandbox shows something I am dealing with where certain CSS properties are inconsistent between using in a wrapped component with `styleable` and without it. My actual usage is much more complex and a work around might be to use `forwardRef` instead but figure I would bring this up in case this should be working.

![image](https://github.com/tamagui/tamagui/assets/88064187/1d05abf8-9ab3-4fd7-9846-69cc9119c1b6)
