### PR TITLE
fix(web): avoid classes if acceptsClassName is not set

### DIFF
--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -299,7 +299,7 @@ export const useComponentState = (
     const isDisabledManually =
       disableClassName && !isServer && didHydrateOnce && state.unmounted === true
 
-    if (isAnimatedAndHydrated || isDisabledManually) {
+    if (isAnimatedAndHydrated || isDisabledManually || !staticConfig.acceptsClassName) {
       shouldAvoidClasses = true
 
       // debug
@@ -309,6 +309,7 @@ export const useComponentState = (
           {
             isAnimatedAndHydrated,
             isDisabledManually,
+            acceptsClassName: staticConfig.acceptsClassName
           },
           {
             isAnimated,


### PR DESCRIPTION
Fixes: #2773 

Before refactor:

https://github.com/tamagui/tamagui/blob/148e67ac5976110e9a405318a1db5265878ec69c/packages/web/src/createComponent.tsx#L287-L296

We now missing the !staticConfig.acceptsClassName.

This pr attempts to restore that condition

Used this component to verify that works on sandbox:

```tsx
function MyComponent({ style, onMouseEnter, onMouseLeave }) {
  console.log(" => style", style, onMouseEnter, onMouseLeave);
  return (
    <div
      style={{ width: 20, height: 20, ...style }}
      onMouseEnter={onMouseEnter}
      onMouseLeave={onMouseLeave}
    ></div>
  );
}

const MyStyledComponent = styled(MyComponent, {
  name: "MyStyledComponent",

  backgroundColor: "red",
  hoverStyle: {
    backgroundColor: "blue",
  },
});

export default function StyledHTMLTags() {
  return (<MyStyledComponent debug={"verbose"} />);
}
```