### PR TITLE
fix(switch): fix starting position of thumb when switch is initially checked

### DIFF
--- a/packages/demos/src/SwitchDemo.tsx
+++ b/packages/demos/src/SwitchDemo.tsx
@@ -3,16 +3,28 @@ import { Label, Separator, SizeTokens, Switch, XStack, YStack, styled } from 'ta
 export function SwitchDemo() {
   return (
     <YStack width={200} alignItems="center" space="$3">
-      <SwitchWithLabel size="$2" />
-      <SwitchWithLabel size="$3" />
-      <SwitchWithLabel size="$4" />
-      <SwitchWithLabel size="$5" />
+      <XStack space="$3" $xs={{ flexDirection: 'column' }}>
+        <SwitchWithLabel size="$2" />
+        <SwitchWithLabel size="$2" defaultChecked />
+      </XStack>
+      <XStack space="$3" $xs={{ flexDirection: 'column' }}>
+        <SwitchWithLabel size="$3" />
+        <SwitchWithLabel size="$3" defaultChecked />
+      </XStack>
+      <XStack space="$3" $xs={{ flexDirection: 'column' }}>
+        <SwitchWithLabel size="$4" />
+        <SwitchWithLabel size="$4" defaultChecked />
+      </XStack>
+      <XStack space="$3" $xs={{ flexDirection: 'column' }}>
+        <SwitchWithLabel size="$5" />
+        <SwitchWithLabel size="$5" defaultChecked />
+      </XStack>
     </YStack>
   )
 }
 
-export function SwitchWithLabel(props: { size: SizeTokens }) {
-  const id = `switch-${props.size.toString().slice(1)}`
+export function SwitchWithLabel(props: { size: SizeTokens; defaultChecked?: boolean }) {
+  const id = `switch-${props.size.toString().slice(1)}-${props.defaultChecked ?? ''}}`
   return (
     <XStack width={200} alignItems="center" space="$4">
       <Label
@@ -25,7 +37,7 @@ export function SwitchWithLabel(props: { size: SizeTokens }) {
         Dark mode
       </Label>
       <Separator minHeight={20} vertical />
-      <Switch id={id} size={props.size}>
+      <Switch id={id} size={props.size} defaultChecked={props.defaultChecked}>
         <Switch.Thumb animation="quick" />
       </Switch>
     </XStack>

--- a/packages/demos/types/SwitchDemo.d.ts
+++ b/packages/demos/types/SwitchDemo.d.ts
@@ -3,5 +3,6 @@ import { SizeTokens } from 'tamagui';
 export declare function SwitchDemo(): JSX.Element;
 export declare function SwitchWithLabel(props: {
     size: SizeTokens;
+    defaultChecked?: boolean;
 }): JSX.Element;
 //# sourceMappingURL=SwitchDemo.d.ts.map

--- a/packages/switch/src/Switch.tsx
+++ b/packages/switch/src/Switch.tsx
@@ -1,6 +1,6 @@
 import { SizeTokens, getVariableValue, styled } from '@tamagui/core'
 import { getSize } from '@tamagui/get-token'
-import { ThemeableStack, XStack } from '@tamagui/stacks'
+import { ThemeableStack, YStack } from '@tamagui/stacks'
 
 import { SwitchContext, createSwitch } from './createSwitch'
 
@@ -38,7 +38,7 @@ const getSwitchHeight = (val: SizeTokens) =>
 
 const getSwitchWidth = (val: SizeTokens) => getSwitchHeight(val) * 2
 
-export const SwitchFrame = styled(XStack, {
+export const SwitchFrame = styled(YStack, {
   name: 'Switch',
   tag: 'button',
   context: SwitchContext,

--- a/packages/switch/src/createSwitch.tsx
+++ b/packages/switch/src/createSwitch.tsx
@@ -34,7 +34,7 @@ export const SwitchContext = createStyledContext<{
   checked: false,
   disabled: false,
   size: undefined,
-  frameWidth: 60,
+  frameWidth: 0,
   unstyled: false,
 })
 
@@ -70,13 +70,16 @@ export function createSwitch<
     const { size: sizeProp, ...thumbProps } = props
     const { disabled, checked, unstyled, frameWidth } = React.useContext(SwitchContext)
     const [thumbWidth, setThumbWidth] = React.useState(0)
+    const initialChecked = React.useRef(checked).current
+    const distance = frameWidth - thumbWidth
     return (
       // @ts-ignore
       <Thumb
         theme={unstyled === false && checked ? 'active' : null}
         data-state={getState(checked)}
         data-disabled={disabled ? '' : undefined}
-        x={checked ? frameWidth - thumbWidth : 0}
+        alignSelf={initialChecked ? 'flex-end' : 'flex-start'}
+        x={initialChecked ? (checked ? 0 : -distance) : checked ? distance : 0}
         {...thumbProps}
         // @ts-ignore
         onLayout={composeEventHandlers(props.onLayout, (e) =>
@@ -147,8 +150,7 @@ export function createSwitch<
           : true
         : false
 
-      // just guess some value
-      const [frameWidth, setFrameWidth] = React.useState(60)
+      const [frameWidth, setFrameWidth] = React.useState(0)
 
       const [checked = false, setChecked] = useControllableState({
         prop: checkedProp,
@@ -187,7 +189,7 @@ export function createSwitch<
             size={size}
             checked={checked}
             disabled={disabled}
-            frameWidth={frameWidth - leftBorderWidth * 2}
+            frameWidth={frameWidth ? frameWidth - leftBorderWidth * 2 : 0}
             theme={checked ? 'active' : null}
             themeShallow
             role="switch"


### PR DESCRIPTION
## Description

This fixes a visual bug with the switch component. When it is initially checked (either with `defaultChecked` or the `checked` prop) the starting position of the thumb is out of the boundaries of the switch frame. 

A demonstration of this issue can be seen on the Tamagui docs site on demos with an animation switch:

https://github.com/tamagui/tamagui/assets/2250252/9dec3a4e-607f-4576-b5a0-cbaf54319913

## List of changes

* Set initial position of the switch's thumb without needing any measurements
  - Update tamagui's `SwitchFrame` component to use `YStack` instead of `XStack`, so that the thumb can position itself using flex alignment
  - Update Switch Thumb component to alter its starting position based on the initial value of `checked`/`defaultChecked`. When initially checked, the thumb aligns itself to `flex-end` and the `x` translation direction is swapped.
* Remove guessed starting width from the frame (changed initial measurement: 60 -> 0)

## Breaking changes

If any users have built a custom switch component (`createSwitch(...)`) using an `XStack` as their switch frame, these styles will not work.

Luckily the default example in the docs uses a raw `Stack` which is in a column direction by default, so I hope this will have minimal impact.