### PR TITLE
Register Switch's ID so Label can update it

### DIFF
--- a/code/ui/switch/src/createSwitch.tsx
+++ b/code/ui/switch/src/createSwitch.tsx
@@ -167,7 +167,21 @@ export function createSwitch<
         [checked, setChecked],
         forwardedRef
       )
+      
+      if (process.env.TAMAGUI_TARGET === 'native') {
+        React.useEffect(() => {
+          if (!props.id) return
+          if (props.disabled) return
 
+          return registerFocusable(props.id, {
+            focusAndSelect: () => {
+              setChecked?.((value) => !value)
+            },
+            focus: () => {},
+          })
+        }, [props.id, props.disabled])
+      }
+      
       const renderNative = shouldRenderNativePlatform(native)
       if (renderNative === 'android' || renderNative === 'ios') {
         return (

--- a/code/ui/switch/src/createSwitch.tsx
+++ b/code/ui/switch/src/createSwitch.tsx
@@ -11,6 +11,7 @@ import type {
   SwitchExtraProps as HeadlessSwitchExtraProps,
   SwitchState,
 } from '@tamagui/switch-headless'
+import { registerFocusable } from '@tamagui/focusable'
 import { useSwitch } from '@tamagui/switch-headless'
 import { useControllableState } from '@tamagui/use-controllable-state'
 import * as React from 'react'
@@ -167,7 +168,7 @@ export function createSwitch<
         [checked, setChecked],
         forwardedRef
       )
-      
+
       if (process.env.TAMAGUI_TARGET === 'native') {
         React.useEffect(() => {
           if (!props.id) return
@@ -181,7 +182,7 @@ export function createSwitch<
           })
         }, [props.id, props.disabled])
       }
-      
+
       const renderNative = shouldRenderNativePlatform(native)
       if (renderNative === 'android' || renderNative === 'ios') {
         return (


### PR DESCRIPTION
This is the same fix as for Checkbox. 
Clicking on a Label HTMLFor results in an error:
No input found for id $id

This registers the ID so the Switch can be controlled by Press on the Label.