### PR TITLE
feat(popover): imperative close

### DIFF
--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -563,6 +563,7 @@ type Rect = {
 
 export type Popover = {
   anchorTo: (rect: Rect) => void
+  close: () => void
 }
 
 export const Popover = withStaticProperties(
@@ -622,6 +623,7 @@ export const Popover = withStaticProperties(
 
       React.useImperativeHandle(forwardedRef, () => ({
         anchorTo: setAnchorTo,
+        close: () => setOpen(false),
       }))
 
       // needs to be entirely memoized!

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -563,7 +563,7 @@ type Rect = {
 
 export type Popover = {
   anchorTo: (rect: Rect) => void
-  close: () => void
+  toggle: () => void
 }
 
 export const Popover = withStaticProperties(
@@ -623,7 +623,7 @@ export const Popover = withStaticProperties(
 
       React.useImperativeHandle(forwardedRef, () => ({
         anchorTo: setAnchorTo,
-        close: () => setOpen(false),
+        toggle: () => setOpen(prev => !prev),
       }))
 
       // needs to be entirely memoized!

--- a/packages/popover/src/Popover.tsx
+++ b/packages/popover/src/Popover.tsx
@@ -564,6 +564,9 @@ type Rect = {
 export type Popover = {
   anchorTo: (rect: Rect) => void
   toggle: () => void
+  open: () => void
+  close: () => void
+  setOpen: (open: boolean) => void
 }
 
 export const Popover = withStaticProperties(
@@ -624,6 +627,9 @@ export const Popover = withStaticProperties(
       React.useImperativeHandle(forwardedRef, () => ({
         anchorTo: setAnchorTo,
         toggle: () => setOpen(prev => !prev),
+        open: () => setOpen(true),
+        close: () => setOpen(false),
+        setOpen,
       }))
 
       // needs to be entirely memoized!


### PR DESCRIPTION
Allow to close popover imperatively. It's useful when you don't want to take over the control over `open` value and want to close it manually at some point.