### PR TITLE
fix(native): update theme native fix

### DIFF
--- a/packages/demos/src/UpdateThemeDemo.tsx
+++ b/packages/demos/src/UpdateThemeDemo.tsx
@@ -2,7 +2,9 @@ import * as Config from '@tamagui/config'
 import { addTheme, updateTheme } from '@tamagui/theme'
 import React, { useState } from 'react'
 import {
+  Adapt,
   Button,
+  Popover,
   Square,
   Theme,
   XStack,
@@ -55,6 +57,63 @@ export function UpdateThemeDemo() {
       >
         Set to random color
       </Button>
+
+      <Popover size="$5" allowFlip>
+        <Popover.Trigger asChild>
+          <Button>Set a specific Color</Button>
+        </Popover.Trigger>
+
+        <Adapt when="sm" platform="touch">
+          <Popover.Sheet modal dismissOnSnapToBottom>
+            <Popover.Sheet.Frame padding="$4">
+              <Adapt.Contents />
+            </Popover.Sheet.Frame>
+            <Popover.Sheet.Overlay />
+          </Popover.Sheet>
+        </Adapt>
+
+        <Popover.Content
+          borderWidth={1}
+          borderColor="$borderColor"
+          enterStyle={{ x: 0, y: -10, opacity: 0 }}
+          exitStyle={{ x: 0, y: -10, opacity: 0 }}
+          x={0}
+          y={0}
+          opacity={1}
+          animation={[
+            'quick',
+            {
+              opacity: {
+                overshootClamping: true,
+              },
+            },
+          ]}
+          elevate
+        >
+          <Popover.Arrow borderWidth={1} borderColor="$borderColor" />
+          <Popover.ScrollView>
+            <XStack flexWrap="wrap" gap={'$1.5'} flexBasis={10}>
+              {Object.values(colors).map((color) => (
+                <Popover.Close key={color.key} asChild>
+                  <Button
+                    size={'$3'}
+                    backgroundColor={color.val}
+                    onPress={() => {
+                      updateTheme({
+                        name: 'custom',
+                        theme: {
+                          color: color.val,
+                        },
+                      })
+                      update()
+                    }}
+                  />
+                </Popover.Close>
+              ))}
+            </XStack>
+          </Popover.ScrollView>
+        </Popover.Content>
+      </Popover>
     </YStack>
   )
 }

--- a/packages/web/src/hooks/useTheme.tsx
+++ b/packages/web/src/hooks/useTheme.tsx
@@ -333,7 +333,7 @@ export const useChangeThemeEffect = (
         if (nextState) {
           state = nextState
 
-          if (!prev.isNewTheme || !isWeb) {
+          if (!prev.isNewTheme && !isWeb) {
             themeManager = getNewThemeManager()
           } else {
             themeManager.updateState(nextState, true)


### PR DESCRIPTION
Fixes a bug on native where `updateTheme` and `replaceTheme` are always one render behind. On Web this bug doesn't exist as it was using a slightly different codepath (updating themeManager instead of getting a new one).

You can see below the "Set Random Color" example for `updateTheme` doesn't update the color on the second tap. Every tap after that is one color behind what it should be.

To make this kind of issue a bit more obvious moving forward I have added an extra button to this demo to be able to choose a specific color instead of serving up a random color.

Before:

https://github.com/tamagui/tamagui/assets/2300298/b3cdcca8-86f8-42de-a193-20e7364a9f44


After:


https://github.com/tamagui/tamagui/assets/2300298/8a87c5e4-f9b5-4553-9ddb-3cb0bae06492

As you can see in the example above once choosing a color every update after that is one color behind. Selecting specific colors we can see that the color is being set to the previous selection when choosing a new one.

## Related Commit
- https://github.com/tamagui/tamagui/commit/6a2bbbe22f2f2ac0c5e2f6ad690a910c5515294f#diff-a10873264f8621767da1544f171064b33baa1db11a14ec9e875e2d30a9ed8c4cR289
- https://github.com/tamagui/tamagui/commit/8e1b20c5bf4a8c7bb774fbc319d5638660e9ae28#diff-a10873264f8621767da1544f171064b33baa1db11a14ec9e875e2d30a9ed8c4c

## Disclaimer

I tried my best to test as many situations as I could, however I am fairly new to this codebase. Not sure I have full context into the side effects of this change.