### PR TITLE
feat(sheet): support custom container

### DIFF
--- a/packages/sheet/src/SheetImplementationCustom.tsx
+++ b/packages/sheet/src/SheetImplementationCustom.tsx
@@ -15,6 +15,7 @@ import { Portal } from '@tamagui/portal'
 import { useKeyboardVisible } from '@tamagui/use-keyboard-visible'
 import {
   forwardRef,
+  Fragment,
   useCallback,
   useContext,
   useEffect,
@@ -52,6 +53,7 @@ export const SheetImplementationCustom = themeable(
       moveOnKeyboardChange = false,
       unmountChildrenWhenHidden = false,
       portalProps,
+      containerComponent: ContainerComponent = Fragment,
     } = props
 
     const keyboardIsVisible = useKeyboardVisible()
@@ -471,11 +473,13 @@ export const SheetImplementationCustom = themeable(
       const modalContents = (
         <Portal zIndex={zIndex} {...portalProps}>
           {shouldMountChildren && (
-            <Theme forceClassName name={themeName}>
-              <AdaptParentContext.Provider value={adaptContext}>
-                {contents}
-              </AdaptParentContext.Provider>
-            </Theme>
+            <ContainerComponent>
+              <Theme forceClassName name={themeName}>
+                <AdaptParentContext.Provider value={adaptContext}>
+                  {contents}
+                </AdaptParentContext.Provider>
+              </Theme>
+            </ContainerComponent>
           )}
         </Portal>
       )

--- a/packages/sheet/src/types.tsx
+++ b/packages/sheet/src/types.tsx
@@ -44,6 +44,7 @@ export type SheetProps = ScopedProps<
      * Native-only flag that will make the sheet move up when the mobile keyboard opens so the focused input remains visible
      */
     moveOnKeyboardChange?: boolean
+    containerComponent?: React.ComponentType<any>
   },
   'Sheet'
 >

--- a/packages/sheet/types/Sheet.d.ts
+++ b/packages/sheet/types/Sheet.d.ts
@@ -70,6 +70,7 @@ export declare const Sheet: import("react").ForwardRefExoticComponent<{
     zIndex?: number | undefined;
     portalProps?: import("@tamagui/portal").PortalProps | undefined;
     moveOnKeyboardChange?: boolean | undefined;
+    containerComponent?: import("react").ComponentType<any> | undefined;
 } & {
     __scopeSheet?: import("@tamagui/create-context").Scope<any>;
 } & import("react").RefAttributes<import("react-native").View>> & {

--- a/packages/sheet/types/SheetImplementationCustom.d.ts
+++ b/packages/sheet/types/SheetImplementationCustom.d.ts
@@ -24,6 +24,7 @@ export declare const SheetImplementationCustom: (props: Omit<{
     zIndex?: number | undefined;
     portalProps?: import("@tamagui/portal").PortalProps | undefined;
     moveOnKeyboardChange?: boolean | undefined;
+    containerComponent?: import("react").ComponentType<any> | undefined;
 } & {
     __scopeSheet?: import("@tamagui/create-context").Scope<any>;
 } & import("react").RefAttributes<View>, "themeInverse" | "theme"> & import("@tamagui/core").ThemeableProps) => import("react").ReactNode;

--- a/packages/sheet/types/createSheet.d.ts
+++ b/packages/sheet/types/createSheet.d.ts
@@ -34,6 +34,7 @@ export declare function createSheet<H extends SheetStyledComponent | TamaguiComp
     zIndex?: number | undefined;
     portalProps?: import("@tamagui/portal").PortalProps | undefined;
     moveOnKeyboardChange?: boolean | undefined;
+    containerComponent?: import("react").ComponentType<any> | undefined;
 } & {
     __scopeSheet?: import("@tamagui/create-context").Scope<any>;
 } & RefAttributes<View>> & {

--- a/packages/sheet/types/types.d.ts
+++ b/packages/sheet/types/types.d.ts
@@ -39,6 +39,7 @@ export type SheetProps = ScopedProps<{
      * Native-only flag that will make the sheet move up when the mobile keyboard opens so the focused input remains visible
      */
     moveOnKeyboardChange?: boolean;
+    containerComponent?: React.ComponentType<any>;
 }, 'Sheet'>;
 export type PositionChangeHandler = (position: number) => void;
 type OpenChangeHandler = ((open: boolean) => void) | React.Dispatch<React.SetStateAction<boolean>>;


### PR DESCRIPTION
- [x] add `containerComponent` prop to support custom container for sheet.
 will fix this issue [discord](https://discord.com/channels/909986013848412191/1208891297457504286/1219306834788225166) by letting the user to add `FullWindowOverlay` from `react-native-screens` as a wrapper to render modal on top of ios modal when `presentation: 'modal'` in `react-navigation` Stack.screen
- [x] sheet is not touchable after popping up

```tsx
      <Sheet
        containerComponent={useMemo(
          () => (props) => (
            <FullWindowOverlay>
              <View flex={1} pointerEvents="box-none">
                {props.children}
              </View>
            </FullWindowOverlay>
          ),
          []
        )}
```