### PR TITLE
docs(expo): add real link to expo.dev typescript setup

### DIFF
--- a/apps/site/data/docs/guides/expo.mdx
+++ b/apps/site/data/docs/guides/expo.mdx
@@ -13,9 +13,13 @@ This guide assumes Expo is configured with TypeScript support.
 npx create-expo-app -t expo-template-blank-typescript
 ```
 
-For instructions on adding TypeScript to an existing project, visit https://docs.expo.dev/guides/typescript/
+For instructions on adding TypeScript to an existing project, visit the [expo typescript documentation](https://docs.expo.dev/guides/typescript/).
 
-To support dark mode, update your app.json to app.config.ts and set "userInterfaceStyle" to "automatic"
+To support dark mode, update your `app.json` to `app.config.ts` and set userInterfaceStyle to automatic.
+
+```ts
+userInterfaceStyle: "automatic",
+```
 
 ### Update Babel / Metro
 


### PR DESCRIPTION
this does not spark joy 😭

![cleanshot-Firefox-WP3vlhze](https://github.com/tamagui/tamagui/assets/360936/99866724-be8d-4979-9587-9104a6e89e98)

I added a real link, so that devs can open another extra tab
