### PR TITLE
fix(core): infer correct prop types for inner function of styleable

### DIFF
--- a/packages/web/src/types.tsx
+++ b/packages/web/src/types.tsx
@@ -1355,13 +1355,15 @@ export type StyleableOptions = {
 }
 
 export type Styleable<Props, Ref, BaseProps, VariantProps, ParentStaticProperties> = <
-  CustomProps extends Object | void = void,
-  X extends FunctionComponent<any> = FunctionComponent<any>
+  CustomProps extends Object = {},
+  X extends FunctionComponent<
+    Omit<Props, keyof CustomProps> & CustomProps
+  > = FunctionComponent<Omit<Props, keyof CustomProps> & CustomProps>
 >(
   a: X,
   options?: StyleableOptions
 ) => TamaguiComponent<
-  CustomProps extends void ? Props : Omit<Props, keyof CustomProps> & CustomProps,
+  Omit<Props, keyof CustomProps> & CustomProps,
   Ref,
   BaseProps,
   VariantProps,

--- a/packages/web/types/types.d.ts
+++ b/packages/web/types/types.d.ts
@@ -753,7 +753,7 @@ export type StyleableOptions = {
     disableTheme?: boolean;
     staticConfig?: Partial<StaticConfig>;
 };
-export type Styleable<Props, Ref, BaseProps, VariantProps, ParentStaticProperties> = <CustomProps extends Object | void = void, X extends FunctionComponent<any> = FunctionComponent<any>>(a: X, options?: StyleableOptions) => TamaguiComponent<CustomProps extends void ? Props : Omit<Props, keyof CustomProps> & CustomProps, Ref, BaseProps, VariantProps, ParentStaticProperties>;
+export type Styleable<Props, Ref, BaseProps, VariantProps, ParentStaticProperties> = <CustomProps extends Object = {}, X extends FunctionComponent<Omit<Props, keyof CustomProps> & CustomProps> = FunctionComponent<Omit<Props, keyof CustomProps> & CustomProps>>(a: X, options?: StyleableOptions) => TamaguiComponent<Omit<Props, keyof CustomProps> & CustomProps, Ref, BaseProps, VariantProps, ParentStaticProperties>;
 export type TamaguiComponent<Props = any, Ref = any, BaseProps = {}, VariantProps = {}, ParentStaticProperties = {}> = ReactComponentWithRef<Props, Ref> & StaticComponentObject<Props, Ref, BaseProps, VariantProps, ParentStaticProperties> & ParentStaticProperties & {
     __baseProps: BaseProps;
     __variantProps: VariantProps;


### PR DESCRIPTION
This fixes a regression in the types of `styleable()` introduced in [1.74.20](https://github.com/tamagui/tamagui/releases/tag/v1.74.20) by these commits:

- 3db30bf7
- fa19f604

Ever since this version, the inner function of `styleable` has an inferred type of `FunctionComponent<any>`

This PR restores default prop types for the inner function.

---

I tested this out on my local project and all of our `styleable` wrappers seem to be working as expected. We have at least once instance of a double-wrapped `styleable` (`Foo.styleable(...).styleable(...)`) and it seems fine too.