### PR TITLE
fix: use readOnly prop instead of editable for Input to avoid a warning

### DIFF
--- a/packages/tamagui/src/views/Input.tsx
+++ b/packages/tamagui/src/views/Input.tsx
@@ -82,7 +82,7 @@ export function useInputProps(props: InputProps, ref: any) {
 
   return {
     ref: combinedRef,
-    editable: !props.disabled,
+    readOnly: props.disabled,
     ...props,
     placeholderTextColor,
     onChangeText,

--- a/packages/tamagui/types/views/Input.d.ts
+++ b/packages/tamagui/types/views/Input.d.ts
@@ -421,7 +421,7 @@ export declare function useInputProps(props: InputProps, ref: any): {
     caretHidden?: boolean | undefined;
     contextMenuHidden?: boolean | undefined;
     defaultValue?: string | undefined;
-    editable: boolean;
+    editable?: boolean | undefined;
     keyboardType?: import("react-native").KeyboardTypeOptions | undefined;
     inputMode?: import("react-native").InputModeOptions | undefined;
     maxLength?: number | undefined;
@@ -464,5 +464,6 @@ export declare function useInputProps(props: InputProps, ref: any): {
     showSoftInputOnFocus?: boolean | undefined;
     rows?: number | undefined;
     ref: (node: any) => void;
+    readOnly: boolean | undefined;
 };
 //# sourceMappingURL=Input.d.ts.map


### PR DESCRIPTION
The `disabled={value}` prop is translated to `editable={!value}` in `useInputProps`, and causes "editable is deprecated. Use readOnly." warning. so use `readOnly` instead of `editable`.