### PR TITLE
vxs takeout diff fixes

### DIFF
--- a/apps/x/app/(site)/takeout.tsx
+++ b/apps/x/app/(site)/takeout.tsx
@@ -825,14 +825,13 @@ export type TakeoutPageProps = Awaited<
 >
 
 const TakeoutCard2Frame = styled(YStack, {
-  className: 'blur-8',
   minWidth: 282,
   maxWidth: 282,
   minHeight: 312,
   maxHeight: 312,
   elevation: '$0.5',
   overflow: 'hidden',
-  borderRadius: '$10',
+  borderRadius: '$4',
 
   '$group-takeoutBody-gtXs': {
     scale: 0.915,

--- a/apps/x/app/(site)/takeout.tsx
+++ b/apps/x/app/(site)/takeout.tsx
@@ -866,7 +866,7 @@ const TakeoutCard = ({ children, title, icon, ...props }: TakeoutCardFrameProps)
     strategy: 'blur',
     blurPct: 60,
     // inverse: true,
-    color: isDark ? 'var(--color9)' : 'var(--color4)',
+    color: isDark ? 'var(--color1)' : 'var(--color4)',
     opacity: isDark ? 0.18 : 0.35,
     background: 'transparent',
     style: {
@@ -916,7 +916,8 @@ const TakeoutCard = ({ children, title, icon, ...props }: TakeoutCardFrameProps)
         <YStack f={1} space zi={100}>
           <H2
             fontFamily="$munro"
-            size="$10"
+            size="$8"
+            ls={3}
             als="center"
             my={-8}
             color="$color10"

--- a/apps/x/app/(site)/takeout.tsx
+++ b/apps/x/app/(site)/takeout.tsx
@@ -93,7 +93,7 @@ export default function TakeoutPage() {
         t={-100}
         b={0}
         style={{
-          background: 'linear-gradient(var(--color6), var(--color4))',
+          background: 'linear-gradient(var(--color6), var(--color2))',
         }}
         zi={-3}
       />
@@ -106,7 +106,7 @@ export default function TakeoutPage() {
           t={-100}
           b={0}
           style={{
-            background: 'linear-gradient(10deg, var(--color10), var(--color4))',
+            background: 'linear-gradient(10deg, var(--color2), var(--color1))',
           }}
           zi={-3}
         />
@@ -120,11 +120,12 @@ export default function TakeoutPage() {
           t={-100}
           b={0}
           style={{
-            background: 'linear-gradient(to bottom, var(--color3) 2%, transparent 20%)',
+            background: 'linear-gradient(to bottom, var(--color1) 2%, transparent 20%)',
           }}
           zi={-1}
         />
-        <ThemeNameEffect colorKey="$color3" />
+        {/* linearGradient / background of */}
+        <ThemeNameEffect colorKey="$color1" />
       </ThemeTintAlt>
 
       <ThemeTintAlt offset={1}>
@@ -134,6 +135,7 @@ export default function TakeoutPage() {
           r={0}
           t={-100}
           b={0}
+          o={0.3}
           style={{
             background: 'linear-gradient(to right, transparent, var(--color7))',
           }}
@@ -146,7 +148,8 @@ export default function TakeoutPage() {
         pos="absolute"
         t={-950}
         l="50%"
-        x={-300}
+        x={-500}
+        scale={0.75}
         rotate="120deg"
         o={0.01}
         $theme-light={{
@@ -173,7 +176,7 @@ export default function TakeoutPage() {
           zi={-1}
           fullscreen
           style={{
-            background: `linear-gradient(to bottom, transparent, transparent, var(--color3))`,
+            background: `linear-gradient(to bottom, transparent, transparent, var(--color2))`,
           }}
         />
       </ThemeTint>
@@ -229,9 +232,9 @@ export default function TakeoutPage() {
                   <H2
                     className="text-wrap-balance pixelate"
                     ff="$munro"
+                    ls={2}
                     my="$2"
-                    pr={200}
-                    maw={600}
+                    pr={150}
                     size="$10"
                     color="$color10"
                     $group-takeoutBody-xs={{
@@ -243,26 +246,14 @@ export default function TakeoutPage() {
                       pr: '$1',
                     }}
                   >
-                    From idea to shipped in less time&nbsp;than&nbsp;ever.
+                    A better way to get started
                   </H2>
                 </ThemeTint>
 
                 <ThemeTintAlt>
-                  <Paragraph
-                    className="text-wrap-balance"
-                    size="$8"
-                    $sm={{ size: '$7' }}
-                    fow="400"
-                  >
-                    Takeout is a bootstrap extracted from our experience creating and
-                    consulting on apps with Tamagui. It builds off the free and open
-                    source starter <CodeInline>(npm&nbsp;create&nbsp;tamagui)</CodeInline>
-                    , adding{' '}
-                    <a target="_blank" href="https://supabase.com" rel="noreferrer">
-                      Supabase
-                    </a>{' '}
-                    for data and auth, all the flows for a user-based app, and a bunch of
-                    other goodies that take time to&nbsp;set&nbsp;up&nbsp;well.
+                  <Paragraph className="text-wrap-balance" size="$7" $sm={{ size: '$7' }}>
+                    Takeout is a bootstrap designed to ship faster with React and React
+                    Native, extracted from our experience consulting on apps with Tamagui.
                   </Paragraph>
 
                   <Paragraph
@@ -270,11 +261,24 @@ export default function TakeoutPage() {
                     size="$7"
                     $sm={{ size: '$6' }}
                     $xs={{ size: '$5' }}
-                    fow="400"
                   >
-                    With <CodeInline>npx&nbsp;tamagui&nbsp;add&nbsp;font</CodeInline> and{' '}
-                    <CodeInline>npx&nbsp;tamagui&nbsp;add&nbsp;icon</CodeInline>, add on
-                    the ~1,500{' '}
+                    It builds off the free and open source starter{' '}
+                    <CodeInline>npm&nbsp;create&nbsp;tamagui</CodeInline>, adding{' '}
+                    <a target="_blank" href="https://supabase.com" rel="noreferrer">
+                      Supabase
+                    </a>{' '}
+                    for data and auth, screens and flows for a user system,
+                    profiles,&nbsp;settings,&nbsp;assets,&nbsp;and&nbsp;more.
+                  </Paragraph>
+
+                  <Paragraph
+                    className="text-wrap-balance"
+                    size="$7"
+                    $sm={{ size: '$6' }}
+                    $xs={{ size: '$5' }}
+                  >
+                    With <CodeInline>tamagui&nbsp;add&nbsp;font</CodeInline> and{' '}
+                    <CodeInline>tamagui&nbsp;add&nbsp;icon</CodeInline>, clone ~1,500{' '}
                     <Link href="https://fonts.google.com" target="_blank">
                       Google Fonts
                     </Link>{' '}
@@ -282,7 +286,8 @@ export default function TakeoutPage() {
                     <Link href="https://icones.js.org" target="_blank">
                       icones.js.org
                     </Link>{' '}
-                    icon packs to your app as typed, Tamagui-styled components.
+                    icon packs to your app as typed, Tamagui
+                    &nbsp;components&nbsp;in&nbsp;seconds.
                   </Paragraph>
                 </ThemeTintAlt>
 
@@ -684,43 +689,22 @@ export default function TakeoutPage() {
                       }}
                     />
 
-                    <ThemeTint>
-                      <Paragraph
-                        fontFamily="$silkscreen"
-                        size="$9"
-                        color="$color1"
-                        ls={-2}
-                        fow="400"
-                        bg="$color12"
-                        als="center"
-                        px="$2"
-                        mt={-55}
-                        mb={10}
-                      >
-                        it's not all about shipping&nbsp;fast.
-                      </Paragraph>
-                    </ThemeTint>
-
                     <Paragraph size="$7" $sm={{ size: '$6' }} fow="400">
-                      Takeout is a template repo that comes with a Github bot that sends
-                      PRs as we improve the starter. This is done with some git magic,
-                      scripting, and an architecture designed for easy merges. When we
-                      make significant updates, we trigger TakeoutBot to
-                      send&nbsp;a&nbsp;PR.
+                      TakeoutBot is a Github bot that sends PRs as we improve the starter.
+                      This is done with a few git commands, scripts and an architecture
+                      that tries to avoid the worst of merge conflicts.
                     </Paragraph>
 
-                    <Paragraph size="$7" $sm={{ size: '$6' }} fow="400">
-                      As you diverge we can't be perfect at sending updates, but we also
-                      have an ignorefile you can configure that gives you a lot of
-                      control. Ultimately, if you diverge enough, you can easily unplug
-                      and use it as a source of ideas and tips.
+                    <Paragraph size="$6" $sm={{ size: '$5' }} fow="400">
+                      As you diverge we can't be perfect at sending updates, but we have
+                      an ignorefile you can configure, and if you diverge enough it's
+                      still a nice reference, as we ensure dependency upgrades work across
+                      all listed features.
                     </Paragraph>
 
                     <ThemeTintAlt>
-                      <Paragraph size="$7" $sm={{ size: '$6' }} fow="400">
-                        We focus on staying up to date with recent versions and features
-                        that are universally useful. Here's some of the features we'd like
-                        to land:
+                      <Paragraph size="$6" $sm={{ size: '$5' }} fow="400">
+                        Here's some things we've been working or are planning:
                       </Paragraph>
                     </ThemeTintAlt>
 
@@ -1575,7 +1559,7 @@ const Points = () => (
       All the important screens: Onboard, Register, Login, Forgot Password, Account,
       Settings, Profile, Edit Profile, Feed
     </Point>
-    <Point>SSR, RSC, choose from 3 animation drivers</Point> 
+    <Point>SSR, RSC, choose from 3 animation drivers</Point>
     <Point>Complete & fully typed design system</Point>
     <Point>+150 icon packs</Point>
     <Point>2 all new theme suites: Pastel & Neon</Point>

--- a/apps/x/app/(site)/takeout.tsx
+++ b/apps/x/app/(site)/takeout.tsx
@@ -1089,8 +1089,8 @@ const Point = ({
 }) => {
   return (
     <XStack tag="li" ai="flex-start" space f={1} ov="hidden" {...props}>
-      <YStack py="$1.5">
-        <Check size={16} color="$color10" />
+      <YStack mr={-12} py="$1.5">
+        <Dot size={16} color="$color10" />
       </YStack>
       <YStack f={1}>
         <Paragraph color="$color" wordWrap="break-word" size={size}>

--- a/apps/x/app/(site)/takeout.tsx
+++ b/apps/x/app/(site)/takeout.tsx
@@ -1044,15 +1044,9 @@ const TakeoutHero = () => {
         />
 
         <FeatureIcon
-          themeIndex={1}
-          title="Design"
-          icon="retro-icons/design-color-painting-palette-25.svg"
-        />
-
-        <FeatureIcon
           themeIndex={2}
-          title="Deploy"
-          icon="retro-icons/computers-devices-electronics-vintage-mac-54.svg"
+          title="Screens"
+          icon="retro-icons/coding-app-website-ui-62.svg"
         />
 
         <FeatureIcon
@@ -1063,8 +1057,8 @@ const TakeoutHero = () => {
 
         <FeatureIcon
           themeIndex={4}
-          title="Screens"
-          icon="retro-icons/coding-app-website-ui-62.svg"
+          title="Stack"
+          icon="retro-icons/computers-devices-electronics-vintage-mac-54.svg"
         />
 
         <FeatureIcon
@@ -1075,7 +1069,7 @@ const TakeoutHero = () => {
 
         <FeatureIcon
           themeIndex={6}
-          title="& More"
+          title="Profiles"
           icon="retro-icons/coding-apps-websites-programming-hold-code-9.svg"
         />
       </XStack>

--- a/apps/x/app/(site)/takeout.tsx
+++ b/apps/x/app/(site)/takeout.tsx
@@ -1186,7 +1186,7 @@ const StarterCard = memo(({ product }: { product: TakeoutPageProps['starter'] })
           }}
         >
           <YStack zi={-1} fullscreen bg="$color5" o={0.5} />
-
+          {/* 
           <ThemeTintAlt>
             <LinearGradient
               pos="absolute"
@@ -1197,7 +1197,7 @@ const StarterCard = memo(({ product }: { product: TakeoutPageProps['starter'] })
               colors={['$background0', '$color5']}
               zi={100}
             />
-          </ThemeTintAlt>
+          </ThemeTintAlt> */}
 
           <YStack pos="absolute" b="$4" l="$4" r="$4" zi={100}>
             {/* cant use buttonlink it breaks scroll on press if not enabled, conditionally use a link */}
@@ -1213,12 +1213,8 @@ const StarterCard = memo(({ product }: { product: TakeoutPageProps['starter'] })
 
           <ScrollView p="$6" disabled={media.md} showsVerticalScrollIndicator={false}>
             <YStack space="$2">
-              <MunroP size="$3" o={0.1} mt={-15} mb={-5}>
-                Drop 0001
-              </MunroP>
-
               <ThemeTintAlt>
-                <MunroP color="$color11" size="$11" ls={2}>
+                <MunroP color="$color11" size="$9" ls={2}>
                   The Stack
                 </MunroP>
               </ThemeTintAlt>

--- a/apps/x/features/site/home/HomeTypography.tsx
+++ b/apps/x/features/site/home/HomeTypography.tsx
@@ -235,10 +235,9 @@ const Delay = ({ children, by, passThrough }) => {
   const [done, setDone] = useState(false)
 
   useEffect(() => {
-    if (passThrough) return
     const showTimer = setTimeout(() => setDone(true), by)
     return () => clearTimeout(showTimer)
-  }, [passThrough])
+  })
 
   if (passThrough) {
     return children

--- a/apps/x/features/takeout/TakeoutLogo.tsx
+++ b/apps/x/features/takeout/TakeoutLogo.tsx
@@ -2,7 +2,7 @@ import { ThemeTint, ThemeTintAlt } from '@tamagui/logo'
 import { useDisableMotion } from '~/hooks/useDisableMotion'
 import { H1, YStack } from 'tamagui'
 
-export const TAKEOUT = ({ fontSize = 450, lineHeight = fontSize * 0.64, ...props }) => (
+export const TAKEOUT = ({ fontSize = 420, lineHeight = fontSize * 0.64, ...props }) => (
   <H1
     userSelect="none"
     color="transparent"


### PR DESCRIPTION
**site**

-diff HeroTypography to HomeTypography

- site removed use of passThrough prop from Delay component

-diff Community to HomeCommunity

- SocialLinksRow (same, no changes)
    - Card (same, no changes)

**general vxs port issues found:**

theme change does not change text font color

regression notes:

I am seeing a regressions of component reviewed from weekend changes. ‘code preview’ and ‘resize breakpoint’ not working correctly.

**takeout**

- TakeoutGallery
    - TakeoutImage (takeout image has not code changes. Yet not showing. when debugging the src has the correct path, its a problem with props miss behaving, some are missing like objectFit. Looks like its related to Image component.
- Takeout index
    - TakeoutPage
    - CodeInline (no changes)
    - points (no changes)
    - TakeoutCard2Frame diff
    - TakeoutCard diff
    - TakeoutHero diff
    - Point diff
    - IconFrame (no changes)
    - StarterCard diff
    - Row (no changes)
    - PurchaseSelectTeam (no changes)
    - TabsRovingIndicatior (no changes)
    - FeatureIcon (no changes)
    - Bullet (no changes)
    - TakeoutLogo diff