### PR TITLE
fix(TextArea): firefox newline doesn't work issue

### DIFF
--- a/packages/tamagui/src/views/TextArea.tsx
+++ b/packages/tamagui/src/views/TextArea.tsx
@@ -10,6 +10,8 @@ import { InputFrame, InputProps, defaultStyles, useInputProps } from './Input'
 export const TextAreaFrame = styled(InputFrame, {
   name: 'TextArea',
   multiline: true,
+  // this attribute will fix firefox newline issue
+  whiteSpace: 'pre-wrap',
 
   variants: {
     unstyled: {


### PR DESCRIPTION
fix #1370 