### PR TITLE
docs: fix hero example code padding

### DIFF
--- a/apps/site/components/HeroExampleCode.tsx
+++ b/apps/site/components/HeroExampleCode.tsx
@@ -1,7 +1,7 @@
 import { ThemeTint, useTint } from '@tamagui/logo'
 import { FastForward } from '@tamagui/lucide-icons'
 import { memo, useState } from 'react'
-import { Button, Paragraph, ScrollView, XGroup, XStack, YStack } from 'tamagui'
+import { Button, Paragraph, ScrollView, Spacer, XGroup, XStack, YStack } from 'tamagui'
 
 import { CodeDemoPreParsed } from './CodeDemoPreParsed'
 import { ContainerLarge } from './Container'
@@ -32,6 +32,8 @@ export const HeroExampleCode = memo(
               </HomeH3>
             </YStack>
           )}
+
+          <Spacer />
 
           <ThemeTint>
             <XGroup
@@ -183,6 +185,7 @@ const CodeExamples = memo(({ examples, title }: any) => {
           </XStack>
         </ScrollView>
       </>
+      <Spacer />
       <XStack maxWidth="100%" f={1}>
         <YStack f={1} maxWidth="100%" opacity={0.9} hoverStyle={{ opacity: 1 }}>
           <CodeDemoPreParsed


### PR DESCRIPTION
In the HeroCodeCode component, as used in the documentation, padding was missing.

https://tamagui.dev/docs/intro/why-a-compiler#:~:text=Here%27s%20what%20it%20does%2C%20in%20code%3A

I added two Spacers above the title and below it.

Before

![Captura de Tela 2023-08-19 às 01 15 41](https://github.com/tamagui/tamagui/assets/25235170/124897cf-5212-4dc7-b844-1a8a91a5d51a)

After

![Captura de Tela 2023-08-19 às 04 20 48](https://github.com/tamagui/tamagui/assets/25235170/18fbbdfc-38c2-4140-bec6-bf83236f70e7)