### PR TITLE
fix(sheet): better implementation of 'fit' snap points mode

### DIFF
--- a/apps/site/data/docs/components/sheet/1.59.0.mdx
+++ b/apps/site/data/docs/components/sheet/1.59.0.mdx
@@ -55,15 +55,17 @@ export default () => (
 By default, snap points are treated as percentages.
 
 ```tsx
-<Sheet snapPoints={[85, 50]} /> // 85% and 50%
+<Sheet snapPoints={[85, 50]}> // 85% and 50%
 ```
 
 The behavior of snap points can be changed by setting the `snapPointsMode` prop to any of these values:
 
-- **percent** (default) - Snap points are treated as percentages of the parent container or screen
-- **constant** - Snap points are treated as raw pixel values
-- **fit** - Snap points are ignored and the sheet is constrained to the content height
+- **percent** (default) - Snap points are percentages of the parent container or screen as numbers
+- **constant** - Snap points are raw pixel values as numbers
+- **fit** - The sheet is constrained to the content's natural height without the `snapPoints` prop
 - **mixed** - Snap points can be either numbers (pixels), percentages as strings (ex: `"50%"`), or `"fit"` for fit behavior
+
+Snap points should be ordered from largest to smallest (most visible to least visible). When using `mixed` mode with the `"fit"` as a snap point, it must be the first and largest snap point.
 
 ## Unstyled
 
@@ -177,15 +179,15 @@ Contains every component for the sheet.
     },
     {
       name: 'snapPoints',
-      type: '(number | string)[]',
+      type: '(number | string)[] | undefined',
       default: `[80]`,
-      description: `Array of values representing different sizes for the sheet to snap to. Values should be ordered most visible to least visible. Use "open" prop for fully closed.`,
+      description: `Array of values representing different sizes for the sheet to snap to. Not used in 'fit' mode. See docs above for usage information.`,
     },
     {
       name: 'snapPointsMode',
       type: '"percent" | "constant" | "fit" | "mixed"',
       default: '"percent"',
-      description: `Alters the behavior of the 'snapPoints' prop. See docs above for usage information.`
+      description: `Alters the behavior of the 'snapPoints' prop. See docs above for usage information.`,
     },
     {
       name: 'onPositionChange',

--- a/packages/demos/src/SheetDemo.tsx
+++ b/packages/demos/src/SheetDemo.tsx
@@ -26,7 +26,7 @@ export const SheetDemo = () => {
     : isFit
     ? undefined
     : mixedFitDemo
-    ? ['fit', 190]
+    ? ['fit', 110]
     : ['80%', 256, 190]
 
   return (
@@ -65,8 +65,6 @@ export const SheetDemo = () => {
       </YStack>
 
       <Sheet
-        // force remount when switching to fit modes to avoid weird measurement loop
-        key={hasFit ? 'fit' : 'no-fit'}
         forceRemoveScrollEnabled={open}
         modal={modal}
         open={open}
@@ -85,14 +83,7 @@ export const SheetDemo = () => {
           exitStyle={{ opacity: 0 }}
         />
         <Sheet.Handle />
-        <Sheet.Frame
-          flex={1}
-          padding="$4"
-          justifyContent="center"
-          alignItems="center"
-          space="$5"
-          {...(hasFit && { minHeight: 320, flexShrink: 0 })}
-        >
+        <Sheet.Frame padding="$4" justifyContent="center" alignItems="center" space="$5">
           <Button size="$6" circular icon={ChevronDown} onPress={() => setOpen(false)} />
           <Input width={200} />
           {modal && isPercent && (

--- a/packages/sheet/src/SheetImplementationCustom.tsx
+++ b/packages/sheet/src/SheetImplementationCustom.tsx
@@ -378,7 +378,7 @@ export const SheetImplementationCustom = themeable(
     }, [open])
 
     const forcedContentHeight = hasFit
-      ? frameSize
+      ? undefined
       : snapPointsMode === 'percent'
       ? `${maxSnapPoint}%`
       : maxSnapPoint
@@ -408,7 +408,7 @@ export const SheetImplementationCustom = themeable(
           <AnimatedView
             ref={ref}
             {...panResponder?.panHandlers}
-            onLayout={hasFit ? undefined : handleAnimationViewLayout}
+            onLayout={handleAnimationViewLayout}
             pointerEvents={open && !shouldHideParentSheet ? 'auto' : 'none'}
             //  @ts-ignore
             animation={props.animation}

--- a/packages/sheet/src/createSheet.tsx
+++ b/packages/sheet/src/createSheet.tsx
@@ -11,15 +11,8 @@ import {
   withStaticProperties,
 } from '@tamagui/core'
 import { RemoveScroll } from '@tamagui/remove-scroll'
-import {
-  FunctionComponent,
-  RefAttributes,
-  forwardRef,
-  memo,
-  useCallback,
-  useMemo,
-} from 'react'
-import { LayoutChangeEvent, Platform, View } from 'react-native'
+import { FunctionComponent, RefAttributes, forwardRef, memo, useMemo } from 'react'
+import { Platform, View } from 'react-native'
 
 import { SHEET_HANDLE_NAME, SHEET_NAME, SHEET_OVERLAY_NAME } from './constants'
 import { getNativeSheet } from './nativeSheet'
@@ -129,30 +122,23 @@ export function createSheet<
         forwardedRef
       ) => {
         const context = useSheetContext(SHEET_NAME, __scopeSheet)
-        const { removeScrollEnabled, frameSize, contentRef } = context
+        const { hasFit, removeScrollEnabled, frameSize, contentRef } = context
         const composedContentRef = useComposedRefs(forwardedRef, contentRef)
         const offscreenSize = useSheetOffscreenSize(context)
-
-        const handleLayoutChange = useCallback((e: LayoutChangeEvent) => {
-          const next = e.nativeEvent?.layout.height
-          if (!next) return
-          context.setFrameSize(next)
-        }, [])
-
         const sheetContents = useMemo(() => {
           return (
             // @ts-ignore
             <Frame
               ref={composedContentRef}
-              height={context.hasFit ? undefined : frameSize}
-              onLayout={context.hasFit ? handleLayoutChange : undefined}
+              flex={hasFit ? 0 : 1}
+              height={hasFit ? undefined : frameSize}
               {...props}
             >
               {children}
               <Stack data-sheet-offscreen-pad height={offscreenSize} width="100%" />
             </Frame>
           )
-        }, [props, frameSize, offscreenSize])
+        }, [props, frameSize, offscreenSize, hasFit])
 
         return (
           <>

--- a/packages/sheet/src/useSheetOffscreenSize.tsx
+++ b/packages/sheet/src/useSheetOffscreenSize.tsx
@@ -21,24 +21,24 @@ export const useSheetOffscreenSize = ({
   if (snapPointsMode === 'percent') {
     const maxPercentOpened = Number(snapPoints[0]) / 100
     const percentOpened = Number(snapPoints[position] ?? 0) / 100
-    const percentHidden = 1 - maxPercentOpened - percentOpened
+    const percentHidden = maxPercentOpened - percentOpened
     const offscreenSize = percentHidden * screenSize
     return offscreenSize
   }
 
   // mixed:
   const maxSnapPoint = snapPoints[0]
+  if (maxSnapPoint === 'fit') {
+    return 0
+  }
+
   const maxSize =
-    maxSnapPoint === 'fit'
-      ? frameSize
-      : typeof maxSnapPoint === 'string'
+    typeof maxSnapPoint === 'string'
       ? (Number(maxSnapPoint.slice(0, -1)) / 100) * screenSize
       : maxSnapPoint
   const currentSnapPoint = snapPoints[position] ?? 0
   const currentSize =
-    currentSnapPoint === 'fit'
-      ? frameSize
-      : typeof currentSnapPoint === 'string'
+    typeof currentSnapPoint === 'string'
       ? (Number(currentSnapPoint.slice(0, -1)) / 100) * screenSize
       : currentSnapPoint
   const offscreenSize = maxSize - currentSize


### PR DESCRIPTION
## Description

Improves the implementation of the Sheet's "fit" snap points mode. 

After these changes I was able to remove all the fit-mode-specific changes to the SheetDemo (key prop, extra styles). I think I got it right this time 🤞 

## List of changes

- Moved fit mode's frame size measurement layout handler back to the AnimatedView where it probably belongs
- Set `forcedContentHeight` constraint to `undefined` when in fit mode - previously this was being constrained to the initial frame size before measurement (`0`)
- Conditionally toggle the frame to `flex: 0` when in fit mode
- Update offscreen calculation to always return `0` when in fit mode.
  - Without this, the `data-sheet-offscreen-pad` element changes the height of the frame when the sheet is partially off screen, causing nasty layout measurement loops
- Fixed regression in offscreen calculation for percent mode
- Fixed missing useMemo dependency of `hasFit` in `sheetContents`

## Demo

https://github.com/tamagui/tamagui/assets/2250252/3758ce11-f400-41d1-b6a9-47ebfa16c36c
