### PR TITLE
[bug] invalid props.style key 'borderStyle' for Image fix

### DIFF
--- a/packages/web/src/createComponent.tsx
+++ b/packages/web/src/createComponent.tsx
@@ -612,7 +612,13 @@ export function createComponent<
       elementType,
       debugProp
     )
-
+    if (process.env.TAMAGUI_TARGET === 'native') {
+      if (Component.name === "Image") {
+        if (splitStyles.props['borderStyle']) {
+          delete splitStyles.props['borderStyle'];
+        }
+      }
+    }
     // hide strategy will set this opacity = 0 until measured
     if (props.group && props.untilMeasured === 'hide' && !stateRef.current.hasMeasured) {
       splitStyles.style.opacity = 0


### PR DESCRIPTION
<img width="336" alt="image" src="https://github.com/tamagui/tamagui/assets/17267419/f746da08-8ef6-4740-b6d9-48437ba0c482">

This style gets inserted here: https://github.com/tamagui/tamagui/blob/f7b64488813ce51ff4468aa8e113f8cd4608441e/packages/web/src/helpers/expandStyles.ts#L26-L30

It's valid for other component types, but not `<Image>`.