### PR TITLE
fix: 404 links in docs

### DIFF
--- a/apps/site/data/docs/intro/compiler-install.mdx
+++ b/apps/site/data/docs/intro/compiler-install.mdx
@@ -3,7 +3,7 @@ title: Install the Compiler
 description: Adding the compiler to your apps.
 ---
 
-For more background read the [Compiler About](/intro/why-a-compiler) page, for performance see [Benchmarks](/intro/benchmarks).
+For more background read the [Compiler About](/docs/intro/why-a-compiler) page, for performance see [Benchmarks](/docs/intro/benchmarks).
 
 It's important to note the compiler is optional, and it's much easier to get started by building your app out before you commit to the setup cost.
 


### PR DESCRIPTION
This is a small PR fixing 404 links in docs