### PR TITLE
fix(core): `rulesToInsert` can be undefined on native

### DIFF
--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -1346,7 +1346,7 @@ export function createComponent<
     }
 
     // add in <style> tags inline
-    if (process.env.TAMAGUI_REACT_19) {
+    if (process.env.TAMAGUI_REACT_19 && process.env.TAMAGUI_TARGET !== 'native') {
       const { rulesToInsert } = splitStyles
       const keys = Object.keys(splitStyles.rulesToInsert)
       if (keys.length) {


### PR DESCRIPTION
in `code/core/web/src/helpers/getSplitStyles.tsx:170`, we have:

```ts
  const rulesToInsert: RulesToInsert =
    process.env.TAMAGUI_TARGET === 'native' ? (undefined as any) : {}
```

So, on native, `const keys = Object.keys(splitStyles.rulesToInsert)` will cause error `Cannot convert undefined value to object`.

I think this might be a fix for that.