### PR TITLE
fix: expose possible null value in createStyledContext types

### DIFF
--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -38,6 +38,14 @@ export const ButtonContext = createStyledContext<
   textAlign: undefined,
 })
 
+const useButtonContext = () => {
+  const value = useContext(ButtonContext)
+  if (value === null) {
+    throw new Error('useButtonContext must be used within a ButtonContext.Provider')
+  }
+  return value
+}
+
 type ButtonIconProps = { color?: string; size?: number }
 type IconProp = JSX.Element | FunctionComponent<ButtonIconProps> | null
 
@@ -145,7 +153,7 @@ const ButtonText = styled(SizableText, {
 
 const ButtonIcon = (props: { children: React.ReactNode; scaleIcon?: number }) => {
   const { children, scaleIcon = 1 } = props
-  const { size, color } = useContext(ButtonContext)
+  const { size, color } = useButtonContext()
   const iconSize =
     (typeof size === 'number' ? size * 0.5 : getFontSize(size as FontSizeTokens)) *
     scaleIcon

--- a/packages/checkbox/src/Checkbox.tsx
+++ b/packages/checkbox/src/Checkbox.tsx
@@ -32,6 +32,16 @@ export const CheckboxStyledContext = createStyledContext({
   scaleIcon: 1,
 })
 
+const useCheckboxStyledContext = () => {
+  const value = React.useContext(CheckboxStyledContext)
+  if (value === null) {
+    throw new Error(
+      'useCheckboxStyledContext must be used within a CheckboxStyledContext.Provider'
+    )
+  }
+  return value
+}
+
 export type CheckedState = boolean | 'indeterminate'
 
 export function isIndeterminate(checked?: CheckedState): checked is 'indeterminate' {
@@ -140,7 +150,7 @@ const CheckboxIndicator = CheckboxIndicatorFrame.extractable(
         ...indicatorProps
       } = props
       const context = useCheckboxContext(INDICATOR_NAME, __scopeCheckbox)
-      const styledContext = React.useContext(CheckboxStyledContext)
+      const styledContext = useCheckboxStyledContext()
       const iconSize =
         (typeof styledContext.size === 'number'
           ? styledContext.size * 0.65
@@ -288,8 +298,7 @@ const CheckboxComponent = CheckboxFrame.extractable(
       onChange: onCheckedChange,
     })
 
-    // TODO: this could be null - fix the type
-    const styledContext = React.useContext(CheckboxStyledContext)
+    const styledContext = useCheckboxStyledContext()
     const adjustedSize = getVariableValue(
       getSize(propsActive.size ?? styledContext?.size ?? '$true', {
         shift: sizeAdjust,

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -76,7 +76,13 @@ type PopoverContextValue = {
 
 export const PopoverContext = createStyledContext<PopoverContextValue>({} as any)
 
-export const usePopoverContext = () => React.useContext(PopoverContext)
+export const usePopoverContext = () => {
+  const value = React.useContext(PopoverContext)
+  if (value === null) {
+    throw new Error('usePopoverContext must be used within a PopoverContext.Provider')
+  }
+  return value
+}
 
 /* -------------------------------------------------------------------------------------------------
  * PopoverAnchor

--- a/packages/popper/src/Popper.tsx
+++ b/packages/popper/src/Popper.tsx
@@ -51,7 +51,13 @@ export type PopperContextValue = UseFloatingReturn & {
 
 export const PopperContext = createStyledContext<PopperContextValue>({} as any)
 
-export const usePopperContext = () => React.useContext(PopperContext)
+export const usePopperContext = () => {
+  const value = React.useContext(PopperContext)
+  if (value === null) {
+    throw new Error('usePopperContext must be used within a PopperContext.Provider')
+  }
+  return value
+}
 
 export type PopperProps = {
   size?: SizeTokens

--- a/packages/web/src/helpers/createStyledContext.tsx
+++ b/packages/web/src/helpers/createStyledContext.tsx
@@ -3,10 +3,10 @@ import React, { createContext, useContext, useMemo } from 'react'
 import { objectIdentityKey } from './objectIdentityKey'
 
 export type StyledContext<Props extends Object = any> = Omit<
-  React.Context<Props>,
+  React.Context<Props | null>,
   'Provider'
 > & {
-  context: React.Context<Props>
+  context: React.Context<Props | null>
   props: Object
   Provider: React.ProviderExoticComponent<
     Partial<Props> & {
@@ -18,7 +18,7 @@ export type StyledContext<Props extends Object = any> = Omit<
 export function createStyledContext<VariantProps extends Record<string, any>>(
   props: VariantProps
 ): StyledContext<VariantProps> {
-  const OGContext = createContext<any>(null)
+  const OGContext = createContext<VariantProps | null>(null)
   const OGProvider = OGContext.Provider
   const Context = OGContext as any as StyledContext<VariantProps>
 
@@ -26,7 +26,7 @@ export function createStyledContext<VariantProps extends Record<string, any>>(
     children,
     ...values
   }: VariantProps & { children?: React.ReactNode }) => {
-    const value = useMemo(() => values, [objectIdentityKey(values)])
+    const value = useMemo(() => values as VariantProps, [objectIdentityKey(values)])
     return <OGProvider value={value}>{children}</OGProvider>
   }
 

--- a/packages/web/types/helpers/createStyledContext.d.ts
+++ b/packages/web/types/helpers/createStyledContext.d.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-export type StyledContext<Props extends Object = any> = Omit<React.Context<Props>, 'Provider'> & {
-    context: React.Context<Props>;
+export type StyledContext<Props extends Object = any> = Omit<React.Context<Props | null>, 'Provider'> & {
+    context: React.Context<Props | null>;
     props: Object;
     Provider: React.ProviderExoticComponent<Partial<Props> & {
         children?: React.ReactNode;


### PR DESCRIPTION
The implementation of `createStyledContext` produces a context that has a default value of `null`.

But the types applied to the context report that it will always have a value.

This PR adjusts the types to more accurately represent the possible value of the context.

I also added some null guards to all the components which were directly accessing a styled context with `React.useContext`