### PR TITLE
RFC - feat(web): allow DOM elements

### DIFF
--- a/packages/core-test/getSplitStyles.web.test.tsx
+++ b/packages/core-test/getSplitStyles.web.test.tsx
@@ -104,6 +104,35 @@ describe('getSplitStyles', () => {
     expect(styles.rulesToInsert[0].property).toEqual(`boxShadow`)
   })
 
+  test(`backgroundColor in defaultVariant for div`, () => {
+    const CustomDiv = styled('div', {
+      backgroundColor: 'white',
+      variants: {
+        variant: {
+          red: {
+            backgroundColor: 'red',
+          },
+          green: {
+            backgroundColor: 'green',
+          },
+          gray: {
+            backgroundColor: 'gray',
+          }
+        }
+      },
+      defaultVariants: {
+        variant: 'gray'
+      }
+    } as const)
+    const styles = simplifiedGetSplitStyles(CustomDiv, {
+      backgroundColor: 'gray',
+      variant: 'gray',
+    })
+    expect(styles.rulesToInsert.length).toEqual(1)
+    expect(styles.rulesToInsert[0].value).toEqual(`gray`)
+    expect(styles.rulesToInsert[0].property).toEqual(`backgroundColor`) 
+  })
+
   test(`group container queries generate @supports and @container`, () => {
     const styles = simplifiedGetSplitStyles(Text, {
       '$group-testy-sm': {

--- a/packages/web/src/styled.tsx
+++ b/packages/web/src/styled.tsx
@@ -182,6 +182,7 @@ export function styled<
       const acceptsClassName =
         acceptsClassNameProp ??
         (isPlainStyledComponent ||
+          typeof Component === 'string' ||
           isReactNative ||
           (parentStaticConfig?.isHOC && parentStaticConfig?.acceptsClassName))
 

--- a/packages/web/src/types.tsx
+++ b/packages/web/src/types.tsx
@@ -2000,6 +2000,8 @@ export type ViewStyleWithPseudos =
       disabledStyle?: TextStyle
     })
 
+type ReactDOMComponents = string;
+
 /**
  * --------------------------------------------
  *   variants
@@ -2011,6 +2013,7 @@ export type StylableComponent =
   | ComponentType<any>
   | ForwardRefExoticComponent<any>
   | ReactComponentWithRef<any, any>
+  | ReactDOMComponents
   | (new (
       props: any
     ) => any)


### PR DESCRIPTION
The goal of the PR is to get something like
```jsx
let StyledDiv = styled('div', {
  backgroundColor: 'violet',
  variants: {
    variant: {
      red: {
        backgroundColor: 'red',
      },
      gray: {
        backgroundColor: 'gray',
      }
    }
  },
  defaultVariants: {
    variant: 'gray'
  }
} as const);
```

working:

See 
https://codesandbox.io/p/sandbox/cranky-resonance-l779n8?file=%2Fsrc%2FApp.tsx%3A27%2C34

Note the backgroundColor is violet with 1.100.3, but it should be 'gray' because of the defaultVariants.

<img width="154" alt="image" src="https://github.com/tamagui/tamagui/assets/52435/4dbfa14f-b95f-4a2a-8dfd-39a6e5fdcd32">

There is 2 change: 
1.) add string to StylableComponent
2.) acceptsClassName is true for string components. 

Neither of those are complete changes:
- typescript `InferStyledProps` generic type needs to be implemented for string components
- acceptsClassNames is not really for all string components - custom elements like 'my-element' doesn't accept classNames they access class . See https://react.dev/reference/react-dom/components#custom-html-elements

.