### PR TITLE
Next-Expo-Solito starter: fix vercel deployment issue

### DIFF
--- a/starters/next-expo-solito/README.md
+++ b/starters/next-expo-solito/README.md
@@ -87,14 +87,14 @@ You can also install the native library inside of `packages/app` if you want to 
 
 You may potentially want to have the native module transpiled for the next app. If you get error messages with `Cannot use import statement outside a module`, you may need to use `transpilePackages` in your `next.config.js` and add the module to the array there.
 
-### Deploying to Vercel
+## Deploying to Vercel
 
 - Root: `apps/next`
 - Install command to be `yarn set version stable && yarn install`
 - Build command: leave default setting
 - Output dir: leave default setting
 
-#### Troubleshooting Vercel Deployment
+### Troubleshooting Vercel Deployment
 If after pushing to GitHub you're seeing that your automatic vercel deployment failed because of an error that looks like this:
 ```
 ➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.

--- a/starters/next-expo-solito/README.md
+++ b/starters/next-expo-solito/README.md
@@ -93,3 +93,13 @@ You may potentially want to have the native module transpiled for the next app. 
 - Install command to be `yarn set version stable && yarn install`
 - Build command: leave default setting
 - Output dir: leave default setting
+
+#### Troubleshooting Vercel Deployment
+If after pushing to GitHub you're seeing that your automatic vercel deployment failed because of an error that looks like this:
+```
+➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
+➤ YN0000: └ Completed
+➤ YN0000: Failed with errors in 0s 700ms
+Error: Command "yarn set version stable && yarn install" exited with 1
+```
+Run `yarn vercel:install` locally and then commit and push the changes to GitHub.

--- a/starters/next-expo-solito/package.json
+++ b/starters/next-expo-solito/package.json
@@ -8,14 +8,14 @@
   "scripts": {
     "native": "cd apps/expo && yarn start",
     "watch": "yarn workspaces foreach -pi run watch",
-    "vercel:install": "yarn set version 3.5 && yarn install",
+    "vercel:install": "yarn set version stable && yarn install",
     "web": "yarn build && cd apps/next && yarn next",
     "web:extract": "DISABLE_EXTRACTION=false yarn workspace next-app dev",
     "web:prod": "yarn workspace next-app build",
     "web:prod:serve": "yarn workspace next-app serve",
     "fix": "manypkg fix",
     "postinstall": "yarn check-deps && yarn build",
-    "build": "yarn workspaces foreach --exclude next-app run build",
+    "build": "yarn workspaces foreach --all --exclude next-app run build",
     "upgrade:tamagui": "yarn up '*tamagui*'@latest '@tamagui/*'@latest",
     "upgrade:tamagui:canary": "yarn up '*tamagui*'@canary '@tamagui/*'@canary",
     "check-deps": "check-dependency-version-consistency ."


### PR DESCRIPTION
Issue this addresses:
The PR requested by nate [here in discord](https://discord.com/channels/909986013848412191/1116381883748585563/1151169168679370813). 

Issue summarized:
Strictly following the current readme instructions for the next-expo-solito starter repo results in a failed deployment with the error shown below. 

What this PR does:
- This PR updates the package.json vercel:install script to use `set version stable`. 
- This results in a failure with yarn 4.0.0 (current stable) because of [this yarn update](https://github.com/yarnpkg/berry/issues/5817), so it also updates the build script to include the `--all` flag. 
- It also updates the readme instructions for the starter repo. 
Together these changes result in a successful github push auto-deploy on vercel.

```
> Detected Turbo. Adjusting default settings...
Running "install" command: `yarn set version stable && yarn install`...
➤ YN0000: Retrieving https://repo.yarnpkg.com/3.6.3/packages/yarnpkg-cli/bin/yarn.js
➤ YN0000: Saving the new release in ../../.yarn/releases/yarn-3.6.3.cjs
➤ YN0000: Done in 0s 420ms
➤ YN0000: ┌ Project validation
➤ YN0057: │ expo-app: Resolutions field will be ignored
➤ YN0000: └ Completed
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 0s 554ms
➤ YN0000: ┌ Post-resolution validation
➤ YN0000: │ @@ -20325,13 +20325,12 @@
➤ YN0000: │    linkType: hard
➤ YN0000: │  
➤ YN0000: │  "typescript@patch:typescript@^5.1.3#~builtin<compat/typescript>":
➤ YN0000: │    version: 5.1.3
➤ YN0028: │ -  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=85af82"
➤ YN0028: │ +  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=5da071"
➤ YN0000: │    bin:
➤ YN0000: │      tsc: bin/tsc
➤ YN0000: │      tsserver: bin/tsserver
➤ YN0028: │ -  checksum: 32a25b2e128a4616f999d4ee502aabb1525d5647bc8955e6edf05d7fbc53af8aa98252e2f6ba80bcedfc0260c982b885f3c09cfac8bb65d2924f3133ad1e1e62
➤ YN0000: │    languageName: node
➤ YN0000: │    linkType: hard
➤ YN0000: │  
➤ YN0000: │  "ua-parser-js@npm:^0.7.30":
➤ YN0000: │ 
➤ YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
➤ YN0000: └ Completed
➤ YN0000: Failed with errors in 0s 700ms
Error: Command "yarn set version stable && yarn install" exited with 1
```

Also FWIW this is my first PR here so though I've tried to follow the contribution guide, please let me know if you'd like to see something different.