### PR TITLE
Don't offset Popper arrow by 1 when on bottom

### DIFF
--- a/packages/popper/src/Popper.tsx
+++ b/packages/popper/src/Popper.tsx
@@ -399,11 +399,6 @@ export const PopperArrow = PopperArrowFrame.styleable<PopperArrowExtraProps>(
         arrowStyle[oppSide] = -size
         innerArrowStyle[oppSide] = size / 2
       }
-      if (oppSide === 'bottom') {
-        // on the bottom it needs to be 1px further up
-        // @ts-ignore it exists
-        arrowStyle[oppSide] += 1
-      }
       if (oppSide === 'top' || oppSide === 'bottom') {
         arrowStyle.left = 0
       }


### PR DESCRIPTION
I'm sure there's a reason for this offset by 1, perhaps if it's on a corner? Perhaps it's to account for a border, but even with the border it's still noticeable

At the moment, with a transparent Tooltip, you can see the visible overlap between the two.

Reproducable example:

```ts
<Tooltip placement='top'>
  <Tooltip.Trigger>
    <Text>Trigger</Text>
  </Tooltip.Trigger>

  <Tooltip.Content
    animation='fast'
    enterStyle={{ x: 0, y: 5, opacity: 0, scale: 0.9 }}
    exitStyle={{ x: 0, y: 5, opacity: 0, scale: 0.9 }}
    scale={1}
    x={0}
    y={0}
    opacity={1}
    borderColor='rgba(100, 100, 100, 0.4)'
    backgroundColor='rgba(100, 100, 100, 0.4)'
    style={{ backdropFilter: 'blur(8px)' }}
  >
    <Tooltip.Arrow
      borderColor='rgba(100, 100, 100, 0.4)'
      backgroundColor='rgba(100, 100, 100, 0.4)'
      style={{ backdropFilter: 'blur(8px)' }}
    />

    <Text>Tooltip</Text>
  </Tooltip.Content>
</Tooltip>
```


Before this change:

<img width="78" alt="image" src="https://github.com/tamagui/tamagui/assets/397824/1142cadc-228f-44bb-81ad-b7b6ecfb553c">


After this change:

<img width="72" alt="image" src="https://github.com/tamagui/tamagui/assets/397824/caf46d82-6b14-4d70-bdb5-4c736f225d41">


Note that the Arrow is also `10%` more opaque than the Tooltip body in this example. Thus, changing the color to `'rgba(100, 100, 100, 0.3)'` for just the arrow seems to fix this 🤷 

<img width="75" alt="image" src="https://github.com/tamagui/tamagui/assets/397824/fbe8a5a7-51ce-49a2-840e-81b44a113431">

No rush 🙏 Creating the PR as it's behaviour I noticed and patched in our app. Not sure what the proper behaviour is overall. Thanks as always for an awesome library! ❤️ 
