### PR TITLE
Small typo update in how to build a button guide

### DIFF
--- a/apps/site/data/docs/guides/how-to-build-a-button.mdx
+++ b/apps/site/data/docs/guides/how-to-build-a-button.mdx
@@ -28,7 +28,7 @@ Keep in mind that this is an advanced use case. Usually you can just grab Tamagu
 
 <Notice>
   This guide is more of a primer on designing composable components, teaching advanced
-  concepts that aren't necessary if you just want to build your app. If you just a simple,
+  concepts that aren't necessary if you just want to build your app. If you just want a simple,
   ready to use Button, you can use the [Tamagui Button](/docs/components/button) itself
   directly.
 </Notice>


### PR DESCRIPTION
Just a small text change in the docs. 
I really love what you're building here. 
I've been integrating Tamagui with Next.js 14.4 app router, the initial setup has been a little complicated but it is working fine.

![image](https://github.com/tamagui/tamagui/assets/74047809/a40ad8ff-8483-41bd-9c1d-50fe116d8a8f)
