### PR TITLE
Make next-plugin types accept loader-options

### DIFF
--- a/packages/loader/src/TamaguiPlugin.ts
+++ b/packages/loader/src/TamaguiPlugin.ts
@@ -1,7 +1,7 @@
 import { TamaguiOptions, loadTamagui, watchTamaguiConfig } from '@tamagui/static'
 import type { Compiler, RuleSetRule } from 'webpack'
 
-type PluginOptions = TamaguiOptions & {
+export type PluginOptions = TamaguiOptions & {
   isServer?: boolean
   enableStudio?: boolean
   exclude?: RuleSetRule['exclude']

--- a/packages/loader/types/TamaguiPlugin.d.ts
+++ b/packages/loader/types/TamaguiPlugin.d.ts
@@ -1,6 +1,6 @@
 import { TamaguiOptions } from '@tamagui/static';
 import type { Compiler, RuleSetRule } from 'webpack';
-type PluginOptions = TamaguiOptions & {
+export type PluginOptions = TamaguiOptions & {
     isServer?: boolean;
     enableStudio?: boolean;
     exclude?: RuleSetRule['exclude'];
@@ -16,5 +16,4 @@ export declare class TamaguiPlugin {
     constructor(options?: PluginOptions);
     apply(compiler: Compiler): void;
 }
-export {};
 //# sourceMappingURL=TamaguiPlugin.d.ts.map

--- a/packages/next-plugin/src/withTamagui.ts
+++ b/packages/next-plugin/src/withTamagui.ts
@@ -1,15 +1,14 @@
 import { existsSync } from 'fs'
 import path, { dirname, join } from 'path'
 
-import type { TamaguiOptions } from '@tamagui/static'
 import browserslist from 'browserslist'
 import buildResolver from 'esm-resolve'
 import { lazyPostCSS } from 'next/dist/build/webpack/config/blocks/css'
 import { getGlobalCssLoader } from 'next/dist/build/webpack/config/blocks/css/loaders'
-import { TamaguiPlugin, shouldExclude as shouldExcludeDefault } from 'tamagui-loader'
+import { TamaguiPlugin, shouldExclude as shouldExcludeDefault, type PluginOptions as LoaderPluginOptions  } from 'tamagui-loader'
 import webpack from 'webpack'
 
-export type WithTamaguiProps = TamaguiOptions & {
+export type WithTamaguiProps = LoaderPluginOptions & {
   useReactNativeWebLite: boolean
   enableLegacyFontSupport?: boolean
   aliasReactPackages?: boolean

--- a/packages/next-plugin/types/withTamagui.d.ts
+++ b/packages/next-plugin/types/withTamagui.d.ts
@@ -1,5 +1,5 @@
-import type { TamaguiOptions } from '@tamagui/static';
-export type WithTamaguiProps = TamaguiOptions & {
+import { type PluginOptions as LoaderPluginOptions } from 'tamagui-loader';
+export type WithTamaguiProps = LoaderPluginOptions & {
     useReactNativeWebLite: boolean;
     enableLegacyFontSupport?: boolean;
     aliasReactPackages?: boolean;


### PR DESCRIPTION
close https://github.com/tamagui/tamagui/issues/1755

It fixes type definitions to avoid that using next app router make jsx build failed.