### PR TITLE
feat(babel-plugin-fully-specified): implement and use forceExtension

### DIFF
--- a/code/packages/babel-plugin-fully-specified/package.json
+++ b/code/packages/babel-plugin-fully-specified/package.json
@@ -19,6 +19,7 @@
     "watch": "node ../../../node_modules/.bin/tamagui-build --watch",
     "lint": "npx biome check src",
     "lint:fix": "npx biome check --apply-unsafe src",
+    "test": "vitest",
     "clean": "node ../../../node_modules/.bin/tamagui-build clean",
     "clean:build": "node ../../../node_modules/.bin/tamagui-build clean:build"
   },
@@ -26,7 +27,8 @@
     "@babel/core": "^7.23.3"
   },
   "devDependencies": {
-    "@babel/types": "^7.23.3"
+    "@babel/types": "^7.23.3",
+    "vitest": "^0.34.3"
   },
   "gitHead": "a49cc7ea6b93ba384e77a4880ae48ac4a5635c14"
 }

--- a/code/packages/babel-plugin-fully-specified/package.json
+++ b/code/packages/babel-plugin-fully-specified/package.json
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "node ../../../node_modules/.bin/tamagui-build --exclude ./**/__tests__",
-    "watch": "node ../../../node_modules/.bin/tamagui-build --exclude ./**/__tests__ --watch",
+    "build": "node ../../../node_modules/.bin/tamagui-build --exclude __tests__",
+    "watch": "node ../../../node_modules/.bin/tamagui-build --exclude __tests__ --watch",
     "lint": "npx biome check src",
     "lint:fix": "npx biome check --apply-unsafe src",
     "test": "vitest",

--- a/code/packages/babel-plugin-fully-specified/package.json
+++ b/code/packages/babel-plugin-fully-specified/package.json
@@ -15,8 +15,8 @@
     "access": "public"
   },
   "scripts": {
-    "build": "node ../../../node_modules/.bin/tamagui-build",
-    "watch": "node ../../../node_modules/.bin/tamagui-build --watch",
+    "build": "node ../../../node_modules/.bin/tamagui-build --exclude ./**/__tests__",
+    "watch": "node ../../../node_modules/.bin/tamagui-build --exclude ./**/__tests__ --watch",
     "lint": "npx biome check src",
     "lint:fix": "npx biome check --apply-unsafe src",
     "test": "vitest",

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`transforming actual files > multiple extensions exists 1`] = `
+"// Expected to be transformed to use the \`.mjs\` extension, which is same as this file.
+import { foo, bar } from \\"./modules/module.mjs\\";"
+`;
+
 exports[`transforming actual files > test 1`] = `
 "import foo, { bar } from \\"./modules/module.mjs\\";
 import { foo as foo2 } from \\"./modules/module.mjs\\";

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`transforming actual files > test 1`] = `
+"import foo, { bar } from \\"./modules/module.mjs\\";
+import { foo as foo2 } from \\"./modules/module.mjs\\";
+import * as someModule from \\"./modules/module.mjs\\";
+import { foo as cjsFoo } from \\"./modules/cjs-module.cjs\\";
+
+// Will not be transformed
+import { foo as packageFoo } from '@my-org/my-pkg';
+
+// These will be transformed if \`includePackages\` includes \`@my-org/my-pkg\`.
+import { someStuff } from \\"@my-org/my-pkg/lib/index.js\\";
+// import { someOtherStuff } from '@my-org/my-pkg/lib/index' // TODO: Fix me
+import { exampleFunction } from \\"@my-org/my-pkg/lib/exampleFunction.js\\";"
+`;

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/.gitignore
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/.gitignore
@@ -1,0 +1,2 @@
+# node_modules in the fixtures directory are part of the mocked project and should not be ignored
+!node_modules

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/force-extension/bar.js
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/force-extension/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/force-extension/foo.js
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/force-extension/foo.js
@@ -1,0 +1,1 @@
+import { bar } from './bar'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/modules/module.cjs
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/modules/module.cjs
@@ -1,0 +1,2 @@
+exports.foo = 'foo'
+exports.bar = 'bar'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/modules/module.js
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/modules/module.js
@@ -1,0 +1,2 @@
+exports.foo = 'foo'
+exports.bar = 'bar'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/modules/module.mjs
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/modules/module.mjs
@@ -1,0 +1,4 @@
+export const foo = 'foo'
+export const bar = 'bar'
+
+export default foo

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/test.mjs
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/multiple-extensions-exists/test.mjs
@@ -1,0 +1,2 @@
+// Expected to be transformed to use the `.mjs` extension, which is same as this file.
+import { foo, bar } from './modules/module'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/modules/cjs-module.cjs
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/modules/cjs-module.cjs
@@ -1,0 +1,2 @@
+exports.foo = 'foo'
+exports.bar = 'bar'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/modules/module.mjs
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/modules/module.mjs
@@ -1,0 +1,4 @@
+export const foo = 'foo'
+export const bar = 'bar'
+
+export default foo

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/@my-org/my-pkg/lib/exampleFunction.js
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/@my-org/my-pkg/lib/exampleFunction.js
@@ -1,0 +1,3 @@
+exports.exampleFunction = function exampleFunction() {
+  return null
+}

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/@my-org/my-pkg/lib/index.js
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/@my-org/my-pkg/lib/index.js
@@ -1,0 +1,1 @@
+exports.foo = 'foo'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/@my-org/my-pkg/package.json
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/@my-org/my-pkg/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@my-org/my-pkg",
+  "main": "lib/index.js"
+}

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/README.md
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/node_modules/README.md
@@ -1,0 +1,1 @@
+Note: this is a mocked node_modules directory which is a part of the test mock setup. It is not a real node_modules directory created by package managers and should be commited into the repository.

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/test.mjs
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/fixtures/sample-project-1/test.mjs
@@ -1,0 +1,13 @@
+import foo, { bar } from './modules/module'
+import { foo as foo2 } from './modules/module'
+import * as someModule from './modules/module'
+
+import { foo as cjsFoo } from './modules/cjs-module'
+
+// Will not be transformed
+import { foo as packageFoo } from '@my-org/my-pkg'
+
+// These will be transformed if `includePackages` includes `@my-org/my-pkg`.
+import { someStuff } from '@my-org/my-pkg/lib'
+// import { someOtherStuff } from '@my-org/my-pkg/lib/index' // TODO: Fix me
+import { exampleFunction } from '@my-org/my-pkg/lib/exampleFunction'

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/index.test.ts
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/index.test.ts
@@ -112,4 +112,28 @@ describe('transforming actual files', () => {
 
     expect(code).toMatchSnapshot()
   })
+
+  test('multiple extensions exists', () => {
+    const { code } =
+      transformFileSync(
+        path.join(__dirname, 'fixtures', 'multiple-extensions-exists', 'test.mjs'),
+        getTransformOptions({
+          pluginOptions: { ensureFileExists: true },
+        })
+      ) || {}
+
+    expect(code).toMatchSnapshot()
+  })
+
+  test('force extension', () => {
+    const { code } =
+      transformFileSync(
+        path.join(__dirname, 'fixtures', 'force-extension', 'foo.js'),
+        getTransformOptions({
+          pluginOptions: { ensureFileExists: { forceExtension: '.mjs' } },
+        })
+      ) || {}
+
+    expect(code).toBe('import { bar } from "./bar.mjs";')
+  })
 })

--- a/code/packages/babel-plugin-fully-specified/src/__tests__/index.test.ts
+++ b/code/packages/babel-plugin-fully-specified/src/__tests__/index.test.ts
@@ -1,0 +1,115 @@
+import path from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { type TransformOptions, transform, transformFileSync } from '@babel/core'
+
+import plugin, { type FullySpecifiedOptions } from '../'
+
+/** A helper function to get the default transform options for the plugin to test. */
+const getTransformOptions = ({
+  pluginOptions,
+}: { pluginOptions?: Partial<FullySpecifiedOptions> } = {}) => ({
+  plugins: [[plugin, { ensureFileExists: false, ...pluginOptions }]],
+})
+
+/** A test helper for calling Babel transform with the plugin to test and some default options. */
+function getTransformResult(
+  input,
+  {
+    transformOptions,
+    pluginOptions,
+  }: {
+    transformOptions?: TransformOptions
+    pluginOptions?: Partial<FullySpecifiedOptions>
+  } = {}
+) {
+  return transform(input, {
+    filename: 'myFile.js',
+    configFile: false,
+    ...transformOptions,
+    ...getTransformOptions({ pluginOptions }),
+  })
+}
+
+describe('local imports', () => {
+  test('named import', () => {
+    const example1 = "import { foo } from './foo'"
+    expect(getTransformResult(example1)?.code).toBe('import { foo } from "./foo.js";')
+
+    const example2 = "import { foo as bar } from './foo'"
+    expect(getTransformResult(example2)?.code).toBe(
+      'import { foo as bar } from "./foo.js";'
+    )
+  })
+
+  test('default import', () => {
+    const example1 = "import defaultFoo from './foo'"
+    expect(getTransformResult(example1)?.code).toBe('import defaultFoo from "./foo.js";')
+
+    const example2 = "import defaultFoo, { foo } from './foo'"
+    expect(getTransformResult(example2)?.code).toBe(
+      'import defaultFoo, { foo } from "./foo.js";'
+    )
+  })
+
+  test('namespace import', () => {
+    const example = "import * as fooModule from './foo'"
+    expect(getTransformResult(example)?.code).toBe(
+      'import * as fooModule from "./foo.js";'
+    )
+  })
+
+  test('side effects only import', () => {
+    const example = "import './foo'"
+    expect(getTransformResult(example)?.code).toBe('import "./foo.js";')
+  })
+
+  test('dynamic import()', () => {
+    const example = "const foo = await import('./foo')"
+    expect(getTransformResult(example)?.code).toBe(
+      'const foo = await import("./foo.js");'
+    )
+  })
+})
+
+describe('local re-exports', () => {
+  test('named', () => {
+    const example1 = "export { foo } from './foo'"
+    expect(getTransformResult(example1)?.code).toBe('export { foo } from "./foo.js";')
+
+    const example2 = "export { foo as bar } from './foo'"
+    expect(getTransformResult(example2)?.code).toBe(
+      'export { foo as bar } from "./foo.js";'
+    )
+  })
+
+  test('default', () => {
+    const example1 = "export { default as fooDefault } from './foo'"
+    expect(getTransformResult(example1)?.code).toBe(
+      'export { default as fooDefault } from "./foo.js";'
+    )
+  })
+
+  test('namespace', () => {
+    const example1 = "export * as fooModule from './foo'"
+    expect(getTransformResult(example1)?.code).toBe(
+      'export * as fooModule from "./foo.js";'
+    )
+
+    const example2 = "export * from './foo'"
+    expect(getTransformResult(example2)?.code).toBe('export * from "./foo.js";')
+  })
+})
+
+describe('transforming actual files', () => {
+  test('test', () => {
+    const { code } =
+      transformFileSync(
+        path.join(__dirname, 'fixtures', 'sample-project-1', 'test.mjs'),
+        getTransformOptions({
+          pluginOptions: { ensureFileExists: true, includePackages: ['@my-org/my-pkg'] },
+        })
+      ) || {}
+
+    expect(code).toMatchSnapshot()
+  })
+})

--- a/code/packages/babel-plugin-fully-specified/src/index.ts
+++ b/code/packages/babel-plugin-fully-specified/src/index.ts
@@ -1,168 +1,233 @@
 import { existsSync, readFileSync, lstatSync } from 'node:fs'
 import { resolve, extname, dirname } from 'node:path'
-import {
-  importDeclaration,
-  exportNamedDeclaration,
-  exportAllDeclaration,
-  stringLiteral,
-} from '@babel/types'
 
-import type { ConfigAPI, NodePath, PluginPass } from '@babel/core'
+import type { ConfigAPI, NodePath, PluginObj, PluginPass } from '@babel/core'
 import type {
-  ImportSpecifier,
-  ImportDeclaration,
   ExportAllDeclaration,
-  StringLiteral,
-  ExportSpecifier,
-  ExportDeclaration,
   ExportNamedDeclaration,
+  Import,
+  ImportDeclaration,
 } from '@babel/types'
 
-type ImportDeclarationFunc = (
-  specifiers: Array<ImportSpecifier>,
-  source: StringLiteral
-) => ImportDeclaration
-
-type ExportNamedDeclarationFunc = (
-  declaration?: ExportDeclaration,
-  specifiers?: Array<ExportSpecifier>,
-  source?: StringLiteral
-) => ExportNamedDeclaration
-
-type ExportAllDeclarationFunc = (source: StringLiteral) => ExportAllDeclaration
-
-type PathDeclaration = NodePath & {
-  node: ImportDeclaration & ExportNamedDeclaration & ExportAllDeclaration
-}
-
-type PackageData = {
-  hasPath: boolean
-  packagePath: string
-}
-
-interface FullySpecifiedOptions {
-  declaration:
-    | ImportDeclarationFunc
-    | ExportNamedDeclarationFunc
-    | ExportAllDeclarationFunc
-  makeNodes: (path: PathDeclaration) => Array<PathDeclaration>
+export interface FullySpecifiedOptions {
   ensureFileExists: boolean
   esExtensionDefault: string
+  /** List of all extensions which we try to find. */
   tryExtensions: Array<string>
+  /** List of extensions that can run in Node.js or in the Browser. */
   esExtensions: Array<string>
+  /** List of packages that also should be transformed with this plugin. */
   includePackages: Array<string>
 }
 
-const makeDeclaration = ({
-  declaration,
-  makeNodes,
-  ensureFileExists = false,
-  esExtensionDefault = '.js',
-
-  // List of all extensions which we try to find
-  tryExtensions = ['.js', '.mjs', '.cjs'],
-
-  // List of extensions that can run in Node.js or in the Browser
-  esExtensions = ['.js', '.mjs', '.cjs'],
-
-  // List of packages that also should be transformed with this plugin
-  includePackages = [],
-}: FullySpecifiedOptions) => {
-  return (
-    path: PathDeclaration,
-    {
-      file: {
-        opts: { filename },
-      },
-    }: PluginPass
-  ) => {
-    const { source } = path.node
-
-    if (!source || !filename) {
-      return // stop here
-    }
-
-    const { exportKind, importKind } = path.node
-    const isTypeOnly = exportKind === 'type' || importKind === 'type'
-    if (isTypeOnly) {
-      return // stop here
-    }
-
-    const { value } = source
-    const module = value as string
-
-    let packageData: PackageData | null = null
-
-    if (!isLocalFile(module)) {
-      if (includePackages.some((name) => module.startsWith(name))) {
-        packageData = getPackageData(module)
-      }
-
-      if (!(packageData && packageData.hasPath)) {
-        return // stop here
-      }
-    }
-
-    const filenameExtension = extname(filename)
-    const filenameDirectory = dirname(filename)
-    const isDirectory = isLocalDirectory(resolve(filenameDirectory, module))
-
-    const currentModuleExtension = extname(module)
-    const targetModule = evaluateTargetModule({
-      module,
-      filenameDirectory,
-      filenameExtension,
-      packageData,
-      currentModuleExtension,
-      isDirectory,
-      tryExtensions,
-      esExtensions,
-      esExtensionDefault,
-      ensureFileExists,
-    })
-
-    if (targetModule === false || currentModuleExtension === targetModule.extension) {
-      return // stop here
-    }
-
-    const nodes = makeNodes(path)
-
-    path.replaceWith(
-      // @ts-ignore
-      declaration.apply(null, [...nodes, stringLiteral(targetModule.module)])
-    )
-  }
+const DEFAULT_OPTIONS = {
+  ensureFileExists: false,
+  esExtensionDefault: '.js',
+  tryExtensions: ['.js', '.mjs', '.cjs'],
+  esExtensions: ['.js', '.mjs', '.cjs'],
+  includePackages: [],
 }
 
-export default function FullySpecified(api: ConfigAPI, options: FullySpecifiedOptions) {
+export default function FullySpecified(
+  api: ConfigAPI,
+  rawOptions: FullySpecifiedOptions
+): PluginObj {
   api.assertVersion(7)
+
+  const options = { ...DEFAULT_OPTIONS, ...rawOptions }
+
+  /** For `import ... from '...'`. */
+  const importDeclarationVisitor = (
+    path: NodePath<ImportDeclaration>,
+    state: PluginPass
+  ) => {
+    const filePath = state.file.opts.filename
+    if (!filePath) return // cannot determine file path therefore cannot proceed
+
+    const { node } = path
+    if (node.importKind === 'type') return // is a type-only import, skip
+
+    const originalModuleSpecifier = node.source.value
+    const fullySpecifiedModuleSpecifier = getFullySpecifiedModuleSpecifier(
+      originalModuleSpecifier,
+      {
+        filePath,
+        options,
+      }
+    )
+
+    if (fullySpecifiedModuleSpecifier) {
+      node.source.value = fullySpecifiedModuleSpecifier
+    }
+  }
+
+  /** For `export ... from '...'`. */
+  const exportDeclarationVisitor = (
+    path: NodePath<ExportNamedDeclaration> | NodePath<ExportAllDeclaration>,
+    state: PluginPass
+  ) => {
+    const filePath = state.file.opts.filename
+    if (!filePath) return // cannot determine file path therefore cannot proceed
+
+    const { node } = path
+    if (node.exportKind === 'type') return // is a type-only export, skip
+
+    const source = node.source
+    if (!source) return // is not a re-export, skip
+
+    const originalModuleSpecifier = source.value
+    const fullySpecifiedModuleSpecifier = getFullySpecifiedModuleSpecifier(
+      originalModuleSpecifier,
+      {
+        filePath,
+        options,
+      }
+    )
+
+    if (fullySpecifiedModuleSpecifier) {
+      source.value = fullySpecifiedModuleSpecifier
+    }
+  }
+
+  /** For dynamic `import()`s. */
+  const importVisitor = (path: NodePath<Import>, state) => {
+    const filePath = state.file.opts.filename
+    if (!filePath) return // cannot determine file path therefore cannot proceed
+
+    const parent = path.parent
+    if (parent.type !== 'CallExpression') {
+      return // we expect the usage of `import` is a call to it, e.g.: `import('...')`, other usages are not supported
+    }
+
+    const firstArgOfImportCall = parent.arguments[0]
+    if (firstArgOfImportCall.type !== 'StringLiteral') {
+      return // we expect the first argument of `import` to be a string, e.g.: `import('./myModule')`, other types are not supported
+    }
+
+    const originalModuleSpecifier = firstArgOfImportCall.value
+    const fullySpecifiedModuleSpecifier = getFullySpecifiedModuleSpecifier(
+      originalModuleSpecifier,
+      {
+        filePath,
+        options,
+      }
+    )
+
+    if (fullySpecifiedModuleSpecifier) {
+      firstArgOfImportCall.value = fullySpecifiedModuleSpecifier
+    }
+  }
 
   return {
     name: 'babel-plugin-fully-specified',
     visitor: {
-      ImportDeclaration: makeDeclaration({
-        ...options,
-        declaration: importDeclaration,
-        makeNodes: ({ node: { specifiers } }) => [specifiers],
-      }),
-      ExportNamedDeclaration: makeDeclaration({
-        ...options,
-        declaration: exportNamedDeclaration,
-        makeNodes: ({ node: { declaration, specifiers } }) => [declaration, specifiers],
-      }),
-      ExportAllDeclaration: makeDeclaration({
-        ...options,
-        declaration: exportAllDeclaration,
-        makeNodes: () => [],
-      }),
+      ImportDeclaration: importDeclarationVisitor,
+      ExportNamedDeclaration: exportDeclarationVisitor,
+      ExportAllDeclaration: exportDeclarationVisitor,
+      Import: importVisitor,
     },
   }
 }
 
-function getPackageData<PackageData>(module: string) {
+/**
+ * Returns a fully specified [module specifier](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#prod-ModuleSpecifier) (or `null` if it can't be determined or shouldn't be transformed).
+ */
+function getFullySpecifiedModuleSpecifier(
+  /**
+   * The original module specifier in the code.
+   *
+   * For example, `'./foo'` for `import { foo } from './foo'`.
+   */
+  originalModuleSpecifier: string,
+  {
+    filePath,
+    options,
+  }: {
+    /**
+     * The absolute file path of the file being transformed.
+     *
+     * Normally this can be obtained from the 2nd parameter in a visitor function (often named as `state`): `state.file.opts.filename`.
+     */
+    filePath: string
+    /** Options that users pass to babel-plugin-fully-specified. */
+    options: FullySpecifiedOptions
+  }
+): string | null {
+  const fileExt = extname(filePath)
+  const fileDir = dirname(filePath)
+
+  const { includePackages } = options
+
+  let packageData: PackageImportData | null = null
+  if (!isLocalFile(originalModuleSpecifier)) {
+    if (includePackages.some((name) => originalModuleSpecifier.startsWith(name))) {
+      packageData = getPackageData(originalModuleSpecifier, filePath)
+    }
+
+    if (!(packageData && packageData.isDeepImport)) {
+      return null
+    }
+  }
+
+  const isDirectory = isLocalDirectory(resolve(fileDir, originalModuleSpecifier))
+
+  const currentModuleExtension = extname(originalModuleSpecifier)
+
+  const { tryExtensions, esExtensions, esExtensionDefault, ensureFileExists } = options
+
+  const targetModule = evaluateTargetModule({
+    moduleSpecifier: originalModuleSpecifier,
+    filenameDirectory: fileDir,
+    filenameExtension: fileExt,
+    packageData,
+    currentModuleExtension,
+    isDirectory,
+    tryExtensions,
+    esExtensions,
+    esExtensionDefault,
+    ensureFileExists,
+  })
+
+  if (targetModule === false || currentModuleExtension === targetModule.extension) {
+    return null
+  }
+
+  return targetModule.module
+}
+
+/**
+ * Data about how a package is being imported.
+ */
+type PackageImportData = {
+  /**
+   * Indicates whether the import from the package is a deep import.
+   *
+   * Example:
+   *
+   * * `import { foo } from '@org/package'` -> `isDeepImport: false`
+   * * `import { foo } from '@org/package/lib/foo'` -> `isDeepImport: true`
+   */
+  isDeepImport: boolean
+  /**
+   * The resolved absolute path of the exact file being imported. This will always be a file path (such as `<project>/node_modules/my-pkg/dist/index.js`), not just a directory path.
+   */
+  modulePath: string
+}
+
+/**
+ * Given a module specifier and the file path of the source file which imports that module, returns the package data of that module if it can be found.
+ */
+function getPackageData(
+  /** The module specifier, e.g.: `@org/package/lib/someTool`. */
+  moduleSpecifier: string,
+  /** The file path of the source file which imports that module. */
+  filePath?: string
+): PackageImportData | null {
   try {
-    const packagePath = require.resolve(module)
-    const parts = packagePath.split('/')
+    const modulePath = require.resolve(moduleSpecifier, {
+      paths: filePath ? [filePath] : [],
+    })
+    const parts = modulePath.split('/')
 
     let packageDir = ''
     for (let i = parts.length; i >= 0; i--) {
@@ -178,15 +243,15 @@ function getPackageData<PackageData>(module: string) {
 
     const packageJson = JSON.parse(readFileSync(`${packageDir}/package.json`).toString())
 
-    const hasPath = !module.endsWith(packageJson.name)
-    return { hasPath, packagePath }
+    const isDeepImport = !moduleSpecifier.endsWith(packageJson.name)
+    return { isDeepImport, modulePath }
   } catch (e) {}
 
   return null
 }
 
-function isLocalFile(module: string) {
-  return module.startsWith('.') || module.startsWith('/')
+function isLocalFile(moduleSpecifier: string) {
+  return moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('/')
 }
 
 function isLocalDirectory(absoluteDirectory: string) {
@@ -194,7 +259,7 @@ function isLocalDirectory(absoluteDirectory: string) {
 }
 
 function evaluateTargetModule({
-  module,
+  moduleSpecifier,
   currentModuleExtension,
   packageData,
   isDirectory,
@@ -206,12 +271,12 @@ function evaluateTargetModule({
   ensureFileExists,
 }) {
   if (packageData) {
-    if (packageData.packagePath.endsWith('index.js') && !module.endsWith('index.js')) {
-      module = `${module}/index`
+    if (packageData.modulePath.endsWith('index.js') && !moduleSpecifier.endsWith('index.js')) {
+      moduleSpecifier = `${moduleSpecifier}/index`
     }
 
     return {
-      module: module + esExtensionDefault,
+      module: moduleSpecifier + esExtensionDefault,
       extension: esExtensionDefault,
     }
   }
@@ -225,14 +290,14 @@ function evaluateTargetModule({
     !existsSync(
       resolve(
         filenameDirectory,
-        currentModuleExtension ? module : module + esExtensionDefault
+        currentModuleExtension ? moduleSpecifier : moduleSpecifier + esExtensionDefault
       )
     )
   ) {
-    module = `${module}/index`
+    moduleSpecifier = `${moduleSpecifier}/index`
   }
 
-  const targetFile = resolve(filenameDirectory, module)
+  const targetFile = resolve(filenameDirectory, moduleSpecifier)
 
   if (ensureFileExists) {
     // 1. try first with same extension
@@ -241,7 +306,7 @@ function evaluateTargetModule({
       existsSync(targetFile + filenameExtension)
     ) {
       return {
-        module: module + filenameExtension,
+        module: moduleSpecifier + filenameExtension,
         extension: filenameExtension,
       }
     }
@@ -249,17 +314,17 @@ function evaluateTargetModule({
     // 2. then try with all others
     for (const extension of tryExtensions) {
       if (existsSync(targetFile + extension)) {
-        return { module: module + '.mjs', extension }
+        return { module: moduleSpecifier + extension, extension }
       }
     }
   } else if (esExtensions.includes(filenameExtension)) {
     return {
-      module: module + filenameExtension,
+      module: moduleSpecifier + filenameExtension,
       extension: filenameExtension,
     }
   } else {
     return {
-      module: module + esExtensionDefault,
+      module: moduleSpecifier + esExtensionDefault,
       extension: esExtensionDefault,
     }
   }

--- a/code/packages/babel-plugin-fully-specified/types/index.d.ts
+++ b/code/packages/babel-plugin-fully-specified/types/index.d.ts
@@ -1,6 +1,13 @@
 import type { ConfigAPI, PluginObj } from '@babel/core';
 export interface FullySpecifiedOptions {
-    ensureFileExists: boolean;
+    ensureFileExists: boolean | {
+        /**
+         * If you're doing a non-in-place transformation (for example, outputting `.mjs` from `.js`) with `ensureFileExists` enabled, it's possible that the transform will be incorrect due to the imported file is not transformed and written into place yet (for example, we have `foo.js` and `bar.js` and we're transforming them into `foo.mjs` and `bar.mjs` respectively, in `bar.js` we have `import { ... } from './foo.js'` which we expect to be transformed into `import { ... } from './foo.mjs'`, but if `foo.mjs` is not transformed and written yet, it will be transformed into `import { ... } from './foo.js'` because `foo.mjs` can't be found at that time).
+         *
+         * To solve this, you can set this option to `'.mjs'` to force the extension to be transformed into that specified extension.
+         */
+        forceExtension?: string;
+    };
     esExtensionDefault: string;
     /** List of all extensions which we try to find. */
     tryExtensions: Array<string>;

--- a/code/packages/babel-plugin-fully-specified/types/index.d.ts
+++ b/code/packages/babel-plugin-fully-specified/types/index.d.ts
@@ -1,27 +1,13 @@
-import type { ConfigAPI, NodePath, PluginPass } from '@babel/core';
-import type { ImportSpecifier, ImportDeclaration, ExportAllDeclaration, StringLiteral, ExportSpecifier, ExportDeclaration, ExportNamedDeclaration } from '@babel/types';
-type ImportDeclarationFunc = (specifiers: Array<ImportSpecifier>, source: StringLiteral) => ImportDeclaration;
-type ExportNamedDeclarationFunc = (declaration?: ExportDeclaration, specifiers?: Array<ExportSpecifier>, source?: StringLiteral) => ExportNamedDeclaration;
-type ExportAllDeclarationFunc = (source: StringLiteral) => ExportAllDeclaration;
-type PathDeclaration = NodePath & {
-    node: ImportDeclaration & ExportNamedDeclaration & ExportAllDeclaration;
-};
-interface FullySpecifiedOptions {
-    declaration: ImportDeclarationFunc | ExportNamedDeclarationFunc | ExportAllDeclarationFunc;
-    makeNodes: (path: PathDeclaration) => Array<PathDeclaration>;
+import type { ConfigAPI, PluginObj } from '@babel/core';
+export interface FullySpecifiedOptions {
     ensureFileExists: boolean;
     esExtensionDefault: string;
+    /** List of all extensions which we try to find. */
     tryExtensions: Array<string>;
+    /** List of extensions that can run in Node.js or in the Browser. */
     esExtensions: Array<string>;
+    /** List of packages that also should be transformed with this plugin. */
     includePackages: Array<string>;
 }
-export default function FullySpecified(api: ConfigAPI, options: FullySpecifiedOptions): {
-    name: string;
-    visitor: {
-        ImportDeclaration: (path: PathDeclaration, { file: { opts: { filename }, }, }: PluginPass) => void;
-        ExportNamedDeclaration: (path: PathDeclaration, { file: { opts: { filename }, }, }: PluginPass) => void;
-        ExportAllDeclaration: (path: PathDeclaration, { file: { opts: { filename }, }, }: PluginPass) => void;
-    };
-};
-export {};
+export default function FullySpecified(api: ConfigAPI, rawOptions: FullySpecifiedOptions): PluginObj;
 //# sourceMappingURL=index.d.ts.map

--- a/code/packages/build/tamagui-build.js
+++ b/code/packages/build/tamagui-build.js
@@ -612,7 +612,9 @@ async function esbuildWriteIfChanged(
                   [
                     require.resolve('@tamagui/babel-plugin-fully-specified'),
                     {
-                      ensureFileExists: true,
+                      ensureFileExists: {
+                        forceExtension: '.mjs',
+                      },
                       esExtensionDefault: '.mjs',
                       tryExtensions: ['.js'],
                       esExtensions: ['.mjs'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5694,6 +5694,7 @@ __metadata:
   dependencies:
     "@babel/core": "npm:^7.23.3"
     "@babel/types": "npm:^7.23.3"
+    vitest: "npm:^0.34.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#2761 (specifically, [this commit](https://github.com/tamagui/tamagui/pull/2761/commits/ba6d76540dc67a6f9ac1ba7f06a88631ada947b4)) breaks the build because:

* `@tamagui/build` is using `babel-plugin-fully-specified` to transform `.js` into `.mjs`, with `ensureFileExists` set to `true`.
* We expect those transformed `.mjs` to also import from transformed `.mjs` files.
* But during the transformation, the file being imported might not be transformed yet, and that `.mjs` file will not exist. With `ensureFileExists`, we can only find the `.js` file at that time, so the `.js` file is used instead, which is not what we want and will break things because that `.js` file isn't a transformed one.

To prevent this, a `forceExtension` option is added for forcing the usage of a specific extension for `ensureFileExists`.