### PR TITLE
fix(constants): use matching types on all code splitting paths

### DIFF
--- a/packages/constants/src/index.android.ts
+++ b/packages/constants/src/index.android.ts
@@ -1,13 +1,13 @@
 import { useLayoutEffect } from 'react'
 
-export const isWeb = false
-export const isWindowDefined = false
-export const isServer = false
-export const isClient = false
+export const isWeb: boolean = false
+export const isWindowDefined: boolean = false
+export const isServer: boolean = false
+export const isClient: boolean = false
 export const useIsomorphicLayoutEffect = useLayoutEffect
-export const isChrome = false
-export const isWebTouchable = false
-export const isTouchable = true
-export const isAndroid = true
-export const isIos = false
-export const currentPlatform = 'android'
+export const isChrome: boolean = false
+export const isWebTouchable: boolean = false
+export const isTouchable: boolean = true
+export const isAndroid: boolean = true
+export const isIos: boolean = false
+export const currentPlatform: 'web' | 'ios' | 'native' | 'android' = 'android'

--- a/packages/constants/src/index.ios.ts
+++ b/packages/constants/src/index.ios.ts
@@ -1,13 +1,13 @@
 import { useLayoutEffect } from 'react'
 
-export const isWeb = false
-export const isWindowDefined = false
-export const isServer = false
-export const isClient = false
+export const isWeb: boolean = false
+export const isWindowDefined: boolean = false
+export const isServer: boolean = false
+export const isClient: boolean = false
 export const useIsomorphicLayoutEffect = useLayoutEffect
-export const isChrome = false
-export const isWebTouchable = false
-export const isTouchable = true
-export const isAndroid = false
-export const isIos = true
-export const currentPlatform = 'ios'
+export const isChrome: boolean = false
+export const isWebTouchable: boolean = false
+export const isTouchable: boolean = true
+export const isAndroid: boolean = false
+export const isIos: boolean = true
+export const currentPlatform: 'web' | 'ios' | 'native' | 'android' = 'ios'

--- a/packages/constants/src/index.native.ts
+++ b/packages/constants/src/index.native.ts
@@ -1,13 +1,13 @@
 import { useLayoutEffect } from 'react'
 
-export const isWeb = false
-export const isWindowDefined = false
-export const isServer = false
-export const isClient = false
+export const isWeb: boolean = false
+export const isWindowDefined: boolean = false
+export const isServer: boolean = false
+export const isClient: boolean = false
 export const useIsomorphicLayoutEffect = useLayoutEffect
-export const isChrome = false
-export const isWebTouchable = false
-export const isTouchable = true
-export const isAndroid = false
-export const isIos = false
-export const currentPlatform = 'native'
+export const isChrome: boolean = false
+export const isWebTouchable: boolean = false
+export const isTouchable: boolean = true
+export const isAndroid: boolean = false
+export const isIos: boolean = false
+export const currentPlatform: 'web' | 'ios' | 'native' | 'android' = 'native'

--- a/packages/constants/types/index.android.d.ts
+++ b/packages/constants/types/index.android.d.ts
@@ -1,13 +1,13 @@
 import { useLayoutEffect } from 'react';
-export declare const isWeb = false;
-export declare const isWindowDefined = false;
-export declare const isServer = false;
-export declare const isClient = false;
+export declare const isWeb: boolean;
+export declare const isWindowDefined: boolean;
+export declare const isServer: boolean;
+export declare const isClient: boolean;
 export declare const useIsomorphicLayoutEffect: typeof useLayoutEffect;
-export declare const isChrome = false;
-export declare const isWebTouchable = false;
-export declare const isTouchable = true;
-export declare const isAndroid = true;
-export declare const isIos = false;
-export declare const currentPlatform = "android";
+export declare const isChrome: boolean;
+export declare const isWebTouchable: boolean;
+export declare const isTouchable: boolean;
+export declare const isAndroid: boolean;
+export declare const isIos: boolean;
+export declare const currentPlatform: 'web' | 'ios' | 'native' | 'android';
 //# sourceMappingURL=index.android.d.ts.map

--- a/packages/constants/types/index.ios.d.ts
+++ b/packages/constants/types/index.ios.d.ts
@@ -1,13 +1,13 @@
 import { useLayoutEffect } from 'react';
-export declare const isWeb = false;
-export declare const isWindowDefined = false;
-export declare const isServer = false;
-export declare const isClient = false;
+export declare const isWeb: boolean;
+export declare const isWindowDefined: boolean;
+export declare const isServer: boolean;
+export declare const isClient: boolean;
 export declare const useIsomorphicLayoutEffect: typeof useLayoutEffect;
-export declare const isChrome = false;
-export declare const isWebTouchable = false;
-export declare const isTouchable = true;
-export declare const isAndroid = false;
-export declare const isIos = true;
-export declare const currentPlatform = "ios";
+export declare const isChrome: boolean;
+export declare const isWebTouchable: boolean;
+export declare const isTouchable: boolean;
+export declare const isAndroid: boolean;
+export declare const isIos: boolean;
+export declare const currentPlatform: 'web' | 'ios' | 'native' | 'android';
 //# sourceMappingURL=index.ios.d.ts.map

--- a/packages/constants/types/index.native.d.ts
+++ b/packages/constants/types/index.native.d.ts
@@ -1,13 +1,13 @@
 import { useLayoutEffect } from 'react';
-export declare const isWeb = false;
-export declare const isWindowDefined = false;
-export declare const isServer = false;
-export declare const isClient = false;
+export declare const isWeb: boolean;
+export declare const isWindowDefined: boolean;
+export declare const isServer: boolean;
+export declare const isClient: boolean;
 export declare const useIsomorphicLayoutEffect: typeof useLayoutEffect;
-export declare const isChrome = false;
-export declare const isWebTouchable = false;
-export declare const isTouchable = true;
-export declare const isAndroid = false;
-export declare const isIos = false;
-export declare const currentPlatform = "native";
+export declare const isChrome: boolean;
+export declare const isWebTouchable: boolean;
+export declare const isTouchable: boolean;
+export declare const isAndroid: boolean;
+export declare const isIos: boolean;
+export declare const currentPlatform: 'web' | 'ios' | 'native' | 'android';
 //# sourceMappingURL=index.native.d.ts.map


### PR DESCRIPTION
Updates the type definitions of all code-splitting paths to match the un-suffixed web version.

This should handle cases where someone has [**compilerOptions.moduleSuffixes**](https://www.typescriptlang.org/tsconfig#moduleSuffixes) set to something like `[".ios", ".native", ""]` in their typescript configuration.