### PR TITLE
Pass Spinner props to ActivityIndicator

### DIFF
--- a/packages/tamagui/src/views/Spinner.tsx
+++ b/packages/tamagui/src/views/Spinner.tsx
@@ -23,7 +23,7 @@ export const Spinner: React.ForwardRefExoticComponent<
       }
       return (
         <YStack ref={ref} {...stackProps}>
-          <ActivityIndicator size={size} color={color} />
+          <ActivityIndicator {...stackProps} size={size} color={color} />
         </YStack>
       )
     }),


### PR DESCRIPTION
[React Native Web appears to wrap the `ActivityIndicator` in a `View`, which is expecting a `style` prop to display as intended](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/ActivityIndicator/index.js#L56-L77)

This PR passes `stackProps` to `ActivityIndicator` as well. I wasn't sure if it's more optimal to just pass `style` 🤷

Happy to adapt, let me know! Thanks