### PR TITLE
fix: export ScrollView type to use on `useRef`

### DIFF
--- a/packages/scroll-view/src/ScrollView.tsx
+++ b/packages/scroll-view/src/ScrollView.tsx
@@ -17,4 +17,6 @@ export const ScrollView = styled(ScrollViewNative, {
   } as const,
 })
 
+export type ScrollView = Pick<ScrollViewNative, 'scrollTo'>
+
 export type ScrollViewProps = GetProps<typeof ScrollView>

--- a/packages/scroll-view/types/ScrollView.d.ts
+++ b/packages/scroll-view/types/ScrollView.d.ts
@@ -13,5 +13,6 @@ export declare const ScrollView: import("@tamagui/web").TamaguiComponent<import(
     prototype: ScrollViewNative;
     contextType: import("react").Context<any> | undefined;
 }>;
+export type ScrollView = Pick<ScrollViewNative, 'scrollTo'>;
 export type ScrollViewProps = GetProps<typeof ScrollView>;
 //# sourceMappingURL=ScrollView.d.ts.map


### PR DESCRIPTION
For now I've only picked `scrollTo`. We probably only want to pick the ones that are shared between web and native. 
Usage:
```tsx
import { ScrollView } from 'tamagui'
const ref = useRef<ScrollView>(null)
ref.current?.scrollTo() // is typed
```
Input would be appreciated @natew.

Fixes #1486