### PR TITLE
fix(docs): writing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ function Example() {
 ## Contributing
 
 To contribute to Tamagui reference the [contributing guide](https://github.com/tamagui/tamagui/blob/master/CONTRIBUTING.md).
-To contribute to documentation reference the [writing guide](https://github.com/tamagui/tamagui/apps/site/WRITING-GUIDE.md).
+To contribute to documentation reference the [writing guide](https://github.com/tamagui/tamagui/blob/master/apps/site/WRITING-GUIDE.md).


### PR DESCRIPTION
## Why 

I was going to make a PR for a feature, but then I realized that the current writing guide link is incorrect. 

## How 

Add `blob/master` to that link and it will work well now.