### PR TITLE
fix season button overflow

### DIFF
--- a/apps/site/components/SeasonToggleButton.tsx
+++ b/apps/site/components/SeasonToggleButton.tsx
@@ -26,7 +26,7 @@ export const SeasonToggleButton = (props: ButtonProps) => {
           }}
           {...props}
           aria-label="Toggle theme"
-          ov="hidden"
+          ov="visible"
           hoverStyle={{
             bg: 'rgba(0,0,0,0.15)',
           }}


### PR DESCRIPTION
before: 
<img width="1495" alt="image" src="https://github.com/tamagui/tamagui/assets/2502947/84f80dc2-792d-4a9e-b4e8-470074dc8fda">


after:
<img width="1289" alt="image" src="https://github.com/tamagui/tamagui/assets/2502947/3b662af3-5d66-47a3-84c9-aac03adac423">
