### PR TITLE
Fix for create-tamagui fail to detect proper package manager

### DIFF
--- a/packages/create-tamagui/package.json
+++ b/packages/create-tamagui/package.json
@@ -34,6 +34,7 @@
     "commander": "2.20.0",
     "cpy": "7.3.0",
     "cross-spawn": "6.0.5",
+    "detect-package-manager": "^3.0.1",
     "esbuild-register": "^3.4.2",
     "fs-extra": "^11.1.0",
     "got": "10.7.0",

--- a/packages/create-tamagui/src/helpers/cloneStarter.ts
+++ b/packages/create-tamagui/src/helpers/cloneStarter.ts
@@ -90,7 +90,7 @@ async function setupTamaguiDotDir(template: (typeof templates)[number], isRetry 
 
     const cmd = `git clone --branch ${branch} ${
       isInSubDir ? '--depth 1 --sparse --filter=blob:none ' : ''
-    }${sourceGitRepo} ${targetGitDir}`
+    } ${sourceGitRepo} "${targetGitDir}"`
     console.log(`$ ${cmd}`)
     console.log()
 

--- a/packages/create-tamagui/src/helpers/installDependencies.ts
+++ b/packages/create-tamagui/src/helpers/installDependencies.ts
@@ -2,7 +2,7 @@ import * as PackageManager from '@expo/package-manager'
 
 export async function installDependencies(
   projectRoot: string,
-  packageManager: 'yarn' | 'npm' | 'pnpm'
+  packageManager: 'yarn' | 'npm' | 'pnpm' | 'bun'
 ) {
   const options = { cwd: projectRoot }
   if (packageManager === 'yarn') {

--- a/packages/create-tamagui/src/index.ts
+++ b/packages/create-tamagui/src/index.ts
@@ -10,6 +10,7 @@ import { cwd } from 'process'
 import chalk from 'chalk'
 import Commander from 'commander'
 import { $, cd } from 'zx'
+import { detect } from 'detect-package-manager'
 
 import packageJson from '../package.json'
 import { IS_TEST } from './create-tamagui-constants'
@@ -59,9 +60,8 @@ if (process.argv.includes('--version')) {
 }
 const skipCloning = !!program.skipCloning
 
-const packageManager = 'yarn'
-
 async function run() {
+  const packageManager = await detect()
   if (!skipCloning) {
     console.log() // this newline prevents the ascii art from breaking
     console.log(tamaguiRainbowAsciiArt)
@@ -139,6 +139,7 @@ ${chalk.bold(chalk.red(`Please pick a different project name 🥸`))}`
     console.log()
 
     try {
+      console.log('installing with ' + packageManager)
       await installDependencies(resolvedProjectPath, packageManager)
     } catch (e: any) {
       console.error(


### PR DESCRIPTION
This pull request fixes #[1272](https://github.com/tamagui/tamagui/issues/1272). I also encountered an issue while running the program where it failed when cloning the tamagui master repo. since it spits out "fatal error: too many arguments", I had to double-quote the local directory to handle spaces in paths