### PR TITLE
fix(core): fix fastSchemeChange not working if you inverse the theme …

### DIFF
--- a/apps/kitchen-sink/src/Sandbox.tsx
+++ b/apps/kitchen-sink/src/Sandbox.tsx
@@ -2,15 +2,26 @@
 
 import { View } from 'react-native'
 import { Text as RNText, TextInput } from 'react-native'
-import { Button, Input, Square, Text, Theme, useTheme } from 'tamagui'
+import { Button, Input, Square, Stack, Text, Theme, useTheme } from 'tamagui'
 
 export const Sandbox = () => {
   return (
     <View style={{ width: '100%', height: '100%', padding: 50 }}>
       <Theme name="dark">
-        <Square size={100} bc="$background" />
+        <Square
+          size={100}
+          bc="$background"
+          pressStyle={{ bg: 'red' }}
+          onPress={() => {
+            alert('wtf')
+          }}
+        />
         <TestInner />
       </Theme>
+
+      <Stack group="testy">
+        <Text $group-testy={{ color: 'red' }}>Hello!?</Text>
+      </Stack>
     </View>
   )
 }

--- a/apps/kitchen-sink/src/Sandbox.tsx
+++ b/apps/kitchen-sink/src/Sandbox.tsx
@@ -2,14 +2,21 @@
 
 import { View } from 'react-native'
 import { Text as RNText, TextInput } from 'react-native'
-import { Button, Input, Text } from 'tamagui'
+import { Button, Input, Square, Text, Theme, useTheme } from 'tamagui'
 
 export const Sandbox = () => {
   return (
     <View style={{ width: '100%', height: '100%', padding: 50 }}>
-      <Input onPress={() => console.log('press')} onFocus={() => console.log('focus')} />
+      <Theme name="dark">
+        <Square size={100} bc="$background" />
+        <TestInner />
+      </Theme>
     </View>
   )
+}
+
+const TestInner = () => {
+  return null
 }
 
 // const CustomButton = styled(Button, {

--- a/packages/core-test/ThemeManager.web.test.tsx
+++ b/packages/core-test/ThemeManager.web.test.tsx
@@ -171,10 +171,11 @@ describe('ThemeManager', () => {
     expect(newState).toMatchInlineSnapshot(`
       {
         "className": "t_sub_theme t_dark",
-        "componentName": undefined,
+        "isComponent": false,
         "inverse": undefined,
         "name": "dark",
-        "parentName": "",
+        "parentName": undefined,
+        "scheme": "dark",
         "theme": {
           "background": {
             "isVar": true,

--- a/packages/core-test/ThemeManager.web.test.tsx
+++ b/packages/core-test/ThemeManager.web.test.tsx
@@ -374,13 +374,14 @@ describe('ThemeManager', () => {
     expect(child3.state.name).toBe('dark_blue_Button')
   })
 
-  test('Nested Component Themes are working now', () => {
+  test.only('Nested Component Themes are working now', () => {
     const parent = new ThemeManager(
       {
         name: 'dark',
       },
       'root'
     )
+
     const child = new ThemeManager(
       {
         name: 'blue',
@@ -388,6 +389,7 @@ describe('ThemeManager', () => {
       },
       parent
     )
+
     const child2 = new ThemeManager(
       {
         name: 'red',
@@ -395,39 +397,11 @@ describe('ThemeManager', () => {
       },
       child
     )
+
     expect(child2.parentManager).toBe(child)
     // it first check dark_red_Menu and because that doesn't exist it falls back to its parent
     expect(child2.state.name).toBe('dark_blue_Button')
   })
-
-  // this is no longer the case, we now use the component theme
-  // test(`Component sub of another component reverts to parent`, () => {
-  //   const parent = new ThemeManager(
-  //     {
-  //       name: 'dark',
-  //     },
-  //     'root'
-  //   )
-  //   const child = new ThemeManager(
-  //     {
-  //       name: 'red',
-  //       componentName: 'Button',
-  //     },
-  //     parent
-  //   )
-  //   const child2 = new ThemeManager(
-  //     {
-  //       componentName: 'Spacer',
-  //     },
-  //     child
-  //   )
-
-  //   // child 1 does change
-  //   expect(parent.id !== child.id).toBeTruthy()
-
-  //   // child 2 doesnt change so its the same as parent
-  //   expect(child2.id).toBe(parent.id)
-  // })
 
   test(`Doesn't find invalid parent when only passing component`, () => {
     expect(!!conf.themes['dark_Card']).toBeTruthy()

--- a/packages/core-test/ThemeManager.web.test.tsx
+++ b/packages/core-test/ThemeManager.web.test.tsx
@@ -234,7 +234,6 @@ describe('ThemeManager', () => {
     const child2 = new ThemeManager(
       {
         reset: true,
-        debug: 'verbose',
       },
       child
     )
@@ -250,6 +249,7 @@ describe('ThemeManager', () => {
       },
       'root'
     )
+
     const child = new ThemeManager(
       {
         name: 'blue',
@@ -257,14 +257,17 @@ describe('ThemeManager', () => {
       },
       parent
     )
+
     const child2 = new ThemeManager(
       {
         reset: true,
       },
       child
     )
+
     expect(child2.parentManager).toBe(child)
     expect(child2.state.name).toBe('dark')
+
     const child3 = new ThemeManager(
       {
         componentName: 'Button',
@@ -272,6 +275,7 @@ describe('ThemeManager', () => {
       },
       child
     )
+
     expect(child3.parentManager).toBe(child)
     expect(child3.state.name).toBe('dark')
   })
@@ -374,7 +378,7 @@ describe('ThemeManager', () => {
     expect(child3.state.name).toBe('dark_blue_Button')
   })
 
-  test.only('Nested Component Themes are working now', () => {
+  test('Nested component themes work', () => {
     const parent = new ThemeManager(
       {
         name: 'dark',
@@ -399,8 +403,9 @@ describe('ThemeManager', () => {
     )
 
     expect(child2.parentManager).toBe(child)
-    // it first check dark_red_Menu and because that doesn't exist it falls back to its parent
-    expect(child2.state.name).toBe('dark_blue_Button')
+
+    // it should be dark_red because Component themes are optional
+    expect(child2.state.name).toBe('dark_red')
   })
 
   test(`Doesn't find invalid parent when only passing component`, () => {

--- a/packages/core-test/ThemeManager.web.test.tsx
+++ b/packages/core-test/ThemeManager.web.test.tsx
@@ -220,20 +220,25 @@ describe('ThemeManager', () => {
       },
       'root'
     )
+
     const child = new ThemeManager(
       {
         name: 'dark',
       },
       parent
     )
+
     expect(child.state.name).toBe('dark')
     expect(child.parentManager).toBe(parent)
+
     const child2 = new ThemeManager(
       {
         reset: true,
+        debug: 'verbose',
       },
       child
     )
+
     expect(child2.parentManager).toBe(child)
     expect(child2.state.name).toBe('light')
   })

--- a/packages/core-test/ThemeManager.web.test.tsx
+++ b/packages/core-test/ThemeManager.web.test.tsx
@@ -171,8 +171,8 @@ describe('ThemeManager', () => {
     expect(newState).toMatchInlineSnapshot(`
       {
         "className": "t_sub_theme t_dark",
-        "isComponent": false,
         "inverse": undefined,
+        "isComponent": false,
         "name": "dark",
         "parentName": undefined,
         "scheme": "dark",

--- a/packages/core/src/index.tsx
+++ b/packages/core/src/index.tsx
@@ -20,7 +20,7 @@ import { getBaseViews } from './getBaseViews'
 import { useElementLayout } from './hooks/useElementLayout'
 import { usePlatformMethods } from './hooks/usePlatformMethods'
 import { RNViewProps } from './reactNativeTypes'
-import { Pressability, usePressability } from './vendor/Pressability'
+import { usePressability } from './vendor/Pressability'
 
 // re-exports all of @tamagui/web just adds hooks
 export * from '@tamagui/web'

--- a/packages/web/src/helpers/ThemeManager.tsx
+++ b/packages/web/src/helpers/ThemeManager.tsx
@@ -281,10 +281,13 @@ function getState(
         : `${pre}sub_theme ${pre}${
             !scheme || !restNames.length ? firstName : restNames.join('_')
           }`
-      const parentState = parentManager?.state
+
+      // because its a new theme the baseManager is now the parent
+      const parentState = baseManager?.state
       const parentScheme = parentState?.scheme
       const parentName = parentState?.name
       const inverse = parentScheme && scheme !== parentScheme
+
       result = {
         name: found,
         parentName,
@@ -294,6 +297,7 @@ function getState(
         isComponent,
         scheme,
       }
+
       break
     }
   }

--- a/packages/web/src/helpers/ThemeManager.tsx
+++ b/packages/web/src/helpers/ThemeManager.tsx
@@ -2,7 +2,7 @@ import { isWeb } from '@tamagui/constants'
 
 import { getThemes } from '../config'
 import { THEME_CLASSNAME_PREFIX, THEME_NAME_SEPARATOR } from '../constants/constants'
-import { ThemeParsed, ThemeProps } from '../types'
+import { ColorScheme, ThemeParsed, ThemeProps } from '../types'
 
 type ThemeListener = (
   name: string | null,
@@ -21,10 +21,10 @@ export type SetActiveThemeProps = {
 export type ThemeManagerState = {
   name: string
   theme?: ThemeParsed | null
+  isComponent?: boolean
   className?: string
-  parentName?: string
-  componentName?: string
   inverse?: boolean
+  scheme?: ColorScheme
 }
 
 const emptyState: ThemeManagerState = { name: '' }
@@ -37,22 +37,20 @@ let uid = 0
 
 export class ThemeManager {
   id = uid++
-  isComponent = false
   themeListeners = new Set<ThemeListener>()
   parentManager: ThemeManager | null = null
   state: ThemeManagerState = emptyState
-  scheme: 'light' | 'dark' | null = null
 
   constructor(
     public props: ThemeProps = {},
-    parentManagerIn?: ThemeManager | 'root' | null | undefined
+    manager?: ThemeManager | 'root' | null | undefined
   ) {
-    if (parentManagerIn === 'root') {
+    if (manager === 'root') {
       this.updateStateFromProps(props, false)
       return
     }
 
-    if (!parentManagerIn) {
+    if (!manager) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error(
           `No parent manager given, this is likely due to duplicated Tamagui dependencies. Check your lockfile for mis-matched versions. It could also be from an error somewhere else in your stack causing Tamagui to recieve undefined context, you can try putting some ErrorBoundary components around other areas of your app, or a Suspense boundary.`
@@ -61,13 +59,13 @@ export class ThemeManager {
       throw `❌ 0`
     }
 
-    this.parentManager = parentManagerIn
+    this.parentManager = manager
 
     if (this.updateStateFromProps(props, false)) {
       return
     }
 
-    return parentManagerIn || this
+    return manager || this
   }
 
   updateStateFromProps(
@@ -89,11 +87,7 @@ export class ThemeManager {
 
   updateState(nextState: ThemeManagerState, shouldNotify = true) {
     this.state = nextState
-    const names = this.state.name.split('_')
-    const lastName = names[names.length - 1][0]
-    this.isComponent = lastName[0] === lastName[0].toUpperCase()
     this._allKeys = null
-    this.scheme = names[0] === 'light' ? 'light' : names[0] === 'dark' ? 'dark' : null
     if (process.env.NODE_ENV === 'development') {
       this['_numChangeEventsSent'] ??= 0
       this['_numChangeEventsSent']++
@@ -166,72 +160,54 @@ export class ThemeManager {
   }
 }
 
-function getNextThemeClassName(name: string) {
-  const next = `t_sub_theme ${THEME_CLASSNAME_PREFIX}${name}`
-  return next.replace('light_', '').replace('dark_', '')
-}
-
 function getState(
   props: ThemeProps,
-  parentManager?: ThemeManager | null
+  manager?: ThemeManager | null
 ): ThemeManagerState | null {
-  const validManagerAndAllComponentThemes = getNonComponentParentManager(parentManager)
-  parentManager = validManagerAndAllComponentThemes[0]
-  const allComponentThemes = validManagerAndAllComponentThemes[1]
-  const themes = getThemes()
-  const isDirectParentAComponentTheme = allComponentThemes.length > 0
-
   if (props.name && props.reset) {
-    throw new Error('Cannot reset + set new name')
+    throw new Error(
+      process.env.NODE_ENV === 'production'
+        ? `❌004`
+        : 'Cannot reset and set a new name at the same time.'
+    )
   }
-
-  if (!props.name && !props.inverse && !props.reset && !props.componentName) {
+  if (!getHasThemeUpdatingProps(props)) {
     return null
   }
 
-  if (props.reset && !isDirectParentAComponentTheme && !parentManager?.parentManager) {
-    if (process.env.NODE_ENV === 'development') {
-      console.warn('Cannot reset no grandparent exists')
+  const themes = getThemes()
+  const [nonComponentManagers, componentManagers] = getManagers(manager)
+
+  let baseManager = nonComponentManagers[props.reset ? 1 : 0]
+  let parentManager = nonComponentManagers[props.reset ? 2 : 1]
+
+  if (!baseManager) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        props.reset
+          ? 'Cannot reset, no parent theme exists'
+          : `No ThemeManager found, not changing theme`
+      )
     }
     return null
   }
 
   let result: ThemeManagerState | null = null
 
-  const nextName = props.reset
-    ? isDirectParentAComponentTheme
-      ? parentManager?.state?.name || ''
-      : parentManager?.parentManager?.state?.name || ''
-    : props.name || ''
-  const { componentName } = props
-  const parentName = props.reset
-    ? isDirectParentAComponentTheme
-      ? // here because parentManager already skipped componentTheme so we have to only go up once
-        parentManager?.parentManager?.state.name || ''
-      : parentManager?.parentManager?.parentManager?.state.name || ''
-    : isDirectParentAComponentTheme
-    ? allComponentThemes[0] || ''
-    : parentManager?.state.name || ''
+  const isDirectParentAComponentTheme = !!baseManager?.parentManager?.state.isComponent
+  const baseName = baseManager?.state.name || ''
+  const nextName = props.reset ? parentManager?.state.name || '' : props.name || ''
 
+  const allComponentThemes = componentManagers.map((x) => x?.state.name || '')
   if (props.reset && isDirectParentAComponentTheme) {
-    // skip nearest component theme
     allComponentThemes.shift()
   }
 
   // components look for most specific, fallback upwards
-  const base = parentName.split(THEME_NAME_SEPARATOR)
-  const lastSegment = base[base.length - 1]
-  const isParentComponentTheme =
-    parentName && lastSegment[0].toUpperCase() === lastSegment[0]
-  if (isParentComponentTheme) {
-    base.pop() // always remove componentName they can't nest
-  }
-  const parentBaseTheme = isParentComponentTheme
-    ? base.slice(0, base.length).join(THEME_NAME_SEPARATOR)
-    : parentName
+  const base = baseName.split(THEME_NAME_SEPARATOR)
   const max = base.length
   const min =
-    componentName && !nextName
+    props.componentName && !nextName
       ? max // component name only don't search upwards
       : 0
 
@@ -239,12 +215,10 @@ function getState(
     console.groupCollapsed('ThemeManager.getState()')
     console.info({
       props,
-      parentName,
-      parentBaseTheme,
+      baseName,
       base,
       min,
       max,
-      isParentComponentTheme,
     })
   }
 
@@ -256,7 +230,7 @@ function getState(
     }
     let potentials: string[] = []
 
-    if (prefix && prefix !== parentBaseTheme) {
+    if (prefix && prefix !== baseName) {
       potentials.push(prefix)
     }
     if (nextName) {
@@ -269,40 +243,51 @@ function getState(
       }
     }
 
-    if (componentName) {
+    if (props.componentName) {
       let componentPotentials: string[] = []
       // components only look for component themes
       if (nextName) {
         const beforeSeparator = prefix.slice(0, prefix.indexOf(THEME_NAME_SEPARATOR))
-        componentPotentials.push(`${beforeSeparator}_${nextName}_${componentName}`)
+        componentPotentials.push(`${beforeSeparator}_${nextName}_${props.componentName}`)
       }
-      componentPotentials.push(`${prefix}_${componentName}`)
+      componentPotentials.push(`${prefix}_${props.componentName}`)
       if (nextName) {
         // do this one and one level up
         const prefixLessOne = base.slice(0, i - 1).join(THEME_NAME_SEPARATOR)
         if (prefixLessOne) {
-          const lessSpecific = `${prefixLessOne}_${nextName}_${componentName}`
+          const lessSpecific = `${prefixLessOne}_${nextName}_${props.componentName}`
           componentPotentials.unshift(lessSpecific)
         }
-        const moreSpecific = `${prefix}_${nextName}_${componentName}`
+        const moreSpecific = `${prefix}_${nextName}_${props.componentName}`
         componentPotentials.unshift(moreSpecific)
       }
       potentials = [...componentPotentials, ...potentials, ...allComponentThemes]
     }
+
     const found = potentials.find((t) => t in themes)
 
     if (process.env.NODE_ENV === 'development' && typeof props.debug === 'string') {
-      console.info(' - ', { found, potentials, parentManager })
+      console.info(' - ', { found, potentials, baseManager })
     }
 
     if (found) {
+      const names = found.split('_')
+      const [firstName, ...restNames] = names
+      const lastName = names[names.length - 1]
+      const isComponent = lastName[0] === lastName[0].toUpperCase()
+      const scheme =
+        firstName === 'light' ? 'light' : firstName === 'dark' ? 'dark' : undefined
+      const pre = THEME_CLASSNAME_PREFIX
+      const className = !isWeb ? '' : `${pre}sub_theme ${pre}${restNames.join('_')}`
+      const inverse = scheme !== manager?.state.scheme
+
       result = {
         name: found,
         theme: themes[found],
-        className: isWeb ? getNextThemeClassName(found) : '',
-        parentName,
-        componentName,
-        inverse: props.inverse,
+        className,
+        inverse,
+        isComponent,
+        scheme,
       }
       break
     }
@@ -329,19 +314,15 @@ const inverseThemeName = (themeName: string) => {
     : themeName.replace(/^dark/, 'light')
 }
 
-export function getNonComponentParentManager(themeManager?: ThemeManager | null) {
-  // components never inherit from components
-  // example <Switch><Switch.Thumb /></Switch>
-  // the Switch theme shouldn't be considered parent of Thumb
-  let res = themeManager
-  let componentThemeNames: string[] = []
-  while (res) {
-    if (res?.isComponent) {
-      componentThemeNames.push(res?.state?.name!)
-      res = res.parentManager
-    } else {
-      break
-    }
+// components never inherit from components
+// example <Switch><Switch.Thumb /></Switch>
+// the Switch theme shouldn't be considered parent of Thumb
+export function getManagers(themeManager?: ThemeManager | null) {
+  const parents = [[], []] as [(ThemeManager | undefined)[], (ThemeManager | undefined)[]]
+  let cur = themeManager
+  while (cur) {
+    parents[cur.state.isComponent ? 1 : 0].unshift(cur)
+    cur = cur.parentManager
   }
-  return [res || null, componentThemeNames] as const
+  return parents
 }

--- a/packages/web/src/helpers/ThemeManager.tsx
+++ b/packages/web/src/helpers/ThemeManager.tsx
@@ -44,14 +44,14 @@ export class ThemeManager {
 
   constructor(
     public props: ThemeProps = {},
-    manager?: ThemeManager | 'root' | null | undefined
+    parentManager?: ThemeManager | 'root' | null | undefined
   ) {
-    if (manager === 'root') {
+    if (parentManager === 'root') {
       this.updateStateFromProps(props, false)
       return
     }
 
-    if (!manager) {
+    if (!parentManager) {
       if (process.env.NODE_ENV !== 'production') {
         throw new Error(
           `No parent manager given, this is likely due to duplicated Tamagui dependencies. Check your lockfile for mis-matched versions. It could also be from an error somewhere else in your stack causing Tamagui to recieve undefined context, you can try putting some ErrorBoundary components around other areas of your app, or a Suspense boundary.`
@@ -60,13 +60,14 @@ export class ThemeManager {
       throw `❌ 0`
     }
 
-    this.parentManager = manager
+    // this is used in updateStateFromProps so must be set
+    this.parentManager = parentManager
 
     if (this.updateStateFromProps(props, false)) {
       return
     }
 
-    return manager || this
+    return parentManager
   }
 
   updateStateFromProps(
@@ -80,6 +81,7 @@ export class ThemeManager {
       return true
     }
     const nextState = this.getStateIfChanged(props)
+
     if (nextState) {
       this.updateState(nextState, shouldNotify)
       return nextState
@@ -172,6 +174,7 @@ function getState(
         : 'Cannot reset and set a new name at the same time.'
     )
   }
+
   if (!getHasThemeUpdatingProps(props)) {
     return null
   }
@@ -194,7 +197,7 @@ function getState(
 
   const isDirectParentAComponentTheme = !!baseManager?.parentManager?.state.isComponent
   const baseName = baseManager?.state.name || ''
-  const nextName = props.reset ? parentManager?.state.name || '' : props.name || ''
+  const nextName = props.reset ? baseName : props.name || ''
 
   const allComponentThemes = componentManagers.map((x) => x?.state.name || '')
   if (props.reset && isDirectParentAComponentTheme) {

--- a/packages/web/src/hooks/useTheme.tsx
+++ b/packages/web/src/hooks/useTheme.tsx
@@ -133,7 +133,7 @@ export const useThemeWithState = (
 }
 
 export function getThemeProxied(
-  { theme, name }: ThemeManagerState,
+  { theme, name, scheme }: ThemeManagerState,
   deopt = false,
   themeManager?: ThemeManager,
   keys?: string[],
@@ -201,8 +201,7 @@ export function getThemeProxied(
                       config.settings.fastSchemeChange &&
                       !someParentIsInversed(themeManager)
                     ) {
-                      const scheme = getScheme(name)
-                      if (scheme !== 'none') {
+                      if (scheme) {
                         const oppositeThemeName = name.replace(
                           scheme === 'dark' ? 'dark' : 'light',
                           scheme === 'dark' ? 'light' : 'dark'
@@ -240,34 +239,15 @@ export function getThemeProxied(
   }) as UseThemeResult
 }
 
-function getScheme(name: string) {
-  const isDark = name.startsWith('dark')
-  const isLight = !isDark && name.startsWith('light')
-  return isDark ? 'dark' : isLight ? 'light' : 'none'
-}
-
 // to tell if we are inversing the scheme anywhere in the tree, if so we need to de-opt
 function someParentIsInversed(manager?: ThemeManager) {
   if (process.env.TAMAGUI_TARGET === 'native') {
     let cur: ThemeManager | null | undefined = manager
-
     while (cur) {
-      const parent = cur.parentManager
-      if (!parent) {
-        return false
-      }
-      if (cur.state.inverse) {
-        return true
-      }
-      const curScheme = getScheme(cur.state.name)
-      const parentScheme = getScheme(parent.state.name)
-      if (curScheme !== parentScheme) {
-        return true
-      }
-      cur = parent
+      if (cur.state.inverse) return true
+      cur = cur.parentManager
     }
   }
-
   return false
 }
 

--- a/packages/web/src/setupReactNative.ts
+++ b/packages/web/src/setupReactNative.ts
@@ -15,6 +15,9 @@ export function getReactNativeConfig(Component: any) {
     if (Component.propTypes?.textBreakStrategy) {
       return RNConfigs.Text
     }
+
+    // can optimize plain View or Text to not be react native specific
+
     // can assume everything else is react native on native
     return RNConfigs.default
   } else {

--- a/packages/web/src/types.tsx
+++ b/packages/web/src/types.tsx
@@ -29,6 +29,8 @@ import type { ThemeProviderProps } from './views/ThemeProvider'
 
 export type { MediaStyleObject, StyleObject } from '@tamagui/helpers'
 
+export type ColorScheme = 'light' | 'dark'
+
 export type IsMediaType = boolean | 'platform' | 'theme' | 'group'
 
 export type SpaceDirection = 'vertical' | 'horizontal' | 'both'

--- a/packages/web/types/helpers/ThemeManager.d.ts
+++ b/packages/web/types/helpers/ThemeManager.d.ts
@@ -37,6 +37,6 @@ export declare class ThemeManager {
     onChangeTheme(cb: ThemeListener, debugId?: number): () => void;
 }
 type MaybeThemeManager = ThemeManager | undefined;
-export declare function getManagers(themeManager?: ThemeManager | null): MaybeThemeManager[][];
+export declare function getManagers(themeManager?: ThemeManager | null): readonly [MaybeThemeManager[], MaybeThemeManager[]];
 export {};
 //# sourceMappingURL=ThemeManager.d.ts.map

--- a/packages/web/types/helpers/ThemeManager.d.ts
+++ b/packages/web/types/helpers/ThemeManager.d.ts
@@ -23,7 +23,7 @@ export declare class ThemeManager {
     themeListeners: Set<ThemeListener>;
     parentManager: ThemeManager | null;
     state: ThemeManagerState;
-    constructor(props?: ThemeProps, manager?: ThemeManager | 'root' | null | undefined);
+    constructor(props?: ThemeProps, parentManager?: ThemeManager | 'root' | null | undefined);
     updateStateFromProps(props?: ThemeProps & {
         forceTheme?: ThemeParsed;
     }, shouldNotify?: boolean): true | ThemeManagerState | undefined;

--- a/packages/web/types/helpers/ThemeManager.d.ts
+++ b/packages/web/types/helpers/ThemeManager.d.ts
@@ -1,4 +1,4 @@
-import { ThemeParsed, ThemeProps } from '../types';
+import { ColorScheme, ThemeParsed, ThemeProps } from '../types';
 type ThemeListener = (name: string | null, themeManager: ThemeManager, forced: boolean) => void;
 export type SetActiveThemeProps = {
     className?: string;
@@ -9,22 +9,21 @@ export type SetActiveThemeProps = {
 };
 export type ThemeManagerState = {
     name: string;
-    theme?: ThemeParsed | null;
-    className?: string;
     parentName?: string;
-    componentName?: string;
+    theme?: ThemeParsed | null;
+    isComponent?: boolean;
+    className?: string;
     inverse?: boolean;
+    scheme?: ColorScheme;
 };
 export declare function getHasThemeUpdatingProps(props: ThemeProps): string | boolean | undefined;
 export declare class ThemeManager {
     props: ThemeProps;
     id: number;
-    isComponent: boolean;
     themeListeners: Set<ThemeListener>;
     parentManager: ThemeManager | null;
     state: ThemeManagerState;
-    scheme: 'light' | 'dark' | null;
-    constructor(props?: ThemeProps, parentManagerIn?: ThemeManager | 'root' | null | undefined);
+    constructor(props?: ThemeProps, manager?: ThemeManager | 'root' | null | undefined);
     updateStateFromProps(props?: ThemeProps & {
         forceTheme?: ThemeParsed;
     }, shouldNotify?: boolean): true | ThemeManagerState | undefined;
@@ -37,6 +36,7 @@ export declare class ThemeManager {
     notify(forced?: boolean): void;
     onChangeTheme(cb: ThemeListener, debugId?: number): () => void;
 }
-export declare function getNonComponentParentManager(themeManager?: ThemeManager | null): readonly [ThemeManager | null, string[]];
+type MaybeThemeManager = ThemeManager | undefined;
+export declare function getManagers(themeManager?: ThemeManager | null): MaybeThemeManager[][];
 export {};
 //# sourceMappingURL=ThemeManager.d.ts.map

--- a/packages/web/types/hooks/useTheme.d.ts
+++ b/packages/web/types/hooks/useTheme.d.ts
@@ -25,7 +25,7 @@ export type UseThemeResult = {
 };
 export declare const useTheme: (props?: ThemeProps) => UseThemeResult;
 export declare const useThemeWithState: (props: UseThemeWithStateProps) => [ChangedThemeResponse, ThemeParsed];
-export declare function getThemeProxied({ theme, name }: ThemeManagerState, deopt?: boolean, themeManager?: ThemeManager, keys?: string[], debug?: DebugProp): UseThemeResult;
+export declare function getThemeProxied({ theme, name, scheme }: ThemeManagerState, deopt?: boolean, themeManager?: ThemeManager, keys?: string[], debug?: DebugProp): UseThemeResult;
 export declare const activeThemeManagers: Set<ThemeManager>;
 export declare const useChangeThemeEffect: (props: UseThemeWithStateProps, isRoot?: boolean, keys?: string[], shouldUpdate?: () => boolean | undefined) => ChangedThemeResponse;
 //# sourceMappingURL=useTheme.d.ts.map

--- a/packages/web/types/types.d.ts
+++ b/packages/web/types/types.d.ts
@@ -9,6 +9,7 @@ import { Role } from './interfaces/Role';
 import type { LanguageContextType } from './views/FontLanguage.types';
 import type { ThemeProviderProps } from './views/ThemeProvider';
 export type { MediaStyleObject, StyleObject } from '@tamagui/helpers';
+export type ColorScheme = 'light' | 'dark';
 export type IsMediaType = boolean | 'platform' | 'theme' | 'group';
 export type SpaceDirection = 'vertical' | 'horizontal' | 'both';
 export type TamaguiElement = HTMLElement | View;


### PR DESCRIPTION
…somewhere, now it should properly de-opt all sub-components if they are inversing a parent scheme anywhere in the tree