### PR TITLE
feat(adapt): ios/android disctinction

### DIFF
--- a/packages/adapt/src/Adapt.tsx
+++ b/packages/adapt/src/Adapt.tsx
@@ -1,4 +1,4 @@
-import { isWeb, useIsomorphicLayoutEffect } from '@tamagui/constants'
+import { isAndroid, isIos, isWeb, useIsomorphicLayoutEffect } from '@tamagui/constants'
 import { isTouchable } from '@tamagui/constants'
 import type { MediaQueryKey } from '@tamagui/core'
 import { useMedia } from '@tamagui/core'
@@ -9,7 +9,7 @@ type MediaQueryKeyString = MediaQueryKey extends string ? MediaQueryKey : never
 
 export type AdaptProps = {
   when?: MediaQueryKeyString
-  platform?: 'native' | 'web' | 'touch'
+  platform?: 'native' | 'web' | 'touch' | 'ios' | 'android'
   children?: any
 }
 
@@ -73,6 +73,8 @@ export const Adapt = withStaticProperties(
     if (platform === 'touch') enabled = isTouchable
     if (platform === 'native') enabled = !isWeb
     if (platform === 'web') enabled = isWeb
+    if (platform === 'ios') enabled = isIos
+    if (platform === 'android') enabled = isAndroid
 
     if (when && !media[when]) {
       enabled = false


### PR DESCRIPTION
I find it very useful to have the ability to distinguish between iOS and Android separately.
Technically it can be achieved by `isIos` and `isAndroid` but JSX declarative way is way much more readable and consistent.