### PR TITLE
Off-by-1 error with getting identifier from style rule

### DIFF
--- a/packages/web/src/helpers/insertStyleRule.tsx
+++ b/packages/web/src/helpers/insertStyleRule.tsx
@@ -317,7 +317,7 @@ function getTamaguiSelector(
 }
 
 const getIdentifierFromTamaguiSelector = (selector: string) => {
-  let res = selector.slice(8)
+  let res = selector.slice(7)
   if (selector.includes(':')) {
     return res.replace(/:[a-z]+$/, '')
   }


### PR DESCRIPTION
It would produce `jc-row` instead of `_jc-row`, resulting in selectors not being found and styles not being applied properly

Instead of `_jc-row` being inserted on the element, it would insert `_jc-undefined`

It appears to be a race condition, where these styles are attempted initially and fail. But if they were to be attempted a bit later, they should succeed. However, this does not occur

Let me know if I can assist with getting this over the line 🙏 Thanks!