### PR TITLE
chore(dialog): remove cryptic console warn

### DIFF
--- a/packages/dialog/src/Dialog.tsx
+++ b/packages/dialog/src/Dialog.tsx
@@ -731,7 +731,6 @@ const DialogClose = DialogCloseFrame.styleable<DialogCloseExtraProps>(
         {...closeProps}
         ref={forwardedRef}
         onPress={composeEventHandlers(props.onPress as any, () => {
-          console.warn('??')
           context.onOpenChange(false)
         })}
       />


### PR DESCRIPTION
I do not feel like it is supposed to warn a message, feel free to change the content of the warning if necessary