### PR TITLE
Added a section in readme about dev build for kitchen-sink.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,19 @@ yarn sandbox
 
 This runs a client-side only vite build of tamagui, with a complete configuration already set up.
 
-To test on native, `kitchen-sink` is equally light weight and well set up:
+To test on native, `kitchen-sink` is equally light weight and well set up.
+
+You'll need to create a [development build](https://docs.expo.dev/develop/development-builds/create-a-build/) to run this.
+
+```
+# Android
+yarn kitchen-sink:build:android
+
+# iOS
+yarn kitchen-sink:build:ios
+```
+
+After the build has been completed, run:
 
 ```
 yarn kitchen-sink

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "fix": "yarn manypkg fix",
     "format": "node -r esbuild-register ./scripts/format.ts",
     "git-crypt-unlock": "./scripts/git-crypt-unlock.sh",
+    "kitchen-sink:build:android": "yarn workspace @tamagui/kitchen-sink android",
+    "kitchen-sink:build:ios": "yarn workspace @tamagui/kitchen-sink ios",
     "kitchen-sink:android": "yarn workspace @tamagui/kitchen-sink start:android",
     "kitchen-sink:clean": "yarn workspace @tamagui/kitchen-sink start:clean",
     "kitchen-sink:extract": "yarn workspace @tamagui/kitchen-sink start:extract",


### PR DESCRIPTION
The user needs to create a development build to run kitchen-sink (custom metro bundler). This step isn't included in the Readme. Added a new script to create a development build and then included these in the docs.