### PR TITLE
doc: configuration.mdx/defaultProps - add deprecated note

### DIFF
--- a/code/tamagui.dev/data/docs/core/configuration.mdx
+++ b/code/tamagui.dev/data/docs/core/configuration.mdx
@@ -235,10 +235,7 @@ The `createTamagui` function receives a configuration object:
 - `media`: Define reusable responsive [media queries](/docs/core/use-media).
 - `shorthands`: Define any props you want to expand to style values, keys being
   the shorthand and values being the expanded style prop.
-- `defaultProps`: For more advanced uses, you can override all named `styled()`
-  components initial values. These merge downwards, so
-  `styled(Text, { name: 'Paragraph' })` will get any defaultProps set for
-  `Text`.
+- `defaultProps`: Deprecated, use styled() on any component to change it's styles. ~~For more advanced uses, you can override all named `styled()` components initial values.~~ 
 - `onlyAllowShorthands`: When set to true will ensure that if you define
   shorthands, they override existing long-form style props.
 


### PR DESCRIPTION
defaultProps in config, seems to be broken and deprecated in config code example, above so document it here as well

https://codesandbox.io/p/sandbox/old-bash-fyt776?file=%2Fsrc%2FApp.tsx%3A40%2C4