### PR TITLE
fix(switch): export SwitchContext for headless consumers

### DIFF
--- a/packages/switch/src/index.ts
+++ b/packages/switch/src/index.ts
@@ -2,6 +2,7 @@ import { createSwitch } from './createSwitch'
 import { SwitchFrame, SwitchThumb } from './Switch'
 
 export * from './Switch'
+export * from './SwitchContext'
 export * from './createSwitch'
 
 export const Switch = createSwitch({

--- a/packages/switch/types/index.d.ts
+++ b/packages/switch/types/index.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="react" />
 export * from './Switch';
+export * from './SwitchContext';
 export * from './createSwitch';
 export declare const Switch: import("react").ForwardRefExoticComponent<Omit<Omit<import("react-native").ViewProps, "display" | "children" | "style" | ("onLayout" | keyof import("react-native").GestureResponderHandlers)> & import("@tamagui/web").ExtendBaseStackProps & import("@tamagui/web").TamaguiComponentPropsBase & {
     style?: import("@tamagui/web").StyleProp<import("react-native").ViewStyle | import("react").CSSProperties | (import("react").CSSProperties & import("react-native").ViewStyle)>;


### PR DESCRIPTION
Adds a missing export for `SwitchContext` on the `@tamagui/switch` package. 

Previously this was exported from another file.