### PR TITLE
Updated import name

### DIFF
--- a/apps/site/data/docs/guides/expo.mdx
+++ b/apps/site/data/docs/guides/expo.mdx
@@ -73,14 +73,14 @@ import { Stack } from 'expo-router'
 import { useColorScheme } from 'react-native'
 import { TamaguiProvider } from 'tamagui'
 
-import { config } from '../tamagui.config'
+import { tamaguiConfig } from '../tamagui.config'
 
 export default function RootLayout() {
   const colorScheme = useColorScheme()
 
   return (
     // add this
-    <TamaguiProvider config={config} defaultTheme={colorScheme}>
+    <TamaguiProvider config={tamaguiConfig} defaultTheme={colorScheme}>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
           <Stack.Screen name='(tabs)' options={{ headerShown: false }} />


### PR DESCRIPTION
Currently if you copy/paste the code that's in the installation instructions, you'll get a Typescript error because of the import name mismatch. This PR fixes that.