### PR TITLE
fix(portal): fallback to `PortalItem` if no `RootTagContext` is available

### DIFF
--- a/packages/portal/src/Portal.native.tsx
+++ b/packages/portal/src/Portal.native.tsx
@@ -21,19 +21,9 @@ export const Portal = (props: PortalProps) => {
     />
   )
 
-  if (Platform.OS === 'android') {
+  if (Platform.OS === 'android' || !rootTag) {
     return <PortalItem hostName="root">{contents}</PortalItem>
   }
 
-  if (rootTag) {
-    return createPortal(contents, rootTag)
-  }
-
-  if (process.env.NODE_ENV === 'development') {
-    console.warn(
-      `Missing rootTag, this is a bug - you may need a different React Native version, or to avoid using "modal" on native.`
-    )
-  }
-
-  return null
+  return createPortal(contents, rootTag)
 }


### PR DESCRIPTION
This would allow components that use Portal to be used inside iOS native modals. Popover is still misplaced inside native modals, but that would be a separate issue.

Closes #944 - Missing RootTag warning when using Popover 'modal' property.