### PR TITLE
patch h3 for vxrn

### DIFF
--- a/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch
+++ b/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index 03b54b97a520ff093a34428ca2e3976b29cb2fa7..f4fa712a2f59a6e745481f32ffd4fee95f15b09e 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1229,6 +1229,13 @@ function getProxyRequestHeaders(event) {
+       headers[name] = reqHeaders[name];
+     }
+   }
++
++  // vxrn's expoManifestRequestHandlerPlugin (Vite plugin) needs the original request host so that it can compose URLs that can be accessed by physical devices. This won't be needed once vxrn retires the h3 proxy and use Vite Dev Server directly.
++  const originalHost = reqHeaders.host;
++  if (originalHost) {
++    headers['X-Forwarded-Host'] = originalHost;
++  }
++
+   return headers;
+ }
+ function fetchWithEvent(event, req, init, options) {

--- a/code/takeout/package.json
+++ b/code/takeout/package.json
@@ -43,7 +43,7 @@
   "devDependencies": {
     "@tamagui/cli": "1.104.2",
     "esbuild-register": "^3.5.0",
-    "h3": "^1.11.1",
+    "h3": "patch:h3@npm%3A1.11.1#~/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch",
     "patch-package": "^8.0.0",
     "supabase": "1.127.4",
     "vxrn": "^1.1.150"

--- a/code/tamagui.dev/package.json
+++ b/code/tamagui.dev/package.json
@@ -60,7 +60,7 @@
     "acorn-walk": "^8.3.1",
     "archiver": "^7.0.1",
     "esbuild-register": "^3.5.0",
-    "h3": "^1.11.1",
+    "h3": "patch:h3@npm%3A1.11.1#~/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch",
     "mdx-bundler": "^10.0.2",
     "patch-package": "^8.0.0",
     "supabase": "1.127.4",

--- a/package.json
+++ b/package.json
@@ -177,5 +177,8 @@
     "ultra-runner": "^3.10.5",
     "update-ts-references": "^3.3.0",
     "zx": "^7.2.3"
+  },
+  "resolutions": {
+    "h3@npm:^1.11.1": "patch:h3@npm%3A1.11.1#~/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6271,7 +6271,7 @@ __metadata:
     archiver: "npm:^7.0.1"
     color2k: "npm:^2.0.2"
     esbuild-register: "npm:^3.5.0"
-    h3: "npm:^1.11.1"
+    h3: "patch:h3@npm%3A1.11.1#~/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch"
     hsluv: "npm:^0.1.0"
     jsonwebtoken: "npm:^9.0.2"
     mdx-bundler: "npm:^10.0.2"
@@ -7490,7 +7490,7 @@ __metadata:
     esbuild-register: "npm:^3.5.0"
     expo-apple-authentication: "npm:~6.4.1"
     expo-crypto: "npm:~13.0.2"
-    h3: "npm:^1.11.1"
+    h3: "patch:h3@npm%3A1.11.1#~/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch"
     jsonwebtoken: "npm:^9.0.2"
     patch-package: "npm:^8.0.0"
     postmark: "npm:^3.0.18"
@@ -16400,7 +16400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"h3@npm:^1.10.2, h3@npm:^1.11.1":
+"h3@npm:1.11.1, h3@npm:^1.10.2":
   version: 1.11.1
   resolution: "h3@npm:1.11.1"
   dependencies:
@@ -16415,6 +16415,24 @@ __metadata:
     uncrypto: "npm:^0.1.3"
     unenv: "npm:^1.9.0"
   checksum: 10/dcc5104353fbb1b4462f4197f9e5348c3cda09ce5f86deafad4143becfd61f788490d34e4fc22fc2d296f8e5269abd1b475fb1b8a32cf140ec632c0791f06c1c
+  languageName: node
+  linkType: hard
+
+"h3@patch:h3@npm%3A1.11.1#~/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch":
+  version: 1.11.1
+  resolution: "h3@patch:h3@npm%3A1.11.1#~/.yarn/patches/h3-npm-1.11.1-e4c2aa03b9.patch::version=1.11.1&hash=43696d"
+  dependencies:
+    cookie-es: "npm:^1.0.0"
+    crossws: "npm:^0.2.2"
+    defu: "npm:^6.1.4"
+    destr: "npm:^2.0.3"
+    iron-webcrypto: "npm:^1.0.0"
+    ohash: "npm:^1.1.3"
+    radix3: "npm:^1.1.0"
+    ufo: "npm:^1.4.0"
+    uncrypto: "npm:^0.1.3"
+    unenv: "npm:^1.9.0"
+  checksum: 10/e5c287479e184eee0c74a666ebcf7bb8e9cf297d2032d20a8a62419c7c924987b136e1e2ebd17837cb813e058074054ad72d8165c0c4885f40d4d14ccc92b9ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use [`yarn patch`](https://yarnpkg.com/features/patching) to patch h3 since the patches in takeout will not be applied in this yarn workspaces monorepo.