### PR TITLE
feat(web): styled('div', ...) support

### DIFF
--- a/code/core/web/src/styled.tsx
+++ b/code/core/web/src/styled.tsx
@@ -33,6 +33,18 @@ type GetVariantAcceptedValues<V> = V extends Object
     }
   : undefined
 
+const JSXIntrinsicElementsWithClassNames = [
+  "a", "abbr", "address", "area", "article", "aside", "audio", "b", "base", "bdi", "bdo", "big", "blockquote", "body", "br", "button", "canvas", "caption", "center", "cite", "code", "col", "colgroup", "data", "datalist", "dd", "del", "details", "dfn", "dialog", "div", "dl", "dt", "em", "embed", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "head", "header", "hgroup", "hr", "html", "i", "iframe", "img", "input", "ins", "kbd", "keygen", "label", "legend", "li", "link", "main", "map", "mark", "menu", "menuitem", "meta", "meter", "nav", "noindex", "noscript", "object", "ol", "optgroup", "option", "output", "p", "param", "picture", "pre", "progress", "q", "rp", "rt", "ruby", "s", "samp", "search", "slot", "script", "section", "select", "small", "source", "span", "strong", "style", "sub", "summary", "sup", "table", "template", "tbody", "td", "textarea", "tfoot", "th", "thead", "time", "title", "tr", "track", "u", "ul", "var", "video", "wbr", "webview",
+  "svg", "animate", "animateMotion", "animateTransform", "circle", "clipPath", "defs", "desc", "ellipse", "feBlend", "feColorMatrix", "feComponentTransfer", "feComposite", "feConvolveMatrix", "feDiffuseLighting", "feDisplacementMap", "feDistantLight", "feDropShadow", "feFlood", "feFuncA", "feFuncB", "feFuncG", "feFuncR", "feGaussianBlur", "feImage", "feMerge", "feMergeNode", "feMorphology", "feOffset", "fePointLight", "feSpecularLighting", "feSpotLight", "feTile", "feTurbulence", "filter", "foreignObject", "g", "image", "line", "linearGradient", "marker", "mask", "metadata", "mpath", "path", "pattern", "polygon", "polyline", "radialGradient", "rect", "set", "stop", "switch", "symbol", "text", "textPath", "tspan", "use", "view",
+] as const;
+
+// verify JSXIntrinsicElementsWithClassNames is correct:
+// type JSXIntrinsicElementsWithClassNamsUnion = { [K in keyof JSX.IntrinsicElements]-?: JSX.IntrinsicElements[K] extends {className?: string} ? K : never }[keyof JSX.IntrinsicElements];
+// function assert<T extends never>() {}
+// type TypeEqualityGuard<A,B> = Exclude<A,B> | Exclude<B,A>;
+// assert<TypeEqualityGuard<typeof JSXIntrinsicElementsWithClassNames[number], JSXIntrinsicElementsWithClassNamsUnion>>()
+
+
 export function styled<
   ParentComponent extends StylableComponent,
   StyledStaticConfig extends StaticConfigPublic,
@@ -182,6 +194,7 @@ export function styled<
       const acceptsClassName =
         acceptsClassNameProp ??
         (isPlainStyledComponent ||
+          (typeof ComponentIn === 'string' && JSXIntrinsicElementsWithClassNames.includes(ComponentIn)) ||
           isReactNative ||
           (parentStaticConfig?.isHOC && parentStaticConfig?.acceptsClassName))
 

--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -1815,6 +1815,8 @@ export type TamaguiComponent<
     __tama: [Props, Ref, NonStyledProps, BaseStyles, Variants, ParentStaticProperties]
   }
 
+type JSXIntrinsicElements = keyof JSX.IntrinsicElements
+
 export type InferGenericComponentProps<A> = A extends ComponentType<infer Props>
   ? Props
   : A extends ForwardRefExoticComponent<infer P>
@@ -1825,7 +1827,7 @@ export type InferGenericComponentProps<A> = A extends ComponentType<infer Props>
             props: infer Props
           ) => any
         ? Props
-        : {}
+        : A extends keyof JSX.IntrinsicElements ? JSX.IntrinsicElements[A] : {}
 
 export type InferStyledProps<
   A extends StylableComponent,
@@ -2084,6 +2086,7 @@ export type StylableComponent =
   | (new (
       props: any
     ) => any)
+  | JSXIntrinsicElements
 
 export type SpreadKeys =
   | '...fontSize'


### PR DESCRIPTION
Changes:
- treats `keyof JSX.IntrinsicElements` (aka "div" and co as)  StylableComponent
- sets acceptsClassName for intrinsic elements that supports classNames
- implement GetNonStyledProps for `JSX.IntrinsicElements` to return correct props for intrinsic elements (aka "div")

See:
https://react.dev/reference/react-dom/components#custom-html-elements