### PR TITLE
feat: add exclude option to tamagui-build and opt out of picking up babel config

### DIFF
--- a/packages/build/tamagui-build.js
+++ b/packages/build/tamagui-build.js
@@ -25,6 +25,7 @@ const declarationToRoot = !!process.argv.includes('--declaration-root')
 const ignoreBaseUrl = process.argv.includes('--ignore-base-url')
 const baseUrlIndex = process.argv.indexOf('--base-url')
 const tsProjectIndex = process.argv.indexOf('--ts-project')
+const exludeIndex = process.argv.indexOf('--exclude')
 const baseUrl =
   baseUrlIndex > -1 && process.argv[baseUrlIndex + 1]
     ? process.argv[baseUrlIndex + 1]
@@ -33,6 +34,10 @@ const tsProject =
   tsProjectIndex > -1 && process.argv[tsProjectIndex + 1]
     ? process.argv[tsProjectIndex + 1]
     : null
+
+const exclude = exludeIndex > -1 && process.argv[exludeIndex + 1]
+? process.argv[exludeIndex + 1]
+: null
 
 const pkg = fs.readJSONSync('./package.json')
 let shouldSkipInitialTypes = !!process.env.SKIP_TYPES_INITIAL
@@ -181,7 +186,7 @@ async function buildJs() {
   const files = shouldBundle
     ? [pkgSource || './src/index.ts']
     : (await fg(['src/**/*.(m)?[jt]s(x)?', 'src/**/*.css'])).filter(
-        (x) => !x.includes('.d.ts')
+        (x) => !x.includes('.d.ts') && (exclude ? !x.match(exclude) : true)
       )
 
   const externalPlugin = createExternalPlugin({
@@ -564,6 +569,7 @@ async function esbuildWriteIfChanged(
               ? outString
               : transform(outString, {
                   filename: mjsOutPath,
+                  configFile: false,
                   plugins: [
                     [
                       require.resolve('babel-plugin-fully-specified'),


### PR DESCRIPTION
This allows opting into excluding certain files from being built with `tamagui-build` via regex. my main use case for this is it was picking up my inline `.stories` files from storybook and building those.

It also opts out of picking up the babel config files as that proved to be the root cause of some build issues with `mjs` that I was dealing with. This can be parameterized too if needed but I figure it should always be `false`?