### PR TITLE
Fix: theme palettes keys swapped in correct order

### DIFF
--- a/starters/simple-web/src/themes.ts
+++ b/starters/simple-web/src/themes.ts
@@ -20,7 +20,7 @@ import { tokens } from './tokens'
 export const themes = (() => {
   // background => foreground
   const palettes = {
-    dark: [
+    light: [
       tokens.color.darkTransparent,
       tokens.color.light1,
       tokens.color.light2,
@@ -36,7 +36,7 @@ export const themes = (() => {
       tokens.color.light12,
       tokens.color.lightTransparent,
     ],
-    light: [
+    dark: [
       tokens.color.lightTransparent,
       tokens.color.dark1,
       tokens.color.dark2,


### PR DESCRIPTION
palettes have light and dark keys in the wrong order. They need to be swapped.