### PR TITLE
fix(core): forceStyle not passing down

### DIFF
--- a/packages/web/src/createComponent.tsx
+++ b/packages/web/src/createComponent.tsx
@@ -778,6 +778,10 @@ export function createComponent<
     // so the type is pretty loose
     let viewProps = nonTamaguiProps
 
+    if (!isTaggable && props.forceStyle) {
+      viewProps.forceStyle = props.forceStyle
+    }
+
     if (isHOC && _themeProp) {
       viewProps.theme = _themeProp
     }


### PR DESCRIPTION
`forceStyle` need to pass down to the underlying `staticConfig.Component` 
for example following case will not work
```jsx
const Button = styled(_Button, {
  name: 'Button',
  tag: 'button',
  backgroundColor: 'red',
  hoverStyle: {
    backgroundColor: 'blue',
  },
  pressStyle: {
    backgroundColor: 'yellow',
  },
})

export const Sandbox = () => (
      <Button forceStyle="press" />
)

```
fix #2396 