### PR TITLE
Import package, not types

### DIFF
--- a/packages/config/src/animations.reanimated.ts
+++ b/packages/config/src/animations.reanimated.ts
@@ -1,4 +1,4 @@
-import { createAnimations } from '@tamagui/animations-moti/types'
+import { createAnimations } from '@tamagui/animations-moti'
 
 export const animations = createAnimations({
   '100ms': {


### PR DESCRIPTION
This resolves a problem with using Reanimated animations - the compiler is unable to resolve the `/types` import correctly.