### PR TITLE
Fix typo on 'useTheme — Tamagui Core' documentation

### DIFF
--- a/apps/site/data/docs/core/use-theme.mdx
+++ b/apps/site/data/docs/core/use-theme.mdx
@@ -34,7 +34,7 @@ into the type `ThemeParsed`, which maps the values in the object to type `Variab
     isVar: true,
   },
   color: {
-    val: '#fff,
+    val: '#fff',
     variable: 'var(--color)',
     name: 'color',
     isVar: true,


### PR DESCRIPTION
A code snippet had an unclosed single quote