### PR TITLE
fix(select): export SelectValueExtraProps interface

### DIFF
--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -54,7 +54,7 @@ const SelectValueFrame = styled(SizableText, {
   userSelect: 'none',
 })
 
-interface SelectValueExtraProps {
+export interface SelectValueExtraProps {
   placeholder?: React.ReactNode
 }
 

--- a/packages/select/types/Select.d.ts
+++ b/packages/select/types/Select.d.ts
@@ -2,7 +2,7 @@ import { FontSizeTokens, TamaguiElement } from '@tamagui/core';
 import { ListItemProps } from '@tamagui/list-item';
 import * as React from 'react';
 import { ScopedProps, SelectProps } from './types';
-interface SelectValueExtraProps {
+export interface SelectValueExtraProps {
     placeholder?: React.ReactNode;
 }
 export declare const SelectIcon: import("@tamagui/core").TamaguiComponent<import("@tamagui/core").TamaDefer, TamaguiElement, import("@tamagui/core").RNTamaguiViewNonStyleProps, import("@tamagui/core").StackStyleBase, {
@@ -331,5 +331,4 @@ export declare const Select: ((props: ScopedProps<SelectProps>) => JSX.Element) 
         }>> & React.RefAttributes<import("react-native").ScrollView>>;
     };
 };
-export {};
 //# sourceMappingURL=Select.d.ts.map


### PR DESCRIPTION
Fix for this TypeScript error when inferring types from the `Select` component.

```
error TS4023: Exported variable 'MySelect' has or is using name 'SelectValueExtraProps' from external module "/path/to/node_modules/@tamagui/select/types/Select" but cannot be named.
```