### PR TITLE
Fix select scroll behaviour

### DIFF
--- a/packages/select/src/SelectImpl.tsx
+++ b/packages/select/src/SelectImpl.tsx
@@ -60,6 +60,7 @@ export const SelectInlineImpl = (props: SelectImplProps) => {
   const selectTimeoutRef = React.useRef<any>()
   const state = React.useRef({
     isMouseOutside: false,
+    isTyping: false
   })
 
   const [controlledScrolling, setControlledScrolling] = React.useState(false)
@@ -201,6 +202,9 @@ export const SelectInlineImpl = (props: SelectImplProps) => {
       onMatch,
       selectedIndex,
       activeIndex,
+      onTypingChange: (e) => {
+        state.current.isTyping = e
+      }
     }),
   ]
 
@@ -222,7 +226,7 @@ export const SelectInlineImpl = (props: SelectImplProps) => {
             if (
               event.key === 'Enter' ||
               event.code === 'Space' ||
-              (event.key === ' ' && !context.dataRef.current.typing)
+              (event.key === ' ' && !state.current.isTyping)
             ) {
               event.preventDefault()
               setOpen(true)

--- a/packages/select/src/SelectImpl.tsx
+++ b/packages/select/src/SelectImpl.tsx
@@ -196,6 +196,7 @@ export const SelectInlineImpl = (props: SelectImplProps) => {
       activeIndex: activeIndex || 0,
       selectedIndex,
       onNavigate: setActiveIndex,
+      scrollItemIntoView: false,
     }),
     useTypeahead(context, {
       listRef: listContentRef,

--- a/packages/select/src/SelectViewport.tsx
+++ b/packages/select/src/SelectViewport.tsx
@@ -91,7 +91,6 @@ export const SelectViewport = SelectViewportFrame.styleable<SelectViewportExtraP
       style,
       // remove this, it was set to "Select" always
       className,
-      onScroll,
       ...floatingProps
     } = itemContext.interactions.getFloatingProps()
 


### PR DESCRIPTION
Related to #2625

useListNavigation tries to scroll the item into view when the list opens, witch collides with the useInnerOffset, resulting in items further down the list won't end up in the correct position.

The removal of onScroll event makes the down arrow appear when the list opens, even if you are at the end of the list.