### PR TITLE
docs(design-systems): fix configuration link

### DIFF
--- a/apps/site/data/docs/guides/design-systems.mdx
+++ b/apps/site/data/docs/guides/design-systems.mdx
@@ -59,9 +59,9 @@ There are a few things to note here:
 
 ## Step 2: Create your design system.
 
-Check the [/docs/core/configuration] for more detail on this step.
+Check the [configuration](/docs/core/configuration) for more detail on this step.
 
-You'll be creating a tamagui.config.ts at the the root of your app. It will contain a full suite of tokens, themes, and fonts exported onto a single named `config` export.
+You'll be creating a `tamagui.config.ts` at the the root of your app. It will contain a full suite of tokens, themes, and fonts exported onto a single named `config` export.
 
 ## Step 3: Define and export components
 


### PR DESCRIPTION
Configuration link is broken on the docs

![CleanShot 2023-12-08 at 16 24 36](https://github.com/tamagui/tamagui/assets/360936/85697903-96f9-452c-8f6c-9db4f99ae989)
