### PR TITLE
fix shorthand for bc/borderColor

### DIFF
--- a/packages/shorthands/src/index.ts
+++ b/packages/shorthands/src/index.ts
@@ -26,7 +26,7 @@ export const shorthands = {
   ai: 'alignItems',
   als: 'alignSelf',
   b: 'bottom',
-  bc: 'backgroundColor',
+  bc: 'borderColor',
   bg: 'backgroundColor',
   bbc: 'borderBottomColor',
   bblr: 'borderBottomLeftRadius',


### PR DESCRIPTION
 I think `bc` stands for "borderColor', right?
It stopped working for me after updated takeout today, maybe after tamagui@0.18.20