### PR TITLE
feat(animations-moti): added font related styles to animateOnlyKeys

### DIFF
--- a/code/core/animations-moti/src/createAnimations.tsx
+++ b/code/core/animations-moti/src/createAnimations.tsx
@@ -69,6 +69,10 @@ const onlyAnimateKeys: { [key in keyof TextStyle | keyof CSSProperties]?: boolea
   right: true,
   top: true,
   bottom: true,
+  fontSize: true,
+  fontWeight: true,
+  lineHeight: true,
+  letterSpacing: true
 }
 
 export function createAnimations<A extends Record<string, TransitionConfig>>(


### PR DESCRIPTION
This PR added possibility to specify and apply animations for `font` related styles with Moti animations driver.