### PR TITLE
Fix the Slider.onSlideStart is not called when clicking the thumb

### DIFF
--- a/packages/slider/src/Slider.tsx
+++ b/packages/slider/src/Slider.tsx
@@ -598,8 +598,8 @@ const SliderComponent = React.forwardRef<TamaguiElement, SliderProps>(
                   if (target !== 'thumb') {
                     const closestIndex = getClosestValueIndex(values, value)
                     updateValues(value, closestIndex)
-                    onSlideStart?.(event, value, target)
                   }
+                  onSlideStart?.(event, value, target)
                 }
           }
           onSlideMove={disabled ? undefined : handleSlideMove}


### PR DESCRIPTION
We can update the value when clicking the track,
but we need always call `onSlideStart` at any time