### PR TITLE
Fix native toast timing to match burnt specification + tamagui docs

### DIFF
--- a/packages/toast/src/createNativeToast.native.tsx
+++ b/packages/toast/src/createNativeToast.native.tsx
@@ -10,7 +10,7 @@ export const createNativeToast: CreateNativeToastsFn = (
   Burnt.toast({
     title,
     message,
-    duration: duration ? duration * 1000 : undefined,
+    duration: duration ? duration / 1000 : undefined,
     ...burntOptions,
   })
   return true


### PR DESCRIPTION
I noticed that my native toasts were never ending, while my web toasts were working as expected. Turns out, that if we input 2000ms, we end up with a 2,000,000 second toast on native!

This issue stems from us multiplying instead of dividing the `duration` option to match Burnt's spec (which says duration should be in seconds).

### Burnt Documentation

<img width="516" alt="image" src="https://github.com/tamagui/tamagui/assets/16158417/6e541345-9e7b-420a-be0a-e08760d2e145">

### Tamagui Documentation

<img width="361" alt="image" src="https://github.com/tamagui/tamagui/assets/16158417/8942b0ef-7eb4-4b74-b236-b43fd209eaa9">