### PR TITLE
Keep handle dragging for Sheet on Web if scrolled

### DIFF
--- a/packages/sheet/src/SheetImplementationCustom.tsx
+++ b/packages/sheet/src/SheetImplementationCustom.tsx
@@ -274,7 +274,7 @@ export const SheetImplementationCustom = themeable(
         const isDraggingUp = dy < 0
         // we can treat near top instead of exactly to avoid trouble with springs
         const isNearTop = scrollBridge.paneY - 5 <= scrollBridge.paneMinY
-        if (isScrolled) {
+        if (isScrolled && !isWeb) {
           previouslyScrolling = true
           return false
         }


### PR DESCRIPTION
Fixes #2162 

As mentioned in that issue, I'm not sure why this logic is here

However, since I'm currently only working on web, I assume that perhaps it's there for mobile reasons?

Thus, sending this PR to hopefully help identify its purpose and at the least help narrow the impact of this behaviour

As always, let me know how I can help move things forward and thanks for an awesome library! 