### PR TITLE
fix(demos): use `includes` on lucide icon demo for better search

### DIFF
--- a/packages/demos/src/LucideIconsDemo.tsx
+++ b/packages/demos/src/LucideIconsDemo.tsx
@@ -18,7 +18,7 @@ export function LucideIconsDemo() {
   const iconsMemo = useMemo(
     () =>
       lucideIcons
-        .filter((x) => x.key.startsWith(search.toLowerCase()))
+        .filter((x) => x.key.includes(search.toLowerCase()))
         .map(({ Icon, name }) => (
           <YStack
             height={size + 20}


### PR DESCRIPTION
closes #1433