### PR TITLE
fix(popper): Make Popper to work properly on native

### DIFF
--- a/packages/popper/src/Popper.tsx
+++ b/packages/popper/src/Popper.tsx
@@ -285,8 +285,9 @@ export const PopperContent = React.forwardRef<
 
   const frameProps = {
     ref: contentRefs,
-    x: x || 0,
-    y: y || 0,
+    // x: x || 0,
+    // y: y || 0,
+    transform: [{ translateX: x || 0 }, { translateY: y || 0 }],
     position: strategy,
     ...(enableAnimationForPositionChange && {
       // apply animation but disable it on initial render to avoid animating from 0 to the first position
@@ -307,6 +308,8 @@ export const PopperContent = React.forwardRef<
     </Stack>
   )
 })
+
+PopperContent.displayName = 'PopperContent'
 
 /* -------------------------------------------------------------------------------------------------
  * PopperArrow


### PR DESCRIPTION
fix #2109 

- [x] Make it position in correct place
- [ ] check why x, y doesn't work
- [ ] make x and y to have one final values instead of jumping between multiple values until it reach final position. could be a middleware issue

some notes:
x and y is working properly with DropDown. check how that is working probably there is an issue with Popover or Portal