### PR TITLE
docs: add missing `indeterminate` type to `onCheckedChange` callback

### DIFF
--- a/apps/site/data/docs/components/checkbox/1.3.0.mdx
+++ b/apps/site/data/docs/components/checkbox/1.3.0.mdx
@@ -89,7 +89,8 @@ export default () => (
     },
     {
       name: 'onCheckedChange',
-      type: '(checked: boolean) => void',
+      type: '(checked: boolean | "indeterminate") => void',
+      description: "Callback that fires when the checkbox state is changed."
     },
     {
       name: 'sizeAdjust',


### PR DESCRIPTION
![image](https://github.com/tamagui/tamagui/assets/30611343/5b4d4eb7-6e78-4913-a4e8-eb8c152967b6)
