### PR TITLE
feat(sheet): add option for constant snapPoint sizes in pixels

### DIFF
--- a/packages/demos/src/SheetDemo.tsx
+++ b/packages/demos/src/SheetDemo.tsx
@@ -8,13 +8,20 @@ export const SheetDemo = () => {
   const [open, setOpen] = useState(false)
   const [modal, setModal] = useState(true)
   const [innerOpen, setInnerOpen] = useState(false)
+  const [snapPointsMode, setSnapPointsMode] = useState<'percent' | 'constant'>('percent')
+  const isPercent = snapPointsMode === 'percent'
 
   return (
     <>
-      <XStack space>
+      <XStack space $sm={{ flexDirection: 'column', alignItems: 'center' }}>
         <Button onPress={() => setOpen(true)}>Open</Button>
         <Button onPress={() => setModal((x) => !x)}>
           {modal ? 'Type: Modal' : 'Type: Inline'}
+        </Button>
+        <Button onPress={() => setSnapPointsMode(isPercent ? 'constant' : 'percent')}>
+          {snapPointsMode === 'percent'
+            ? 'Snap Points: Percent'
+            : 'Snap Points: Constant'}
         </Button>
       </XStack>
 
@@ -23,7 +30,8 @@ export const SheetDemo = () => {
         modal={modal}
         open={open}
         onOpenChange={setOpen}
-        snapPoints={[85, 50, 25]}
+        snapPoints={isPercent ? [85, 50, 25] : [256, 190]}
+        snapPointsMode={snapPointsMode}
         dismissOnSnapToBottom
         position={position}
         onPositionChange={setPosition}
@@ -45,7 +53,7 @@ export const SheetDemo = () => {
         >
           <Button size="$6" circular icon={ChevronDown} onPress={() => setOpen(false)} />
           <Input width={200} />
-          {modal && (
+          {modal && isPercent && (
             <>
               <InnerSheet open={innerOpen} onOpenChange={setInnerOpen} />
               <Button

--- a/packages/sheet/src/SheetImplementationCustom.tsx
+++ b/packages/sheet/src/SheetImplementationCustom.tsx
@@ -66,6 +66,7 @@ export const SheetImplementationCustom = themeable(
       setFrameSize,
       snapPoints,
       snapPointsMode,
+      hasFit,
       position,
       setPosition,
       scrollBridge,
@@ -89,8 +90,11 @@ export const SheetImplementationCustom = themeable(
     }, [])
 
     const positions = useMemo(
-      () => snapPoints.map((point) => getYPositions(point, screenSize, snapPointsMode)),
-      [screenSize, snapPoints, snapPointsMode]
+      () =>
+        snapPoints.map((point) =>
+          getYPositions(snapPointsMode, point, screenSize, frameSize)
+        ),
+      [screenSize, frameSize, snapPoints, snapPointsMode]
     )
 
     const driver = useAnimationDriver()
@@ -180,11 +184,11 @@ export const SheetImplementationCustom = themeable(
     }, [hasntMeasured, screenSize])
 
     useIsomorphicLayoutEffect(() => {
-      if (!frameSize || isHidden || (hasntMeasured && !open)) {
+      if (!frameSize || !screenSize || isHidden || (hasntMeasured && !open)) {
         return
       }
       animateTo(position)
-    }, [isHidden, frameSize, open, position])
+    }, [isHidden, frameSize, screenSize, open, position])
 
     const disableDrag = props.disableDrag ?? controller?.disableDrag
     const themeName = useThemeName()
@@ -373,6 +377,12 @@ export const SheetImplementationCustom = themeable(
       }
     }, [open])
 
+    const forcedContentHeight = hasFit
+      ? frameSize
+      : snapPointsMode === 'percent'
+      ? `${maxSnapPoint}%`
+      : maxSnapPoint
+
     const contents = (
       <ParentSheetContext.Provider value={nextParentContext}>
         <SheetProvider {...providerProps}>
@@ -380,7 +390,7 @@ export const SheetImplementationCustom = themeable(
             {shouldHideParentSheet || !open ? null : overlayComponent}
           </AnimatePresence>
 
-          {snapPointsMode === 'constant' && (
+          {snapPointsMode !== 'percent' && (
             <View
               style={{
                 opacity: 0,
@@ -398,7 +408,7 @@ export const SheetImplementationCustom = themeable(
           <AnimatedView
             ref={ref}
             {...panResponder?.panHandlers}
-            onLayout={handleAnimationViewLayout}
+            onLayout={hasFit ? undefined : handleAnimationViewLayout}
             pointerEvents={open && !shouldHideParentSheet ? 'auto' : 'none'}
             //  @ts-ignore
             animation={props.animation}
@@ -407,9 +417,8 @@ export const SheetImplementationCustom = themeable(
                 position: 'absolute',
                 zIndex,
                 width: '100%',
-                height: snapPointsMode === 'constant' ? maxSnapPoint : `${maxSnapPoint}%`,
-                minHeight:
-                  snapPointsMode === 'constant' ? maxSnapPoint : `${maxSnapPoint}%`,
+                height: forcedContentHeight,
+                minHeight: forcedContentHeight,
                 opacity,
               },
               animatedStyle,
@@ -455,17 +464,48 @@ export const SheetImplementationCustom = themeable(
   })
 )
 
-function getYPositions(point?: number, screenSize?: number, mode?: SnapPointsMode) {
-  if (!screenSize) return 0
-  if (point === undefined) {
-    console.warn('No snapPoint')
+function getYPositions(
+  mode: SnapPointsMode,
+  point: string | number,
+  screenSize?: number,
+  frameSize?: number
+) {
+  if (!screenSize || !frameSize) return 0
+
+  if (mode === 'mixed') {
+    if (typeof point === 'number') {
+      return screenSize - Math.min(screenSize, Math.max(0, point))
+    }
+    if (point === 'fit') {
+      return screenSize - frameSize
+    }
+    if (point.endsWith('%')) {
+      const pct = Math.min(100, Math.max(0, Number(point.slice(0, -1)))) / 100
+      if (Number.isNaN(pct)) {
+        console.warn('Invalid snapPoint percentage string')
+        return 0
+      }
+      const next = Math.round(screenSize - pct * screenSize)
+      return next
+    }
+    console.warn('Invalid snapPoint unknown value')
     return 0
   }
-  if (mode === 'constant') {
+
+  if (mode === 'fit') {
+    if (point === 0) return screenSize
+    return screenSize - Math.min(screenSize, frameSize)
+  }
+
+  if (mode === 'constant' && typeof point === 'number') {
     return screenSize - Math.min(screenSize, Math.max(0, point))
   }
-  const pct = point / 100
-  const next = Math.round(screenSize - pct * screenSize)
 
-  return next
+  const pct = Math.min(100, Math.max(0, Number(point))) / 100
+  if (Number.isNaN(pct)) {
+    console.warn('Invalid snapPoint percentage')
+    return 0
+  }
+
+  return Math.round(screenSize - pct * screenSize)
 }

--- a/packages/sheet/src/createSheet.tsx
+++ b/packages/sheet/src/createSheet.tsx
@@ -11,8 +11,15 @@ import {
   withStaticProperties,
 } from '@tamagui/core'
 import { RemoveScroll } from '@tamagui/remove-scroll'
-import { FunctionComponent, RefAttributes, forwardRef, memo, useMemo } from 'react'
-import { Platform, View } from 'react-native'
+import {
+  FunctionComponent,
+  RefAttributes,
+  forwardRef,
+  memo,
+  useCallback,
+  useMemo,
+} from 'react'
+import { LayoutChangeEvent, Platform, View } from 'react-native'
 
 import { SHEET_HANDLE_NAME, SHEET_NAME, SHEET_OVERLAY_NAME } from './constants'
 import { getNativeSheet } from './nativeSheet'
@@ -126,10 +133,21 @@ export function createSheet<
         const composedContentRef = useComposedRefs(forwardedRef, contentRef)
         const offscreenSize = useSheetOffscreenSize(context)
 
+        const handleLayoutChange = useCallback((e: LayoutChangeEvent) => {
+          const next = e.nativeEvent?.layout.height
+          if (!next) return
+          context.setFrameSize(next)
+        }, [])
+
         const sheetContents = useMemo(() => {
           return (
             // @ts-ignore
-            <Frame ref={composedContentRef} height={frameSize} {...props}>
+            <Frame
+              ref={composedContentRef}
+              height={context.hasFit ? undefined : frameSize}
+              onLayout={context.hasFit ? handleLayoutChange : undefined}
+              {...props}
+            >
               {children}
               <Stack data-sheet-offscreen-pad height={offscreenSize} width="100%" />
             </Frame>

--- a/packages/sheet/src/types.tsx
+++ b/packages/sheet/src/types.tsx
@@ -11,7 +11,7 @@ export type SheetProps = ScopedProps<
     onOpenChange?: OpenChangeHandler
     position?: number
     defaultPosition?: number
-    snapPoints?: number[]
+    snapPoints?: (string | number)[]
     snapPointsMode?: SnapPointsMode
     onPositionChange?: PositionChangeHandler
     children?: ReactNode
@@ -55,7 +55,7 @@ type OpenChangeHandler =
 
 export type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>
 
-export type SnapPointsMode = 'percent' | 'constant'
+export type SnapPointsMode = 'percent' | 'constant' | 'fit' | 'mixed'
 
 export type SheetScopedProps<A> = ScopedProps<A, 'Sheet'>
 

--- a/packages/sheet/src/types.tsx
+++ b/packages/sheet/src/types.tsx
@@ -12,6 +12,7 @@ export type SheetProps = ScopedProps<
     position?: number
     defaultPosition?: number
     snapPoints?: number[]
+    snapPointsMode?: SnapPointsMode
     onPositionChange?: PositionChangeHandler
     children?: ReactNode
     dismissOnOverlayPress?: boolean
@@ -53,6 +54,8 @@ type OpenChangeHandler =
   | React.Dispatch<React.SetStateAction<boolean>>
 
 export type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>
+
+export type SnapPointsMode = 'percent' | 'constant'
 
 export type SheetScopedProps<A> = ScopedProps<A, 'Sheet'>
 

--- a/packages/sheet/src/useSheetOffscreenSize.tsx
+++ b/packages/sheet/src/useSheetOffscreenSize.tsx
@@ -4,18 +4,46 @@ export const useSheetOffscreenSize = ({
   snapPoints,
   position,
   screenSize,
+  frameSize,
   snapPointsMode,
 }: SheetContextValue) => {
+  if (snapPointsMode === 'fit') {
+    return 0
+  }
+
   if (snapPointsMode === 'constant') {
-    const maxSize = snapPoints[0]
-    const currentSize = snapPoints[position] ?? 0
+    const maxSize = Number(snapPoints[0])
+    const currentSize = Number(snapPoints[position] ?? 0)
     const offscreenSize = maxSize - currentSize
     return offscreenSize
   }
 
-  const maxPercentOpened = snapPoints[0] / 100
-  const percentOpened = (snapPoints[position] || 0) / 100
-  const percentHidden = 1 - maxPercentOpened - percentOpened
-  const offscreenSize = percentHidden * screenSize
+  if (snapPointsMode === 'percent') {
+    const maxPercentOpened = Number(snapPoints[0]) / 100
+    const percentOpened = Number(snapPoints[position] ?? 0) / 100
+    const percentHidden = 1 - maxPercentOpened - percentOpened
+    const offscreenSize = percentHidden * screenSize
+    return offscreenSize
+  }
+
+  // mixed:
+  const maxSnapPoint = snapPoints[0]
+  const maxSize =
+    maxSnapPoint === 'fit'
+      ? frameSize
+      : typeof maxSnapPoint === 'string'
+      ? (Number(maxSnapPoint.slice(0, -1)) / 100) * screenSize
+      : maxSnapPoint
+  const currentSnapPoint = snapPoints[position] ?? 0
+  const currentSize =
+    currentSnapPoint === 'fit'
+      ? frameSize
+      : typeof currentSnapPoint === 'string'
+      ? (Number(currentSnapPoint.slice(0, -1)) / 100) * screenSize
+      : currentSnapPoint
+  const offscreenSize = maxSize - currentSize
+  if (Number.isNaN(offscreenSize)) {
+    return 0
+  }
   return offscreenSize
 }

--- a/packages/sheet/src/useSheetOffscreenSize.tsx
+++ b/packages/sheet/src/useSheetOffscreenSize.tsx
@@ -4,7 +4,15 @@ export const useSheetOffscreenSize = ({
   snapPoints,
   position,
   screenSize,
+  snapPointsMode,
 }: SheetContextValue) => {
+  if (snapPointsMode === 'constant') {
+    const maxSize = snapPoints[0]
+    const currentSize = snapPoints[position] ?? 0
+    const offscreenSize = maxSize - currentSize
+    return offscreenSize
+  }
+
   const maxPercentOpened = snapPoints[0] / 100
   const percentOpened = (snapPoints[position] || 0) / 100
   const percentHidden = 1 - maxPercentOpened - percentOpened

--- a/packages/sheet/src/useSheetProviderProps.tsx
+++ b/packages/sheet/src/useSheetProviderProps.tsx
@@ -17,7 +17,9 @@ export function useSheetProviderProps(
 ) {
   const contentRef = React.useRef<TamaguiElement>(null)
   const [frameSize, setFrameSize] = useState<number>(0)
+  const [maxContentSize, setMaxContentSize] = useState<number>(0)
   const snapPointsProp = props.snapPoints || [80]
+  const snapPointsMode = props.snapPointsMode ?? 'percent'
 
   const snapPoints = useMemo(
     () => (props.dismissOnSnapToBottom ? [...snapPointsProp, 0] : snapPointsProp),
@@ -51,9 +53,14 @@ export function useSheetProviderProps(
   )
 
   if (process.env.NODE_ENV === 'development') {
-    if (snapPoints.some((p) => p < 0 || p > 100)) {
+    if (snapPointsMode === 'constant' && snapPoints.some((p) => p < 0)) {
       console.warn(
-        '⚠️ Invalid snapPoint given, snapPoints must be between 0 and 100, equal to percent height of frame'
+        '⚠️ Invalid snapPoint given, snapPoints must be positive values when snapPointsMode is constant'
+      )
+    }
+    if (snapPointsMode === 'percent' && snapPoints.some((p) => p < 0 || p > 100)) {
+      console.warn(
+        '⚠️ Invalid snapPoint given, snapPoints must be between 0 and 100, equal to percent height of frame when snapPointsMode is percent'
       )
     }
   }
@@ -90,7 +97,8 @@ export function useSheetProviderProps(
   const removeScrollEnabled = props.forceRemoveScrollEnabled ?? (open && props.modal)
 
   const maxSnapPoint = snapPoints.reduce((prev, cur) => Math.max(prev, cur))
-  const screenSize = frameSize / (maxSnapPoint / 100)
+  const screenSize =
+    snapPointsMode === 'constant' ? maxContentSize : frameSize / (maxSnapPoint / 100)
 
   const providerProps = {
     screenSize,
@@ -110,6 +118,8 @@ export function useSheetProviderProps(
     scope: props.__scopeSheet,
     position,
     snapPoints,
+    snapPointsMode,
+    setMaxContentSize,
     setPosition,
     setPositionImmediate,
     onlyShowFrame: false,

--- a/packages/sheet/types/Sheet.d.ts
+++ b/packages/sheet/types/Sheet.d.ts
@@ -199,6 +199,7 @@ export declare const Sheet: import("react").ForwardRefExoticComponent<{
     position?: number | undefined;
     defaultPosition?: number | undefined;
     snapPoints?: number[] | undefined;
+    snapPointsMode?: import("./types").SnapPointsMode | undefined;
     onPositionChange?: import("./types").PositionChangeHandler | undefined;
     children?: import("react").ReactNode;
     dismissOnOverlayPress?: boolean | undefined;

--- a/packages/sheet/types/Sheet.d.ts
+++ b/packages/sheet/types/Sheet.d.ts
@@ -198,7 +198,7 @@ export declare const Sheet: import("react").ForwardRefExoticComponent<{
     onOpenChange?: (((open: boolean) => void) | import("react").Dispatch<import("react").SetStateAction<boolean>>) | undefined;
     position?: number | undefined;
     defaultPosition?: number | undefined;
-    snapPoints?: number[] | undefined;
+    snapPoints?: (string | number)[] | undefined;
     snapPointsMode?: import("./types").SnapPointsMode | undefined;
     onPositionChange?: import("./types").PositionChangeHandler | undefined;
     children?: import("react").ReactNode;

--- a/packages/sheet/types/SheetContext.d.ts
+++ b/packages/sheet/types/SheetContext.d.ts
@@ -12,7 +12,7 @@ export declare const createSheetContext: <ContextValueType extends object | null
 export declare const SheetProvider: {
     (props: {
         screenSize: number;
-        maxSnapPoint: number;
+        maxSnapPoint: string | number;
         removeScrollEnabled: boolean | undefined;
         scrollBridge: import("./types").ScrollBridge;
         modal: boolean;
@@ -26,8 +26,9 @@ export declare const SheetProvider: {
         dismissOnSnapToBottom: boolean;
         onOverlayComponent: ((comp: any) => void) | undefined;
         scope: import("@tamagui/create-context").Scope<any>;
+        hasFit: boolean;
         position: number;
-        snapPoints: number[];
+        snapPoints: (string | number)[];
         snapPointsMode: import("./types").SnapPointsMode;
         setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
         setPosition: (next: number) => void;
@@ -36,7 +37,7 @@ export declare const SheetProvider: {
     } & {
         scope: import("@tamagui/create-context").Scope<{
             screenSize: number;
-            maxSnapPoint: number;
+            maxSnapPoint: string | number;
             removeScrollEnabled: boolean | undefined;
             scrollBridge: import("./types").ScrollBridge;
             modal: boolean;
@@ -50,8 +51,9 @@ export declare const SheetProvider: {
             dismissOnSnapToBottom: boolean;
             onOverlayComponent: ((comp: any) => void) | undefined;
             scope: import("@tamagui/create-context").Scope<any>;
+            hasFit: boolean;
             position: number;
-            snapPoints: number[];
+            snapPoints: (string | number)[];
             snapPointsMode: import("./types").SnapPointsMode;
             setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
             setPosition: (next: number) => void;
@@ -63,7 +65,7 @@ export declare const SheetProvider: {
     displayName: string;
 }, useSheetContext: (consumerName: string, scope: import("@tamagui/create-context").Scope<{
     screenSize: number;
-    maxSnapPoint: number;
+    maxSnapPoint: string | number;
     removeScrollEnabled: boolean | undefined;
     scrollBridge: import("./types").ScrollBridge;
     modal: boolean;
@@ -77,8 +79,9 @@ export declare const SheetProvider: {
     dismissOnSnapToBottom: boolean;
     onOverlayComponent: ((comp: any) => void) | undefined;
     scope: import("@tamagui/create-context").Scope<any>;
+    hasFit: boolean;
     position: number;
-    snapPoints: number[];
+    snapPoints: (string | number)[];
     snapPointsMode: import("./types").SnapPointsMode;
     setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
     setPosition: (next: number) => void;
@@ -88,7 +91,7 @@ export declare const SheetProvider: {
     warn?: boolean | undefined;
     fallback?: Partial<{
         screenSize: number;
-        maxSnapPoint: number;
+        maxSnapPoint: string | number;
         removeScrollEnabled: boolean | undefined;
         scrollBridge: import("./types").ScrollBridge;
         modal: boolean;
@@ -102,8 +105,9 @@ export declare const SheetProvider: {
         dismissOnSnapToBottom: boolean;
         onOverlayComponent: ((comp: any) => void) | undefined;
         scope: import("@tamagui/create-context").Scope<any>;
+        hasFit: boolean;
         position: number;
-        snapPoints: number[];
+        snapPoints: (string | number)[];
         snapPointsMode: import("./types").SnapPointsMode;
         setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
         setPosition: (next: number) => void;
@@ -112,7 +116,7 @@ export declare const SheetProvider: {
     }> | undefined;
 } | undefined) => {
     screenSize: number;
-    maxSnapPoint: number;
+    maxSnapPoint: string | number;
     removeScrollEnabled: boolean | undefined;
     scrollBridge: import("./types").ScrollBridge;
     modal: boolean;
@@ -126,8 +130,9 @@ export declare const SheetProvider: {
     dismissOnSnapToBottom: boolean;
     onOverlayComponent: ((comp: any) => void) | undefined;
     scope: import("@tamagui/create-context").Scope<any>;
+    hasFit: boolean;
     position: number;
-    snapPoints: number[];
+    snapPoints: (string | number)[];
     snapPointsMode: import("./types").SnapPointsMode;
     setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
     setPosition: (next: number) => void;

--- a/packages/sheet/types/SheetContext.d.ts
+++ b/packages/sheet/types/SheetContext.d.ts
@@ -28,6 +28,8 @@ export declare const SheetProvider: {
         scope: import("@tamagui/create-context").Scope<any>;
         position: number;
         snapPoints: number[];
+        snapPointsMode: import("./types").SnapPointsMode;
+        setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
         setPosition: (next: number) => void;
         setPositionImmediate: import("react").Dispatch<import("react").SetStateAction<number>>;
         onlyShowFrame: boolean;
@@ -50,6 +52,8 @@ export declare const SheetProvider: {
             scope: import("@tamagui/create-context").Scope<any>;
             position: number;
             snapPoints: number[];
+            snapPointsMode: import("./types").SnapPointsMode;
+            setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
             setPosition: (next: number) => void;
             setPositionImmediate: import("react").Dispatch<import("react").SetStateAction<number>>;
             onlyShowFrame: boolean;
@@ -75,6 +79,8 @@ export declare const SheetProvider: {
     scope: import("@tamagui/create-context").Scope<any>;
     position: number;
     snapPoints: number[];
+    snapPointsMode: import("./types").SnapPointsMode;
+    setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
     setPosition: (next: number) => void;
     setPositionImmediate: import("react").Dispatch<import("react").SetStateAction<number>>;
     onlyShowFrame: boolean;
@@ -98,6 +104,8 @@ export declare const SheetProvider: {
         scope: import("@tamagui/create-context").Scope<any>;
         position: number;
         snapPoints: number[];
+        snapPointsMode: import("./types").SnapPointsMode;
+        setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
         setPosition: (next: number) => void;
         setPositionImmediate: import("react").Dispatch<import("react").SetStateAction<number>>;
         onlyShowFrame: boolean;
@@ -120,6 +128,8 @@ export declare const SheetProvider: {
     scope: import("@tamagui/create-context").Scope<any>;
     position: number;
     snapPoints: number[];
+    snapPointsMode: import("./types").SnapPointsMode;
+    setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
     setPosition: (next: number) => void;
     setPositionImmediate: import("react").Dispatch<import("react").SetStateAction<number>>;
     onlyShowFrame: boolean;

--- a/packages/sheet/types/SheetImplementationCustom.d.ts
+++ b/packages/sheet/types/SheetImplementationCustom.d.ts
@@ -7,7 +7,7 @@ export declare const SheetImplementationCustom: (props: Omit<{
     onOpenChange?: (((open: boolean) => void) | import("react").Dispatch<import("react").SetStateAction<boolean>>) | undefined;
     position?: number | undefined;
     defaultPosition?: number | undefined;
-    snapPoints?: number[] | undefined;
+    snapPoints?: (string | number)[] | undefined;
     snapPointsMode?: SnapPointsMode | undefined;
     onPositionChange?: import("./types").PositionChangeHandler | undefined;
     children?: import("react").ReactNode;

--- a/packages/sheet/types/SheetImplementationCustom.d.ts
+++ b/packages/sheet/types/SheetImplementationCustom.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="react" />
 import { View } from 'react-native';
+import { SnapPointsMode } from './types';
 export declare const SheetImplementationCustom: (props: Omit<{
     open?: boolean | undefined;
     defaultOpen?: boolean | undefined;
@@ -7,6 +8,7 @@ export declare const SheetImplementationCustom: (props: Omit<{
     position?: number | undefined;
     defaultPosition?: number | undefined;
     snapPoints?: number[] | undefined;
+    snapPointsMode?: SnapPointsMode | undefined;
     onPositionChange?: import("./types").PositionChangeHandler | undefined;
     children?: import("react").ReactNode;
     dismissOnOverlayPress?: boolean | undefined;

--- a/packages/sheet/types/createSheet.d.ts
+++ b/packages/sheet/types/createSheet.d.ts
@@ -18,6 +18,7 @@ export declare function createSheet<H extends SheetStyledComponent | TamaguiComp
     position?: number | undefined;
     defaultPosition?: number | undefined;
     snapPoints?: number[] | undefined;
+    snapPointsMode?: import("./types").SnapPointsMode | undefined;
     onPositionChange?: import("./types").PositionChangeHandler | undefined;
     children?: import("react").ReactNode;
     dismissOnOverlayPress?: boolean | undefined;

--- a/packages/sheet/types/createSheet.d.ts
+++ b/packages/sheet/types/createSheet.d.ts
@@ -17,7 +17,7 @@ export declare function createSheet<H extends SheetStyledComponent | TamaguiComp
     onOpenChange?: (((open: boolean) => void) | import("react").Dispatch<import("react").SetStateAction<boolean>>) | undefined;
     position?: number | undefined;
     defaultPosition?: number | undefined;
-    snapPoints?: number[] | undefined;
+    snapPoints?: (string | number)[] | undefined;
     snapPointsMode?: import("./types").SnapPointsMode | undefined;
     onPositionChange?: import("./types").PositionChangeHandler | undefined;
     children?: import("react").ReactNode;

--- a/packages/sheet/types/types.d.ts
+++ b/packages/sheet/types/types.d.ts
@@ -10,6 +10,7 @@ export type SheetProps = ScopedProps<{
     position?: number;
     defaultPosition?: number;
     snapPoints?: number[];
+    snapPointsMode?: SnapPointsMode;
     onPositionChange?: PositionChangeHandler;
     children?: ReactNode;
     dismissOnOverlayPress?: boolean;
@@ -41,6 +42,7 @@ export type SheetProps = ScopedProps<{
 export type PositionChangeHandler = (position: number) => void;
 type OpenChangeHandler = ((open: boolean) => void) | React.Dispatch<React.SetStateAction<boolean>>;
 export type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
+export type SnapPointsMode = 'percent' | 'constant';
 export type SheetScopedProps<A> = ScopedProps<A, 'Sheet'>;
 export type ScrollBridge = {
     enabled: boolean;

--- a/packages/sheet/types/types.d.ts
+++ b/packages/sheet/types/types.d.ts
@@ -9,7 +9,7 @@ export type SheetProps = ScopedProps<{
     onOpenChange?: OpenChangeHandler;
     position?: number;
     defaultPosition?: number;
-    snapPoints?: number[];
+    snapPoints?: (string | number)[];
     snapPointsMode?: SnapPointsMode;
     onPositionChange?: PositionChangeHandler;
     children?: ReactNode;
@@ -42,7 +42,7 @@ export type SheetProps = ScopedProps<{
 export type PositionChangeHandler = (position: number) => void;
 type OpenChangeHandler = ((open: boolean) => void) | React.Dispatch<React.SetStateAction<boolean>>;
 export type RemoveScrollProps = React.ComponentProps<typeof RemoveScroll>;
-export type SnapPointsMode = 'percent' | 'constant';
+export type SnapPointsMode = 'percent' | 'constant' | 'fit' | 'mixed';
 export type SheetScopedProps<A> = ScopedProps<A, 'Sheet'>;
 export type ScrollBridge = {
     enabled: boolean;

--- a/packages/sheet/types/useSheet.d.ts
+++ b/packages/sheet/types/useSheet.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="react" />
 export declare const useSheet: () => {
     screenSize: number;
-    maxSnapPoint: number;
+    maxSnapPoint: string | number;
     removeScrollEnabled: boolean | undefined;
     scrollBridge: import("./types").ScrollBridge;
     modal: boolean;
@@ -15,8 +15,9 @@ export declare const useSheet: () => {
     dismissOnSnapToBottom: boolean;
     onOverlayComponent: ((comp: any) => void) | undefined;
     scope: import("@tamagui/create-context").Scope<any>;
+    hasFit: boolean;
     position: number;
-    snapPoints: number[];
+    snapPoints: (string | number)[];
     snapPointsMode: import("./types").SnapPointsMode;
     setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
     setPosition: (next: number) => void;

--- a/packages/sheet/types/useSheet.d.ts
+++ b/packages/sheet/types/useSheet.d.ts
@@ -17,6 +17,8 @@ export declare const useSheet: () => {
     scope: import("@tamagui/create-context").Scope<any>;
     position: number;
     snapPoints: number[];
+    snapPointsMode: import("./types").SnapPointsMode;
+    setMaxContentSize: import("react").Dispatch<import("react").SetStateAction<number>>;
     setPosition: (next: number) => void;
     setPositionImmediate: import("react").Dispatch<import("react").SetStateAction<number>>;
     onlyShowFrame: boolean;

--- a/packages/sheet/types/useSheetOffscreenSize.d.ts
+++ b/packages/sheet/types/useSheetOffscreenSize.d.ts
@@ -1,3 +1,3 @@
 import { SheetContextValue } from './useSheetProviderProps';
-export declare const useSheetOffscreenSize: ({ snapPoints, position, screenSize, }: SheetContextValue) => number;
+export declare const useSheetOffscreenSize: ({ snapPoints, position, screenSize, snapPointsMode, }: SheetContextValue) => number;
 //# sourceMappingURL=useSheetOffscreenSize.d.ts.map

--- a/packages/sheet/types/useSheetOffscreenSize.d.ts
+++ b/packages/sheet/types/useSheetOffscreenSize.d.ts
@@ -1,3 +1,3 @@
 import { SheetContextValue } from './useSheetProviderProps';
-export declare const useSheetOffscreenSize: ({ snapPoints, position, screenSize, snapPointsMode, }: SheetContextValue) => number;
+export declare const useSheetOffscreenSize: ({ snapPoints, position, screenSize, frameSize, snapPointsMode, }: SheetContextValue) => number;
 //# sourceMappingURL=useSheetOffscreenSize.d.ts.map

--- a/packages/sheet/types/useSheetProviderProps.d.ts
+++ b/packages/sheet/types/useSheetProviderProps.d.ts
@@ -23,6 +23,8 @@ export declare function useSheetProviderProps(props: SheetProps, state: SheetOpe
     scope: import("@tamagui/create-context").Scope<any>;
     position: number;
     snapPoints: number[];
+    snapPointsMode: import("./types").SnapPointsMode;
+    setMaxContentSize: React.Dispatch<React.SetStateAction<number>>;
     setPosition: (next: number) => void;
     setPositionImmediate: React.Dispatch<React.SetStateAction<number>>;
     onlyShowFrame: boolean;

--- a/packages/sheet/types/useSheetProviderProps.d.ts
+++ b/packages/sheet/types/useSheetProviderProps.d.ts
@@ -7,7 +7,7 @@ export declare function useSheetProviderProps(props: SheetProps, state: SheetOpe
     onOverlayComponent?: (comp: any) => void;
 }): {
     screenSize: number;
-    maxSnapPoint: number;
+    maxSnapPoint: string | number;
     removeScrollEnabled: boolean | undefined;
     scrollBridge: ScrollBridge;
     modal: boolean;
@@ -21,8 +21,9 @@ export declare function useSheetProviderProps(props: SheetProps, state: SheetOpe
     dismissOnSnapToBottom: boolean;
     onOverlayComponent: ((comp: any) => void) | undefined;
     scope: import("@tamagui/create-context").Scope<any>;
+    hasFit: boolean;
     position: number;
-    snapPoints: number[];
+    snapPoints: (string | number)[];
     snapPointsMode: import("./types").SnapPointsMode;
     setMaxContentSize: React.Dispatch<React.SetStateAction<number>>;
     setPosition: (next: number) => void;


### PR DESCRIPTION
## Description

Adds a new prop to the `Sheet` component called `snapPointsMode`, which changes the behavior of the `snapPoints` prop. 

The possible values for this prop are:

- `percent` - the default, treat snap points as numeric percentages
- `constant` - treat snap points as constant pixel dimensions
- `fit` - auto-fit to the content's inherent height
- `mixed` - a mixture of multiple types (`numbers` = pixels, `"${number}%"` = percentages, `fit` = fit)

If a snap point value is greater than the height of the parent container, it will be constrained to the height of the parent container.

When in non `percent` modes, an extra View is rendered to measure the height of the parent container in order to get the correct `screenHeight` without being able to do percentage math on the sheet's height.

When an `fit` mode, or when `fit` is one of the mixed snap points, the `frameSize` layout handler moves to the `SheetFrame`.

The names of the `constant` and `pixel` prop values are also aligned with [react-native-ios-modal](https://github.com/dominicstop/react-native-ios-modal/blob/main/src/types/RNIComputable/RNIComputableSize.ts).