### PR TITLE
Fix selectItemIndicator not behaving correctly

### DIFF
--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -471,7 +471,9 @@ export const Select = withStaticProperties(
     })
 
     React.useEffect(() => {
-      emitValue(value)
+      if (open) {
+        emitValue(value)
+      }
     }, [open])
 
     const [activeIndex, setActiveIndex] = React.useState<number | null>(0)

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -496,7 +496,7 @@ export const Select = withStaticProperties(
       <AdaptProvider>
         <SelectItemParentProvider
           scope={__scopeSelect}
-          initialValue={React.useMemo(() => value, [])}
+          initialValue={React.useMemo(() => value, [value])}
           size={sizeProp}
           activeIndexSubscribe={activeIndexSubscribe}
           valueSubscribe={valueSubscribe}

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -470,6 +470,10 @@ export const Select = withStaticProperties(
       transition: true,
     })
 
+    React.useEffect(() => {
+      emitValue(value)
+    }, [open])
+
     const [activeIndex, setActiveIndex] = React.useState<number | null>(0)
 
     const [emitValue, valueSubscribe] = useEmitter<any>()
@@ -496,7 +500,7 @@ export const Select = withStaticProperties(
       <AdaptProvider>
         <SelectItemParentProvider
           scope={__scopeSelect}
-          initialValue={React.useMemo(() => value, [value])}
+          initialValue={React.useMemo(() => value, [])}
           size={sizeProp}
           activeIndexSubscribe={activeIndexSubscribe}
           valueSubscribe={valueSubscribe}


### PR DESCRIPTION
selected item lose its selected state after being unmounted ( select closed ) and reset it back to initial value
`isSelected = React.useState(initialValue === value)`
trigger that `emitter` again once Select open