### PR TITLE
Move react-dom of floating to peerDependencies

### DIFF
--- a/packages/floating/package.json
+++ b/packages/floating/package.json
@@ -30,19 +30,20 @@
     "clean:build": "tamagui-build clean:build"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "*",
+    "react-dom": "*"
   },
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.0.6",
-    "@floating-ui/react-native": "^0.10.3",
-    "react-dom": "^18.2.0"
+    "@floating-ui/react-native": "^0.10.3"
   },
   "devDependencies": {
     "@tamagui/build": "1.96.0",
     "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-native": "^0.73.4"
   }
 }


### PR DESCRIPTION
This moves react-dom to peerDependencies for better support of upcoming React 19