### PR TITLE
Set hover and focus when disabled

### DIFF
--- a/packages/web/src/createComponent.tsx
+++ b/packages/web/src/createComponent.tsx
@@ -492,6 +492,10 @@ export function createComponent<
 
     const hasTextAncestor = !!(isWeb && isText ? componentContext.inText : false)
     const isDisabled = props.disabled ?? props.accessibilityState?.disabled
+    if (isDisabled) {
+      state.hover = false
+      state.focus = false
+    }
 
     if (process.env.NODE_ENV === 'development' && time) time`use-context`
 


### PR DESCRIPTION
If a button click is causing the button to be disabled, the button gets stuck in focus and hover state. Beacause the button is disabled it is not possible for the button to loose focus or hover state since all events are turned of.