### PR TITLE
docs(next-expo-starter): bad path on vercel section of README.md

### DIFF
--- a/starters/next-expo-solito/README.md
+++ b/starters/next-expo-solito/README.md
@@ -89,7 +89,7 @@ You may potentially want to have the native module transpiled for the next app. 
 
 ### Deploying to Vercel
 
-- Root: `./apps/next`
+- Root: `apps/next`
 - Install command to be `yarn set version berry && yarn install`
 - Build command: leave default setting
 - Output dir: leave default setting


### PR DESCRIPTION
Related: https://github.com/tamagui/unistack/issues/71 & https://discord.com/channels/909986013848412191/974145843919716412/1107249160442351616