### PR TITLE
docs(site): fix mdx typo

### DIFF
--- a/apps/site/data/docs/core/use-theme.mdx
+++ b/apps/site/data/docs/core/use-theme.mdx
@@ -180,7 +180,7 @@ You can `useTheme()` (and `useMedia()`) at runtime. Like useMedia, useTheme will
 
 If you access `theme.bg.val` in your render function, the component will only re-render when theme.bg changes.
 
-````tsx
+```tsx
 import { theme, Stack } from '@tamagui/core'
 
 export default () => {
@@ -203,7 +203,7 @@ This is a more advanced use for building custom hooks or components, but you can
 function MyComponent(props) {
   const theme = useTheme(props.theme, 'MyComponent')
 }
-````
+```
 
 For example, if you have the following themes:
 


### PR DESCRIPTION
Additional backticks in mdx causing formatting issues on docs site at https://tamagui.dev/docs/core/use-theme. 


**Before:** 

<img width="400" alt="Screen Shot 2023-07-20 at 09 54 44" src="https://github.com/tamagui/tamagui/assets/55989505/b819859d-062a-4f5d-a515-370260d0758a">


**After:** 

<img width="400" alt="Screen Shot 2023-07-20 at 09 55 06" src="https://github.com/tamagui/tamagui/assets/55989505/96cb8cba-a7eb-4894-8def-84963529d3d7">
