### PR TITLE
Update JSDoc for `webContainerType` in `GenericTamaguiSettings`

### DIFF
--- a/packages/web/src/types.tsx
+++ b/packages/web/src/types.tsx
@@ -743,7 +743,7 @@ type GenericTamaguiSettings = {
 
   /**
    * On Web, this allows changing the behavior of container groups which by default uses
-   * `container-type: normal`.
+   * `container-type: inline-size`.
    */
   webContainerType?:
     | 'normal'


### PR DESCRIPTION
It seems that the default is different than the one in the JSDoc. Updated to match.

https://github.com/tamagui/tamagui/blob/dfc96be563092df16b1c15875821284765cdee8b/packages/web/src/helpers/getSplitStyles.tsx#L275