### PR TITLE
fix(Label): Label is not supposed to have a role

### DIFF
--- a/packages/label/src/Label.tsx
+++ b/packages/label/src/Label.tsx
@@ -109,7 +109,6 @@ const LabelComponent = React.forwardRef<typeof LabelFrame, LabelProps>(
     return (
       <LabelProvider id={id} controlRef={controlRef}>
         <LabelFrame
-          role="heading"
           id={id}
           // @ts-ignore
           htmlFor={htmlFor}


### PR DESCRIPTION
According to WAI-ARIA 4, Document conformance requirements for use of ARIA attributes in HTML
https://www.w3.org/TR/html-aria/#docconformance

label role is prohibited and must not have a role, so the role should be removed.