### PR TITLE
fix(sheet): sheet height measurement on mobile web

### DIFF
--- a/packages/sheet/src/SheetImplementationCustom.tsx
+++ b/packages/sheet/src/SheetImplementationCustom.tsx
@@ -325,15 +325,7 @@ export const SheetImplementationCustom = themeable(
 
     const handleAnimationViewLayout = useCallback(
       (e: LayoutChangeEvent) => {
-        const next = (() => {
-          let _ = e.nativeEvent?.layout.height
-          if (isWeb && isTouchable && !open) {
-            // temp fix ios bug where it doesn't go below dynamic bottom...
-            _ += 100
-          }
-          return _
-        })()
-
+        const next = e.nativeEvent?.layout.height
         if (!next) return
         setFrameSize(next)
       },


### PR DESCRIPTION
## Description

Fixes measurement of the sheet height on mobile web by removing an old workaround that added extra height on mobile browsers.

I tested all modes after making this change with mobile Safari's dynamic bottom bar in different positions and everything seemed to still be working.

## Demo

https://github.com/tamagui/tamagui/assets/2250252/5b38c53d-f391-4611-80e8-257744e38feb
