### PR TITLE
fix(RadioGroup): RadioGroupItemFrame uses active theme when checked

### DIFF
--- a/packages/radio-group/src/RadioGroup.tsx
+++ b/packages/radio-group/src/RadioGroup.tsx
@@ -267,7 +267,7 @@ const RadioGroupItem = RadioGroupItemFrame.extractable(
           ) : (
             <>
               <RadioGroupItemFrame
-                // theme={checked ? 'active' : undefined}
+                theme={checked ? 'active' : null}
                 data-state={getState(checked)}
                 data-disabled={isDisabled ? '' : undefined}
                 role="radio"


### PR DESCRIPTION
Enabling active theme lets the RadioGroupItemFrame be themed differently than the base component when checked.