### PR TITLE
fix margin vertical shorthand

### DIFF
--- a/packages/shorthands/src/index.tsx
+++ b/packages/shorthands/src/index.tsx
@@ -64,7 +64,7 @@ export const shorthands = {
   mr: 'marginRight',
   mt: 'marginTop',
   mx: 'marginHorizontal',
-  my: 'marginVertical',
+  mv: 'marginVertical',
   o: 'opacity',
   ov: 'overflow',
   p: 'padding',


### PR DESCRIPTION
assuming this a typo, and should be `mv` not `my`
