### PR TITLE
fix(web): Fix adding extra style elements for each `updateFont` call with same name argument

### DIFF
--- a/packages/web/src/constants/constants.ts
+++ b/packages/web/src/constants/constants.ts
@@ -1,5 +1,6 @@
 export const THEME_NAME_SEPARATOR = '_'
 export const THEME_CLASSNAME_PREFIX = 't_'
+export const FONT_DATA_ATTRIBUTE_NAME = 'data-tamagui-font'
 
 export const stackDefaultStyles = {}
 

--- a/packages/web/src/insertFont.ts
+++ b/packages/web/src/insertFont.ts
@@ -10,36 +10,17 @@ import type { GenericFont } from './types'
 /**
  * Runtime dynamic insert font
  */
-export function insertFont<A extends GenericFont>(
+function insertFont<A extends GenericFont>(
   name: string,
   fontIn: A
-): DeepVariableObject<A> {
-  const styleElement = document.createElement('style')
-  return processFont(name, fontIn, styleElement)
-}
-
-/**
- * Runtime dynamic update font
- */
-export function updateFont<A extends GenericFont>(
-  name: string,
-  fontIn: A
-): DeepVariableObject<A> {
-  const styleElement: HTMLStyleElement =
-    document.querySelector(`style[${FONT_DATA_ATTRIBUTE_NAME}="${name}"]`) ||
-    document.createElement('style')
-  return processFont(name, fontIn, styleElement)
-}
-
-function processFont<A extends GenericFont>(
-  name: string,
-  fontIn: A,
-  styleElement: HTMLStyleElement
 ): DeepVariableObject<A> {
   const font = createFont(fontIn)
   const tokened = createVariables(font, name) as GenericFont
   const parsed = parseFont(tokened) as DeepVariableObject<A>
   if (process.env.TAMAGUI_TARGET === 'web' && typeof document !== 'undefined') {
+    const styleElement: HTMLStyleElement =
+      document.querySelector(`style[${FONT_DATA_ATTRIBUTE_NAME}="${name}"]`) ||
+      document.createElement('style')
     const fontVars = registerFontVariables(parsed)
     styleElement.innerText = `:root .font_${name} {${fontVars.join(';')}}`
     styleElement.setAttribute(FONT_DATA_ATTRIBUTE_NAME, name)
@@ -48,6 +29,8 @@ function processFont<A extends GenericFont>(
   setConfigFont(name, tokened, parsed)
   return parsed
 }
+
+export const updateFont = insertFont
 
 export function parseFont<A extends GenericFont>(definition: A): DeepVariableObject<A> {
   const parsed: any = {}

--- a/packages/web/types/constants/constants.d.ts
+++ b/packages/web/types/constants/constants.d.ts
@@ -1,5 +1,6 @@
 export declare const THEME_NAME_SEPARATOR = "_";
 export declare const THEME_CLASSNAME_PREFIX = "t_";
+export declare const FONT_DATA_ATTRIBUTE_NAME = "data-tamagui-font";
 export declare const stackDefaultStyles: {};
 export declare const webViewFlexCompatStyles: {
     display: string;

--- a/packages/web/types/insertFont.d.ts
+++ b/packages/web/types/insertFont.d.ts
@@ -3,11 +3,9 @@ import type { GenericFont } from './types';
 /**
  * Runtime dynamic insert font
  */
-export declare function insertFont<A extends GenericFont>(name: string, fontIn: A): DeepVariableObject<A>;
-/**
- * Runtime dynamic update font
- */
-export declare function updateFont<A extends GenericFont>(name: string, fontIn: A): DeepVariableObject<A>;
+declare function insertFont<A extends GenericFont>(name: string, fontIn: A): DeepVariableObject<A>;
+export declare const updateFont: typeof insertFont;
 export declare function parseFont<A extends GenericFont>(definition: A): DeepVariableObject<A>;
 export declare function registerFontVariables(parsedFont: any): string[];
+export {};
 //# sourceMappingURL=insertFont.d.ts.map

--- a/packages/web/types/insertFont.d.ts
+++ b/packages/web/types/insertFont.d.ts
@@ -4,7 +4,10 @@ import type { GenericFont } from './types';
  * Runtime dynamic insert font
  */
 export declare function insertFont<A extends GenericFont>(name: string, fontIn: A): DeepVariableObject<A>;
-export declare const updateFont: typeof insertFont;
+/**
+ * Runtime dynamic update font
+ */
+export declare function updateFont<A extends GenericFont>(name: string, fontIn: A): DeepVariableObject<A>;
 export declare function parseFont<A extends GenericFont>(definition: A): DeepVariableObject<A>;
 export declare function registerFontVariables(parsedFont: any): string[];
 //# sourceMappingURL=insertFont.d.ts.map


### PR DESCRIPTION
Updating fonts (calling `updateFont`) in runtime would call `insertFont` which again inserts a new style element each time. This change ensures `insertFont` adds a single new style element given the same name parameter.