### PR TITLE
make anchor text an a tag

### DIFF
--- a/apps/site/components/HeaderLinks.tsx
+++ b/apps/site/components/HeaderLinks.tsx
@@ -17,6 +17,7 @@ const HeadAnchor = styled(Paragraph, {
   pressStyle: { opacity: 0.25 },
   tabIndex: -1,
   w: '100%',
+  tag: 'a',
 })
 
 export const HeaderLinks = ({ showExtra, forceShowAllLinks, showAuth }: HeaderProps) => {


### PR DESCRIPTION
mostly because I use vimium and this annoys me.

also, because accessibility points.

before:

todo

after:

todo
