### PR TITLE
fix(site): tint switch crash issue

### DIFF
--- a/apps/site/pages/ui/[...slug].tsx
+++ b/apps/site/pages/ui/[...slug].tsx
@@ -79,7 +79,7 @@ export default function DocComponentsPage({ frontmatter, code }: Doc) {
       <MDXProvider frontmatter={frontmatter}>
         <ThemeTint disable={!isTinted}>
           <CustomTabs id="type" defaultValue="styled">
-            <Component components={components as any} />
+            <Component components={components as any} key={String(isTinted)} />
           </CustomTabs>
         </ThemeTint>
       </MDXProvider>


### PR DESCRIPTION
fix the issue where turning tint on/off crashed the demos on the site