### PR TITLE
Corrected Shorthand setup github link in configuration.mdx

### DIFF
--- a/apps/site/data/docs/core/configuration.mdx
+++ b/apps/site/data/docs/core/configuration.mdx
@@ -681,7 +681,7 @@ Which will enable usage like:
 where `br` expands into `borderRadius`. 
 
 <Notice theme="green">
-  For a full shorthands setup, see [the @tamagui/shorthands source](https://github.com/tamagui/tamagui/blob/master/packages/shorthands/src/index.tsx).
+  For a full shorthands setup, see [the @tamagui/shorthands source](https://github.com/tamagui/tamagui/blob/master/packages/shorthands/src/index.ts).
 </Notice>
 
 ### Others


### PR DESCRIPTION
https://github.com/tamagui/tamagui/blob/master/packages/shorthands/src/index.tsx - returned file not found

https://github.com/tamagui/tamagui/blob/master/packages/shorthands/src/index.ts - is the correct link