### PR TITLE
Don't error silently in dev mode for inserting styles

### DIFF
--- a/packages/web/src/helpers/insertStyleRule.tsx
+++ b/packages/web/src/helpers/insertStyleRule.tsx
@@ -352,7 +352,7 @@ export function insertStyleRules(rulesToInsert: RulesToInsert) {
     updateRules(identifier, rules)
 
     for (const rule of rules) {
-      if (process.env.NODE_ENV === 'production') {
+      if (process.env.NODE_ENV !== 'production') {
         sheet.insertRule(rule, sheet.cssRules.length)
       } else {
         try {


### PR DESCRIPTION
Errors should throw in dev and (sometimes) be silent in prod, never the opposite.