### PR TITLE
fix(web): font weight not working correctly on android

### DIFF
--- a/packages/web/src/helpers/getSplitStyles.tsx
+++ b/packages/web/src/helpers/getSplitStyles.tsx
@@ -1183,6 +1183,7 @@ export const getSplitStyles: StyleSplitter = (
         if (overrideFace) {
           style.fontFamily = overrideFace
           styleState.fontFamily = overrideFace
+          // If we pass both font family (e.g. InterBold) and a font weight (e.g. 900), android gets confused and just shows the default font, so we remove these:
           delete style.fontWeight
           delete style.fontStyle
         }

--- a/packages/web/src/helpers/getSplitStyles.tsx
+++ b/packages/web/src/helpers/getSplitStyles.tsx
@@ -1183,6 +1183,8 @@ export const getSplitStyles: StyleSplitter = (
         if (overrideFace) {
           style.fontFamily = overrideFace
           styleState.fontFamily = overrideFace
+          delete style.fontWeight
+          delete style.fontStyle
         }
       }
       if (process.env.NODE_ENV === 'development' && debug && debug !== 'profile') {


### PR DESCRIPTION
Fixes #1491 Font weight for Android are not using the correct font family