### PR TITLE
fix(cli): fallback to ssh if https failed on `add`

### DIFF
--- a/packages/cli/src/add.ts
+++ b/packages/cli/src/add.ts
@@ -41,9 +41,15 @@ export const installGeneratedPackage = async (type: string, packagesPath?: strin
   }
   try {
     process.chdir(tamaguiDir)
-    execSync(
-      `git clone -n --depth=1 --branch generated --filter=tree:0 https://github.com/tamagui/${repoName}`
-    )
+    try {
+      execSync(
+        `git clone -n --depth=1 --branch generated --filter=tree:0 https://github.com/tamagui/${repoName}`
+      )
+    } catch (error) {
+      execSync(
+        `git clone -n --depth=1 --branch generated --filter=tree:0 ssh://github.com/tamagui/${repoName}`
+      )
+    }
 
     process.chdir(tempDir)
     execSync([`git sparse-checkout set --no-cone meta`, `git checkout`].join(' && '))
@@ -116,3 +122,5 @@ export const installGeneratedPackage = async (type: string, packagesPath?: strin
     console.log(marked.parse(readFileSync(readmePath).toString()))
   }
 }
+
+function cloneGeneratedBranch(repoName: string) {}


### PR DESCRIPTION
~Not tested yet~ Tested. Works as expected. 

TODO: do the same for `create-tamagu`.