### PR TITLE
fix(label): vertical alignment inconsistency between web and native

### DIFF
--- a/packages/label/src/Label.tsx
+++ b/packages/label/src/Label.tsx
@@ -43,10 +43,11 @@ export const LabelFrame = styled(SizableText, {
     size: {
       '...size': (val, extras) => {
         const buttonStyle = getButtonSized(val, extras)
+        const fontStyle = getFontSized(val, extras)
+
         return {
-          ...getFontSized(val, extras),
-          height: buttonStyle.height,
-          lineHeight: buttonStyle.height,
+          ...fontStyle,
+          lineHeight: extras.tokens.size[buttonStyle.height],
         }
       },
     },


### PR DESCRIPTION
<img width="1033" alt="Screenshot 2023-06-15 at 5 37 55 PM" src="https://github.com/tamagui/tamagui/assets/35243344/25b664c4-2fef-4712-9fa5-e14a278b60a3">


Got rid of height in order to fix the vertical alignment issue mentioned in #1298 

The fix assumes tokens between font and size match, but it was assumed prior to this anyways.

Closes #1298 
