### PR TITLE
fix(font-size): avoid replacing $true with $4 when it is a defined token

### DIFF
--- a/packages/font-size/src/getFontSize.ts
+++ b/packages/font-size/src/getFontSize.ts
@@ -40,7 +40,8 @@ export const getFontSizeToken = (
   const conf = getConfig()
   const fontSize = conf.fontsParsed[opts?.font || '$body'].size
   const size =
-    (inSize === '$true' ? '$4' : inSize) || ('$true' in fontSize ? '$true' : '$4')
+    (inSize === '$true' && !('$true' in fontSize) ? '$4' : inSize) ??
+    ('$true' in fontSize ? '$true' : '$4')
   const sizeTokens = Object.keys(fontSize)
   let foundIndex = sizeTokens.indexOf(size)
   if (foundIndex === -1) {


### PR DESCRIPTION
# Description

This PR fixes a regression in behavior that was caused by this commit:

https://github.com/tamagui/tamagui/commit/0154e14b6ae1cb6cc3776d274db6bf97083907b4

After upgrading to a version that includes this change, I started receiving numerous console warnings because my fonts do not have a `$4` token:

```
No font size found $4 undefined in size tokens 
```

# List of changes

- Only replace `$true` with `$4` when there is no `$true` token defined for the font