### PR TITLE
Correct tab usage example

### DIFF
--- a/apps/site/data/docs/components/tabs/1.7.0.mdx
+++ b/apps/site/data/docs/components/tabs/1.7.0.mdx
@@ -33,13 +33,17 @@ Note: Tabs have landed on v1.7 and not fully ready for runtime. Send us your fee
 ## Usage
 
 ```tsx
-import { Tabs } from 'tamagui'
+import { SizableText, Tabs } from 'tamagui'
 
 export default () => (
   <Tabs defaultValue="tab1" width={400}>
     <Tabs.List space>
-      <Tabs.Tab value="tab1">Tab 1</Tabs.Tab>
-      <Tabs.Tab value="tab2">Tab 2</Tabs.Tab>
+      <Tabs.Tab value="tab1">
+        <SizableText>Tab 1</SizableText>
+      </Tabs.Tab>
+      <Tabs.Tab value="tab2">
+        <SizableText>Tab 2</SizableText>
+      </Tabs.Tab>
     </Tabs.List>
 
     <Tabs.Content value="tab1">


### PR DESCRIPTION
Fix Tabs usage example throwing error, Text strings must be rendered within a <Text> component.