### PR TITLE
docs: fix typos in Unspaced 1.0.0.mdx

### DIFF
--- a/apps/site/data/docs/components/unspaced/1.0.0.mdx
+++ b/apps/site/data/docs/components/unspaced/1.0.0.mdx
@@ -11,9 +11,9 @@ component: Unspaced
   Avoids spacing for children inside a spacing container
 </Description>
 
-While the `space` property is deprecated, Unspaced could like on in a better form, one which is easy to back-ported to make Unspaced support (as well as adding `gap` support).
+While the `space` property is deprecated, Unspaced lives on in a better form, one which is easily back-ported to add Unspaced support (as well as adding `gap` support).
 
-When using the `space` style prop, you may want some children to not be spaced
+When using the `space` style prop, you may want some children to not be spaced.
 
 Use Unspaced:
 


### PR DESCRIPTION
This PR fixes some minor typos in the Unspaced documentation.