### PR TITLE
docs: removed content that is not applicable

### DIFF
--- a/apps/site/data/docs/core/stack-and-text.mdx
+++ b/apps/site/data/docs/core/stack-and-text.mdx
@@ -78,7 +78,3 @@ export const Circle = styled(View, {
 ```
 
 Inline styles and `styled()` both are optimized by the compiler, so you can author styles using both depending on the use case.
-
-### View
-
-As of version `1.31` Tamagui exports a `View` as well, which has no style properties set by default (as opposed to View which sets the flexDirection to column by default).


### PR DESCRIPTION
View component has defaultProps that injects flexDirection: 'column'. Hence this content block is not applicable. Check the code below:

```
export const View = createComponent<StackProps, View, StackPropsBase>({
  acceptsClassName: true,
  defaultProps: {stackDefaultStyles},
  validStyles,
})
```