### PR TITLE
Use styleable for Dialog Title & Description

### DIFF
--- a/packages/dialog/src/Dialog.tsx
+++ b/packages/dialog/src/Dialog.tsx
@@ -650,17 +650,19 @@ type DialogDescriptionProps = GetProps<typeof DialogDescriptionFrame>
 
 const DESCRIPTION_NAME = 'DialogDescription'
 
-const DialogDescription = DialogDescriptionFrame.styleable((props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {
-  const { __scopeDialog, ...descriptionProps } = props
-  const context = useDialogContext(DESCRIPTION_NAME, __scopeDialog)
-  return (
-    <DialogDescriptionFrame
-      id={context.descriptionId}
-      {...descriptionProps}
-      ref={forwardedRef}
-    />
-  )
-})
+const DialogDescription = DialogDescriptionFrame.styleable(
+  (props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {
+    const { __scopeDialog, ...descriptionProps } = props
+    const context = useDialogContext(DESCRIPTION_NAME, __scopeDialog)
+    return (
+      <DialogDescriptionFrame
+        id={context.descriptionId}
+        {...descriptionProps}
+        ref={forwardedRef}
+      />
+    )
+  }
+)
 
 DialogDescription.displayName = DESCRIPTION_NAME
 

--- a/packages/dialog/src/Dialog.tsx
+++ b/packages/dialog/src/Dialog.tsx
@@ -628,7 +628,7 @@ const DialogTitleFrame = styled(H2, {
 
 type DialogTitleProps = GetProps<typeof DialogTitleFrame>
 
-const DialogTitle = React.forwardRef<TamaguiTextElement, DialogTitleProps>(
+const DialogTitle = DialogTitleFrame.styleable(
   (props: ScopedProps<DialogTitleProps>, forwardedRef) => {
     const { __scopeDialog, ...titleProps } = props
     const context = useDialogContext(TITLE_NAME, __scopeDialog)
@@ -650,10 +650,7 @@ type DialogDescriptionProps = GetProps<typeof DialogDescriptionFrame>
 
 const DESCRIPTION_NAME = 'DialogDescription'
 
-const DialogDescription = React.forwardRef<
-  GetRef<typeof DialogDescriptionFrame>,
-  DialogDescriptionProps
->((props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {
+const DialogDescription = DialogDescriptionFrame.styleable((props: ScopedProps<DialogDescriptionProps>, forwardedRef) => {
   const { __scopeDialog, ...descriptionProps } = props
   const context = useDialogContext(DESCRIPTION_NAME, __scopeDialog)
   return (


### PR DESCRIPTION
In my app, if I try to do something like:

```ts
styled(Dialog.Title, { })
```

I get errors that text cannot render within a React Native `View`. Something is going wrong with the composition.

Changing Dialog to extend via `styleable` instead of a `React.forwardRef` appears to fix this issue.

As always, happy to adapt this PR or my codebase 🙏 Thanks!