### PR TITLE
fix(core): make styled context handle boolean props

### DIFF
--- a/packages/web/src/createComponent.tsx
+++ b/packages/web/src/createComponent.tsx
@@ -167,16 +167,17 @@ export function createComponent<
     // order is after default props but before props
     let styledContextProps: Object | undefined
     let overriddenContextProps: Object | undefined
+    let contextValue: Object | null | undefined
     const { context } = staticConfig
     if (context) {
-      const contextValue = useContext(context)
+      contextValue = useContext(context)
       const { inverseShorthands } = getConfig()
       for (const key in context.props) {
         const propVal =
           // because its after default props but before props this annoying amount of checks
-          propsIn[key] ||
-          propsIn[inverseShorthands[key]] ||
-          defaultProps?.[key] ||
+          propsIn[key] ??
+          propsIn[inverseShorthands[key]] ??
+          defaultProps?.[key] ??
           defaultProps?.[inverseShorthands[key]]
         // if not set, use context
         if (propVal === undefined) {
@@ -893,7 +894,11 @@ export function createComponent<
 
     if (overriddenContextProps) {
       const Provider = staticConfig.context!.Provider!
-      content = <Provider {...overriddenContextProps}>{content}</Provider>
+      content = (
+        <Provider {...contextValue} {...overriddenContextProps}>
+          {content}
+        </Provider>
+      )
     }
 
     if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Background

This is a fix for a bug I encountered when using a styled context which has only boolean props, with `false` as their default value.

The code inside `createComponent` which determines whether a prop is set was using `||` to short-circuit. Depending on the order they're defined in, this swallows `false` values unexpectedly, because `false || undefined` resolves to `undefined`.

When a context prop is `false`, it is being excluded from the context value. When all the context props are `false`, the context provider is never rendered at all.

A reproduction of this bug can be found [here](https://github.com/nderscore/tamagui-styled-context-null)

## Changes

* Replace the short-circuiting OR (`||`) in `createComponent` with nullish-coalescing operators (`??`)
* Merge parent styled context value into overridden props when rendering a nested context provider
  - This way its not possible for a context provider to be missing any props