### PR TITLE
feat: Added native Progress implementation

### DIFF
--- a/apps/kitchen-sink/app.json
+++ b/apps/kitchen-sink/app.json
@@ -36,6 +36,15 @@
         "projectId": "5c027280-f9c1-4bba-9c75-762ba6efcecc"
       }
     },
-    "plugins": ["expo-build-properties"]
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "ios": {
+            "deploymentTarget": "14.0"
+          }
+        }
+      ]
+    ]
   }
 }

--- a/packages/demos/src/ProgressDemo.tsx
+++ b/packages/demos/src/ProgressDemo.tsx
@@ -1,37 +1,55 @@
-import { useEffect, useState } from 'react'
-import type { SizeTokens } from 'tamagui'
-import { Button, Paragraph, Progress, Slider, XStack, YStack } from 'tamagui'
+import { useEffect, useState } from "react";
+import { Platform } from "react-native";
+import {
+  Button,
+  Paragraph,
+  Progress,
+  SizeTokens,
+  Slider,
+  XStack,
+  YStack,
+} from "tamagui";
 
 export function ProgressDemo() {
-  const [size, setSize] = useState(4)
-  const [progress, setProgress] = useState(20)
-  const sizeProp = `$${size}` as SizeTokens
+  const [size, setSize] = useState(4);
+  const [progress, setProgress] = useState(0);
+  const sizeProp = `$${size}` as SizeTokens;
 
   useEffect(() => {
-    const timer = setTimeout(() => setProgress(60), 1000)
+    const timer = setTimeout(() => setProgress(50), 1000);
     return () => {
-      clearTimeout(timer)
-    }
-  }, [])
+      clearTimeout(timer);
+    };
+  }, []);
 
   return (
     <>
-      <YStack height={60} alignItems="center" space>
+      <YStack height={60} gap="$5">
         <Paragraph height={30} opacity={0.5}>
           Size: {size}
         </Paragraph>
-        <Progress size={sizeProp} value={progress}>
+        <Progress max={100} size={sizeProp} value={progress}>
           <Progress.Indicator animation="bouncy" />
         </Progress>
+        {Platform.OS === "ios" && (
+          <Progress
+            w={200}
+            h={20}
+            max={100}
+            native="ios"
+            size={sizeProp}
+            value={progress}
+          />
+        )}
       </YStack>
 
       <XStack
         alignItems="center"
         space
         position="absolute"
-        bottom="$3"
+        bottom="$-10"
         left="$4"
-        $xxs={{ display: 'none' }}
+        $xxs={{ display: "none" }}
       >
         <Slider
           size="$2"
@@ -41,7 +59,7 @@ export function ProgressDemo() {
           max={6}
           step={1}
           onValueChange={([val]) => {
-            setSize(val)
+            setSize(val);
           }}
         >
           <Slider.Track borderWidth={1} borderColor="$color5">
@@ -50,10 +68,13 @@ export function ProgressDemo() {
           <Slider.Thumb circular index={0} />
         </Slider>
 
-        <Button size="$2" onPress={() => setProgress((prev) => (prev + 20) % 100)}>
+        <Button
+          size="$2"
+          onPress={() => setProgress((prev) => (prev + 20) % 100)}
+        >
           Load
         </Button>
       </XStack>
     </>
-  )
+  );
 }

--- a/packages/progress/expo-module.config.json
+++ b/packages/progress/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["ios"],
+  "ios": {
+    "modules": ["TamaguiProgressModule"]
+  }
+}

--- a/packages/progress/ios/Progress.podspec
+++ b/packages/progress/ios/Progress.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name           = 'Progress'
+  s.version        = '1.0.0'
+  s.summary        = 'A sample project summary'
+  s.description    = 'A sample project description'
+  s.author         = ''
+  s.homepage       = 'https://docs.expo.dev/modules/'
+  s.platform       = :ios, '13.0'
+  s.source         = { git: '' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  # Swift/Objective-C compatibility
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+  
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/packages/progress/ios/ProgressExpoView.swift
+++ b/packages/progress/ios/ProgressExpoView.swift
@@ -1,0 +1,21 @@
+import ExpoModulesCore
+import SwiftUI
+
+class ProgressExpoView: ExpoView {
+  let props: ProgressProps
+  
+  required init(appContext: AppContext? = nil) {
+    props = ProgressProps()
+    let hostingController = UIHostingController(rootView: ProgressViewView(props: props))
+    super.init(appContext: appContext)
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+    hostingController.view.backgroundColor = .clear
+    addSubview(hostingController.view)
+    NSLayoutConstraint.activate([
+      hostingController.view.topAnchor.constraint(equalTo: self.topAnchor),
+      hostingController.view.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+      hostingController.view.leftAnchor.constraint(equalTo: self.leftAnchor),
+      hostingController.view.rightAnchor.constraint(equalTo: self.rightAnchor)
+    ])
+  }
+}

--- a/packages/progress/ios/ProgressModule.swift
+++ b/packages/progress/ios/ProgressModule.swift
@@ -1,0 +1,18 @@
+import ExpoModulesCore
+
+public class TamaguiProgressModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("Progress")
+    View(ProgressExpoView.self) {
+      Prop("value") { (view: ProgressExpoView, prop: Double) in
+        view.props.value = prop
+      }
+      Prop("max") { (view: ProgressExpoView, prop: Double?) in
+        view.props.max = prop ?? 1
+      }
+      Prop("accent") { (view: ProgressExpoView, prop: UIColor?) in
+        view.props.accent = prop
+      }
+    }
+  }
+}

--- a/packages/progress/ios/ProgressProps.swift
+++ b/packages/progress/ios/ProgressProps.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import ExpoModulesCore
+
+class ProgressProps: ObservableObject {
+  @Published var value: Double = 0
+  @Published var max: Double = 1
+  @Published var accent: UIColor?
+}
+

--- a/packages/progress/ios/ProgressView.swift
+++ b/packages/progress/ios/ProgressView.swift
@@ -1,0 +1,23 @@
+import ExpoModulesCore
+import SwiftUI
+
+struct ProgressViewView: View {
+  @ObservedObject var props: ProgressProps
+  @State private var progress: Double = 0
+  
+  var body: some View {
+    if #available(iOS 14.0, *) {
+      ProgressView(value: progress, total: props.max)
+        .onAppear {
+          withAnimation {
+            progress = props.value
+          }
+        }
+        .onChange(of: props.value) { newValue in
+          withAnimation {
+            progress = newValue
+          }
+        }
+    }
+  }
+}

--- a/packages/progress/src/NativeProgressIOS.tsx
+++ b/packages/progress/src/NativeProgressIOS.tsx
@@ -1,0 +1,17 @@
+import { styled } from "@tamagui/core";
+import { requireNativeViewManager } from "expo-modules-core";
+import * as React from "react";
+import { Platform } from "react-native";
+
+const NativeView: React.ComponentType<any> | null =
+  Platform.OS === "ios" ? requireNativeViewManager("Progress") : null;
+
+function ProgressWrapper({ max, ...restProps }: { max?: number }) {
+  if (!NativeView) return null;
+  return <NativeView max={max ?? 1} {...restProps} />;
+}
+
+export const Progress = styled(ProgressWrapper, {});
+
+// @ts-ignore
+Progress.Indicator = (props: any) => null;

--- a/packages/progress/src/Progress.tsx
+++ b/packages/progress/src/Progress.tsx
@@ -1,28 +1,35 @@
 // forked from Radix UI
 // https://github.com/radix-ui/primitives/blob/main/packages/react/progress/src/Progress.tsx
 
-import type { GetProps } from '@tamagui/core'
-import { getVariableValue, styled } from '@tamagui/core'
-import type { Scope } from '@tamagui/create-context'
-import { createContextScope } from '@tamagui/create-context'
-import { getSize } from '@tamagui/get-token'
-import { withStaticProperties } from '@tamagui/helpers'
-import { ThemeableStack, YStackProps } from '@tamagui/stacks'
-import * as React from 'react'
-import { View } from 'react-native'
+import type { GetProps } from "@tamagui/core";
+import { getVariableValue, styled } from "@tamagui/core";
+import type { Scope } from "@tamagui/create-context";
+import { createContextScope } from "@tamagui/create-context";
+import { getSize } from "@tamagui/get-token";
+import { withStaticProperties } from "@tamagui/helpers";
+import { ThemeableStack } from "@tamagui/stacks";
+import * as React from "react";
+import { Platform } from "react-native";
 
-const PROGRESS_NAME = 'Progress'
+import { Progress as NativeProgressIOS } from "./NativeProgressIOS";
 
-const [createProgressContext, createProgressScope] = createContextScope(PROGRESS_NAME)
-type ProgressContextValue = { value: number | null; max: number; width: number }
+const PROGRESS_NAME = "Progress";
+
+const [createProgressContext, createProgressScope] =
+  createContextScope(PROGRESS_NAME);
+type ProgressContextValue = {
+  value: number | null;
+  max: number;
+  width: number;
+};
 const [ProgressProvider, useProgressContext] =
-  createProgressContext<ProgressContextValue>(PROGRESS_NAME)
+  createProgressContext<ProgressContextValue>(PROGRESS_NAME);
 
 /* -------------------------------------------------------------------------------------------------
  * ProgressIndicator
  * -----------------------------------------------------------------------------------------------*/
 
-const INDICATOR_NAME = 'ProgressIndicator'
+const INDICATOR_NAME = "ProgressIndicator";
 
 export const ProgressIndicatorFrame = styled(ThemeableStack, {
   name: INDICATOR_NAME,
@@ -30,74 +37,80 @@ export const ProgressIndicatorFrame = styled(ThemeableStack, {
   variants: {
     unstyled: {
       false: {
-        height: '100%',
-        width: '100%',
+        height: "100%",
+        width: "100%",
         backgrounded: true,
       },
     },
   } as const,
 
   defaultVariants: {
-    unstyled: process.env.TAMAGUI_HEADLESS === '1' ? true : false,
+    unstyled: process.env.TAMAGUI_HEADLESS === "1" ? true : false,
   },
-})
+});
 
-type ProgressIndicatorProps = GetProps<typeof ProgressIndicatorFrame>
+type ProgressIndicatorProps = GetProps<typeof ProgressIndicatorFrame>;
 
-const ProgressIndicator = ProgressIndicatorFrame.styleable(function ProgressIndicator(
-  props: ScopedProps<ProgressIndicatorProps>,
-  forwardedRef
-) {
-  const { __scopeProgress, ...indicatorProps } = props
-  const context = useProgressContext(INDICATOR_NAME, __scopeProgress)
-  const pct = context.max - (context.value ?? 0)
-  // default somewhat far off
-  const x = -(context.width === 0 ? 300 : context.width) * (pct / 100)
-  return (
-    <ProgressIndicatorFrame
-      data-state={getProgressState(context.value, context.max)}
-      data-value={context.value ?? undefined}
-      data-max={context.max}
-      x={x}
-      width={context.width}
-      {...(!props.unstyled && {
-        animateOnly: ['transform'],
-        opacity: context.width === 0 ? 0 : 1,
-      })}
-      {...indicatorProps}
-      ref={forwardedRef}
-    />
-  )
-})
+const ProgressIndicator = ProgressIndicatorFrame.styleable(
+  function ProgressIndicator(
+    props: ScopedProps<ProgressIndicatorProps>,
+    forwardedRef
+  ) {
+    const { __scopeProgress, ...indicatorProps } = props;
+    const context = useProgressContext(INDICATOR_NAME, __scopeProgress);
+    const pct = context.max - (context.value ?? 0);
+    // default somewhat far off
+    const x = -(context.width === 0 ? 300 : context.width) * (pct / 100);
+    return (
+      <ProgressIndicatorFrame
+        data-state={getProgressState(context.value, context.max)}
+        data-value={context.value ?? undefined}
+        data-max={context.max}
+        x={x}
+        width={context.width}
+        {...(!props.unstyled && {
+          animateOnly: ["transform"],
+          opacity: context.width === 0 ? 0 : 1,
+        })}
+        {...indicatorProps}
+        ref={forwardedRef}
+      />
+    );
+  }
+);
 
 /* ---------------------------------------------------------------------------------------------- */
 
 function defaultGetValueLabel(value: number, max: number) {
-  return `${Math.round((value / max) * 100)}%`
+  return `${Math.round((value / max) * 100)}%`;
 }
 
 function getProgressState(
   value: number | undefined | null,
   maxValue: number
 ): ProgressState {
-  return value == null ? 'indeterminate' : value === maxValue ? 'complete' : 'loading'
+  return value == null
+    ? "indeterminate"
+    : value === maxValue
+    ? "complete"
+    : "loading";
 }
 
 function isNumber(value: any): value is number {
-  return typeof value === 'number'
+  return typeof value === "number";
 }
 
 function isValidMaxNumber(max: any): max is number {
-  return isNumber(max) && !Number.isNaN(max) && max > 0
+  return isNumber(max) && !Number.isNaN(max) && max > 0;
 }
 
 function isValidValueNumber(value: any, max: number): value is number {
-  return isNumber(value) && !Number.isNaN(value) && value <= max && value >= 0
+  return isNumber(value) && !Number.isNaN(value) && value <= max && value >= 0;
 }
 
 // Split this out for clearer readability of the error message.
 function getInvalidMaxError(propValue: string, componentName: string) {
-  return `Invalid prop \`max\` of value \`${propValue}\` supplied to \`${componentName}\`. Only numbers greater than 0 are valid max values. Defaulting to \`${DEFAULT_MAX}\`.`
+  return `Invalid prop \`max\` of value \`${propValue}\` supplied to \`${componentName}\`. Only numbers greater than 0 are valid max values. Defaulting to \`${DEFAULT_MAX}\`.`;
 }
 
 function getInvalidValueError(propValue: string, componentName: string) {
@@ -106,75 +119,88 @@ function getInvalidValueError(propValue: string, componentName: string) {
   - less than the value passed to \`max\` (or ${DEFAULT_MAX} if no \`max\` prop is set)
   - \`null\` if the progress is indeterminate.
 
-Defaulting to \`null\`.`
+Defaulting to \`null\`.`;
 }
 
 /* -------------------------------------------------------------------------------------------------
  * Progress
  * -----------------------------------------------------------------------------------------------*/
 
-const DEFAULT_MAX = 100
+const DEFAULT_MAX = 100;
 
-type ScopedProps<P> = P & { __scopeProgress?: Scope }
+type ScopedProps<P> = P & { __scopeProgress?: Scope };
 
-type ProgressState = 'indeterminate' | 'complete' | 'loading'
+type ProgressState = "indeterminate" | "complete" | "loading";
 
 export const ProgressFrame = styled(ThemeableStack, {
-  name: 'Progress',
+  name: "Progress",
 
   variants: {
     unstyled: {
       false: {
         borderRadius: 100_000,
-        overflow: 'hidden',
+        overflow: "hidden",
         backgrounded: true,
       },
     },
 
     size: {
-      '...size': (val) => {
-        const size = Math.round(getVariableValue(getSize(val)) * 0.25)
+      "...size": (val) => {
+        const size = Math.round(getVariableValue(getSize(val)) * 0.25);
         return {
           height: size,
           minWidth: getVariableValue(size) * 20,
-          width: '100%',
-        }
+          width: "100%",
+        };
       },
     },
   } as const,
 
   defaultVariants: {
-    unstyled: process.env.TAMAGUI_HEADLESS === '1' ? true : false,
+    unstyled: process.env.TAMAGUI_HEADLESS === "1" ? true : false,
   },
-})
+});
 
 interface ProgressExtraProps {
-  value?: number | null | undefined
-  max?: number
-  getValueLabel?(value: number, max: number): string
+  value?: number | null | undefined;
+  max?: number;
+  native?: "ios";
+  getValueLabel?(value: number, max: number): string;
 }
 
-type ProgressProps = GetProps<typeof ProgressFrame> & ProgressExtraProps
+type ProgressProps = GetProps<typeof ProgressFrame> & ProgressExtraProps;
 
 const Progress = withStaticProperties(
-  ProgressFrame.styleable<ProgressExtraProps>(function Progress(props, forwardedRef) {
+  ProgressFrame.styleable<ProgressExtraProps>(function Progress(
+    props,
+    forwardedRef
+  ) {
     const {
       // @ts-expect-error
       __scopeProgress,
       value: valueProp,
       max: maxProp,
       getValueLabel = defaultGetValueLabel,
-      size = '$true',
+      size = "$true",
       ...progressProps
-    } = props
+    } = props;
 
-    const max = isValidMaxNumber(maxProp) ? maxProp : DEFAULT_MAX
-    const value = isValidValueNumber(valueProp, max) ? valueProp : null
-    const valueLabel = isNumber(value) ? getValueLabel(value, max) : undefined
-    const [width, setWidth] = React.useState(0)
+    const max = isValidMaxNumber(maxProp) ? maxProp : DEFAULT_MAX;
+    const value = isValidValueNumber(valueProp, max) ? valueProp : null;
+    const valueLabel = isNumber(value) ? getValueLabel(value, max) : undefined;
+    const [width, setWidth] = React.useState(0);
+
+    if (props.native && Platform.OS === "ios") {
+      return <NativeProgressIOS {...props} />;
+    }
 
     return (
-      <ProgressProvider scope={__scopeProgress} value={value} max={max} width={width}>
+      <ProgressProvider
+        scope={__scopeProgress}
+        value={value}
+        max={max}
+        width={width}
+      >
         <ProgressFrame
           aria-valuemax={max}
           aria-valuemin={0}
@@ -190,18 +216,18 @@ const Progress = withStaticProperties(
           })}
           {...progressProps}
           onLayout={(e) => {
-            setWidth(e.nativeEvent.layout.width)
-            progressProps.onLayout?.(e)
+            setWidth(e.nativeEvent.layout.width);
+            progressProps.onLayout?.(e);
           }}
           ref={forwardedRef}
         />
       </ProgressProvider>
-    )
+    );
   }),
   {
     Indicator: ProgressIndicator,
   }
-)
+);
 
-export { createProgressScope, Progress, ProgressIndicator }
-export type { ProgressProps, ProgressIndicatorProps }
+export { Progress, ProgressIndicator, createProgressScope };
+export type { ProgressIndicatorProps, ProgressProps };


### PR DESCRIPTION
- Added native progress component written with SwiftUI
- Added to kitchen sink for testing
- Supports `max` and `value` props (I think it also supports all tamagui props but it applies it to the wrapper not the actual swiftui view... need to test this more)
