### PR TITLE
fix(build): enable tsProject parameter to allow integrated monorepos …

### DIFF
--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -23,8 +23,9 @@ const shouldWatch = process.argv.includes('--watch')
 const declarationToRoot = !!process.argv.includes('--declaration-root')
 const ignoreBaseUrl = process.argv.includes('--ignore-base-url')
 const baseUrlIndex = process.argv.indexOf('--base-url')
-const tsProject = process.argv.includes('--ts-project')
+const tsProjectIndex = process.argv.indexOf('--ts-project')
 const baseUrl = baseUrlIndex > -1 ? process.argv[baseUrlIndex] : '.'
+const tsProject = tsProjectIndex > -1 ? process.argv[tsProjectIndex] : null
 
 const pkg = fs.readJSONSync('./package.json')
 let shouldSkipInitialTypes = !!process.env.SKIP_TYPES_INITIAL

--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -23,6 +23,7 @@ const shouldWatch = process.argv.includes('--watch')
 const declarationToRoot = !!process.argv.includes('--declaration-root')
 const ignoreBaseUrl = process.argv.includes('--ignore-base-url')
 const baseUrlIndex = process.argv.indexOf('--base-url')
+const tsProject = process.argv.includes('--ts-project')
 const baseUrl = baseUrlIndex > -1 ? process.argv[baseUrlIndex] : '.'
 
 const pkg = fs.readJSONSync('./package.json')
@@ -135,7 +136,8 @@ async function buildTsc() {
 
     const declarationToRootFlag = declarationToRoot ? ' --declarationDir ./' : ''
     const baseUrlFlag = ignoreBaseUrl ? '' : ` --baseUrl ${baseUrl}`
-    const cmd = `tsc${baseUrlFlag} --outDir ${targetDir} --rootDir src ${declarationToRootFlag}--emitDeclarationOnly --declarationMap`
+    const tsProjectFlag = tsProject ? ` --project ${tsProject}` : ''
+    const cmd = `tsc${baseUrlFlag}${tsProjectFlag} --outDir ${targetDir} --rootDir src ${declarationToRootFlag}--emitDeclarationOnly --declarationMap`
 
     // console.log('\x1b[2m$', `npx ${cmd}`)
     await exec('npx', cmd.split(' '))

--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -24,8 +24,8 @@ const declarationToRoot = !!process.argv.includes('--declaration-root')
 const ignoreBaseUrl = process.argv.includes('--ignore-base-url')
 const baseUrlIndex = process.argv.indexOf('--base-url')
 const tsProjectIndex = process.argv.indexOf('--ts-project')
-const baseUrl = baseUrlIndex > -1 ? process.argv[baseUrlIndex] : '.'
-const tsProject = tsProjectIndex > -1 ? process.argv[tsProjectIndex] : null
+const baseUrl = baseUrlIndex > -1 && process.argv[baseUrlIndex + 1] ? process.argv[baseUrlIndex + 1] : '.'
+const tsProject = tsProjectIndex > -1 && process.argv[tsProjectIndex + 1] ? process.argv[tsProjectIndex + 1] : null
 
 const pkg = fs.readJSONSync('./package.json')
 let shouldSkipInitialTypes = !!process.env.SKIP_TYPES_INITIAL


### PR DESCRIPTION
…support (nx)

Integrated monorepos such as NX use tsconfig files to separate projects (and jest) instead of package.json's.  This means that tamagui-build fails to find the correct the tsconfig file and you cannot specify it manually.

Adding this parameter `--ts-project` to the build tool allows you to use tamagui-build inside an nx monorepo but doing the following in the project.json:
```
"build": {
      "executor": "nx:run-commands",
      "options": {
        "command": "tamagui-build --ts-project ./tsconfig.lib.json ",
        "cwd": "libs/ui"
      }
    },
    "watch": {
      "executor": "nx:run-commands",
      "options": {
        "commands": [
          {
            "command": "tamagui-build --ts-project ./tsconfig.lib.json --watch",
            "cwd": "libs/ui"
          }
        ]
      }
    }
```