### PR TITLE
fix: add babel plugin details to setup doc

### DIFF
--- a/apps/site/data/docs/intro/installation.mdx
+++ b/apps/site/data/docs/intro/installation.mdx
@@ -144,7 +144,7 @@ module.exports = {
     [
       "@tamagui/babel-plugin",
       { components: ["tamagui"], config: "./tamagui.config.ts" },
-     ],
+    ],
   ]
 }
 ```

--- a/apps/site/data/docs/intro/installation.mdx
+++ b/apps/site/data/docs/intro/installation.mdx
@@ -140,7 +140,7 @@ module.exports = {
   plugins: [
     ['transform-inline-environment-variables', {
       include: ['TAMAGUI_TARGET']
-    }]
+    }],
     [
       "@tamagui/babel-plugin",
       { components: ["tamagui"], config: "./tamagui.config.ts" },

--- a/apps/site/data/docs/intro/installation.mdx
+++ b/apps/site/data/docs/intro/installation.mdx
@@ -141,6 +141,10 @@ module.exports = {
     ['transform-inline-environment-variables', {
       include: ['TAMAGUI_TARGET']
     }]
+    [
+      "@tamagui/babel-plugin",
+      { components: ["tamagui"], config: "./tamagui.config.ts" },
+     ],
   ]
 }
 ```


### PR DESCRIPTION
The docs tell you to add the babel plugin to the babel config but without telling you how. Added in an example from the example app