### PR TITLE
Adds event listener on target for blur events

### DIFF
--- a/packages/focus-scope/src/FocusScope.tsx
+++ b/packages/focus-scope/src/FocusScope.tsx
@@ -70,6 +70,11 @@ export function useFocusScope(
       if (focusScope.paused || !container) return
       const target = event.target as HTMLElement | null
       if (container.contains(target)) {
+        // Set container as lastFocusedElement to prevent inputs
+        // to be refocused on blur events
+        target?.addEventListener('blur', () => {
+          lastFocusedElementRef.current = container
+        })
         lastFocusedElementRef.current = target
       } else {
         focus(lastFocusedElementRef.current, { select: true })

--- a/packages/focus-scope/src/FocusScope.tsx
+++ b/packages/focus-scope/src/FocusScope.tsx
@@ -66,13 +66,15 @@ export function useFocusScope(
   React.useEffect(() => {
     if (!enabled) return
     if (!trapped) return
+    const controller = new AbortController;
+
     function handleFocusIn(event: FocusEvent) {
       if (focusScope.paused || !container) return
       const target = event.target as HTMLElement | null
       if (container.contains(target)) {
         // Set container as lastFocusedElement to prevent inputs
         // to be refocused on blur events
-        target?.addEventListener('blur', handleBlur, { once: true })
+        target?.addEventListener('blur', handleBlur, { signal: controller.signal })
         lastFocusedElementRef.current = target
       } else {
         focus(lastFocusedElementRef.current, { select: true })
@@ -80,6 +82,7 @@ export function useFocusScope(
     }
 
     function handleFocusOut(event: FocusEvent) {
+      controller.abort()
       if (focusScope.paused || !container) return
       if (!container.contains(event.relatedTarget as HTMLElement | null)) {
         focus(lastFocusedElementRef.current, { select: true })
@@ -93,6 +96,7 @@ export function useFocusScope(
     document.addEventListener('focusin', handleFocusIn)
     document.addEventListener('focusout', handleFocusOut)
     return () => {
+      controller.abort()
       document.removeEventListener('focusin', handleFocusIn)
       document.removeEventListener('focusout', handleFocusOut)
     }

--- a/packages/focus-scope/src/FocusScope.tsx
+++ b/packages/focus-scope/src/FocusScope.tsx
@@ -72,9 +72,7 @@ export function useFocusScope(
       if (container.contains(target)) {
         // Set container as lastFocusedElement to prevent inputs
         // to be refocused on blur events
-        target?.addEventListener('blur', () => {
-          lastFocusedElementRef.current = container
-        })
+        target?.addEventListener('blur', handleBlur, { once: true })
         lastFocusedElementRef.current = target
       } else {
         focus(lastFocusedElementRef.current, { select: true })
@@ -86,6 +84,10 @@ export function useFocusScope(
       if (!container.contains(event.relatedTarget as HTMLElement | null)) {
         focus(lastFocusedElementRef.current, { select: true })
       }
+    }
+
+    function handleBlur() {
+      lastFocusedElementRef.current = container
     }
 
     document.addEventListener('focusin', handleFocusIn)


### PR DESCRIPTION
Related to https://github.com/tamagui/tamagui/issues/2223

Using input inside FocusScope with trapped focus, the input gets reselected on blur events.

This PR adds a eventlistener for blur events, and sets focus to the container if blur events are triggered.