### PR TITLE
move expo to index

### DIFF
--- a/packages/demos/src/SkeletonDemo.tsx
+++ b/packages/demos/src/SkeletonDemo.tsx
@@ -1,5 +1,5 @@
 import { MotiView } from '@tamagui/animations-moti'
-import { Skeleton } from '@tamagui/skeleton'
+import Skeleton from '@tamagui/skeleton'
 import { Paragraph, Spacer, XStack } from 'tamagui'
 
 // TODO: do packages/tamagui/src pattern for Skeleton

--- a/packages/skeleton/src/expo.tsx
+++ b/packages/skeleton/src/expo.tsx
@@ -1,12 +1,12 @@
 // https://github.com/nandorojo/moti/blob/master/packages/moti/src/skeleton/expo.tsx
-import { LinearGradient } from 'expo-linear-gradient'
-import React from 'react'
+// import { LinearGradient } from 'expo-linear-gradient'
+// import React from 'react'
 
-import Skeleton from './skeleton-new'
-import { MotiSkeletonProps } from './types'
+// import Skeleton from './skeleton-new'
+// import { MotiSkeletonProps } from './types'
 
-export default function SkeletonExpo(props: Omit<MotiSkeletonProps, 'Gradient'>) {
-  return <Skeleton {...props} Gradient={LinearGradient as any} />
-}
+// export default function SkeletonExpo(props: Omit<MotiSkeletonProps, 'Gradient'>) {
+//   return <Skeleton {...props} Gradient={LinearGradient as any} />
+// }
 
-SkeletonExpo.Group = Skeleton.Group
+// SkeletonExpo.Group = Skeleton.Group

--- a/packages/skeleton/src/index.tsx
+++ b/packages/skeleton/src/index.tsx
@@ -1,2 +1,13 @@
 //github.com/nandorojo/moti/blob/master/packages/moti/src/skeleton/index.ts#L2
-export { default as Skeleton } from './expo'
+// export { default as Skeleton } from './expo'
+import { LinearGradient } from 'expo-linear-gradient'
+// import React from 'react'
+
+import Skeleton from './skeleton-new'
+import { MotiSkeletonProps } from './types'
+
+export default (props: Omit<MotiSkeletonProps, 'Gradient'>) => {
+  return <Skeleton {...props} Gradient={LinearGradient as any} />
+}
+
+// SkeletonExpo.Group = Skeleton.Group

--- a/packages/skeleton/src/native.tsx
+++ b/packages/skeleton/src/native.tsx
@@ -1,12 +1,12 @@
 // https://github.com/nandorojo/moti/blob/master/packages/moti/src/skeleton/native.tsx
-import React from 'react'
-import LinearGradient from 'react-native-linear-gradient'
+// import React from 'react'
+// import LinearGradient from 'react-native-linear-gradient'
 
-import SkeletonNative from './skeleton-new'
-import { MotiSkeletonProps } from './types'
+// import SkeletonNative from './skeleton-new'
+// import { MotiSkeletonProps } from './types'
 
-export function Skeleton(props: Omit<MotiSkeletonProps, 'Gradient'>) {
-  return <SkeletonNative {...props} Gradient={LinearGradient as any} />
-}
+// export function Skeleton(props: Omit<MotiSkeletonProps, 'Gradient'>) {
+//   return <SkeletonNative {...props} Gradient={LinearGradient as any} />
+// }
 
-Skeleton.Group = SkeletonNative.Group
+// Skeleton.Group = SkeletonNative.Group

--- a/packages/skeleton/types/expo.d.ts
+++ b/packages/skeleton/types/expo.d.ts
@@ -1,11 +1,1 @@
-import React from 'react';
-import { MotiSkeletonProps } from './types';
-declare function SkeletonExpo(props: Omit<MotiSkeletonProps, 'Gradient'>): JSX.Element;
-declare namespace SkeletonExpo {
-    var Group: ({ children, show, }: {
-        children: React.ReactNode;
-        show: boolean;
-    }) => JSX.Element;
-}
-export default SkeletonExpo;
 //# sourceMappingURL=expo.d.ts.map

--- a/packages/skeleton/types/index.d.ts
+++ b/packages/skeleton/types/index.d.ts
@@ -1,2 +1,5 @@
-export { default as Skeleton } from './expo';
+/// <reference types="react" />
+import { MotiSkeletonProps } from './types';
+declare const _default: (props: Omit<MotiSkeletonProps, 'Gradient'>) => JSX.Element;
+export default _default;
 //# sourceMappingURL=index.d.ts.map

--- a/packages/skeleton/types/native.d.ts
+++ b/packages/skeleton/types/native.d.ts
@@ -1,10 +1,1 @@
-import React from 'react';
-import { MotiSkeletonProps } from './types';
-export declare function Skeleton(props: Omit<MotiSkeletonProps, 'Gradient'>): JSX.Element;
-export declare namespace Skeleton {
-    var Group: ({ children, show, }: {
-        children: React.ReactNode;
-        show: boolean;
-    }) => JSX.Element;
-}
 //# sourceMappingURL=native.d.ts.map


### PR DESCRIPTION
change default import, use the expo.tsx file, will continue to clean things up here.

Assuming we don't need the native file anymore since we're going to use '@tamamgui/linear-gradient'
