### PR TITLE
fix docs, theme func arg

### DIFF
--- a/apps/site/data/docs/guides/theme-builder.mdx
+++ b/apps/site/data/docs/guides/theme-builder.mdx
@@ -9,8 +9,8 @@ demoName: ThemeBuilder
 </HeroContainer>
 
 <IntroParagraph>
-  The new theme-builder package makes creating suites of themes for Tamagui far easier,
-  with some performance benefits to boot.
+  The new theme-builder package makes creating suites of themes for Tamagui far
+  easier, with some performance benefits to boot.
 </IntroParagraph>
 
 With version 1.37 Tamagui has released two new things to help make authoring themes much easier:
@@ -23,16 +23,17 @@ The new ThemeBuilder makes it much easier to generate a suite of themes. Meanwhi
 This guide goes into `createThemeBuilder`. If you want to [skip to the API, check here](#createthemebuilder), or you can just copy-paste [a complete example here](#complete-example).
 
 <Notice>
-  You don't need to create your own theme suite. You can use our built-in themes or roll
-  your own by hand. Or you can just avoid themes altogether! This guide is for more
-  advanced use cases where you want to generate a very custom look and feel for your app.
+  You don't need to create your own theme suite. You can use our built-in themes
+  or roll your own by hand. Or you can just avoid themes altogether! This guide
+  is for more advanced use cases where you want to generate a very custom look
+  and feel for your app.
 </Notice>
 
 Before we dive in, here's a minimal createThemeBuilder example to understand what we're building towards. It generates `light`, `dark`, `light_subtle`, and `dark_subtle` themes using all the concepts we'll cover in this guide: palettes, templates, masks, and themes:
 
 <Notice>
-  Note that the @tamagui/theme-builder package requires TypeScript 5 or greater for const
-  generic support.
+  Note that the @tamagui/theme-builder package requires TypeScript 5 or greater
+  for const generic support.
 </Notice>
 
 ```tsx
@@ -193,9 +194,12 @@ The `tamagui` components have standardized on the following minimum theme, so if
 We could make a quick and hard-coded function that takes a template + palette and returns a theme, just to illustrate how they are used:
 
 ```tsx
-const createTheme = (palette: string[]) => ({
-  background: palette[0],
-  color: palette[12],
+const createTheme = (palette: string[], colorTemplate: {
+  background: number
+  color: number
+}) => ({
+  background: palette[colorTemplate.background],
+  color: palette[colorTemplate.color],
 })
 
 createTheme(dark_blue)


### PR DESCRIPTION
docs seem to reference second arg, but it doesn't exist.
