### PR TITLE
fix(web): vertical scrollbar causes horizontal

### DIFF
--- a/packages/web/reset.css
+++ b/packages/web/reset.css
@@ -3,7 +3,7 @@ body, #root, #__next {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
-  min-width: 100vw;
+  min-width: calc(100vw - 100%); /* Reserve the width of the scrollbar, even if it's not present */
 }
 
 * {


### PR DESCRIPTION
Not sure if this was a problem for anyone else, but I found that when my content overflows the viewport vertically, it causes horizontal scrollbars due to the body not accounting for the space of the vertical scrollbars.

Adds dynamic width calculation to prevent horizontal scrollbar when vertical scrollbars are present.