### PR TITLE
Fix the accordion losing height

### DIFF
--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -584,12 +584,6 @@ const HeightAnimator = View.styleable((props, ref) => {
   const { children, ...rest } = props
   const [height, setHeight] = React.useState(0)
 
-  React.useEffect(() => {
-    if (!itemContext.open) {
-      setHeight(0)
-    }
-  }, [itemContext.open])
-
   const onLayout = useEvent(({ nativeEvent }) => {
     if (nativeEvent.layout.height) {
       setHeight(nativeEvent.layout.height)
@@ -597,7 +591,7 @@ const HeightAnimator = View.styleable((props, ref) => {
   })
 
   return (
-    <View ref={ref} height={height} {...rest}>
+    <View ref={ref} height={itemContext.open ? height : 0} {...rest}>
       <View
         position="absolute"
         //@ts-ignore


### PR DESCRIPTION
As reported on Discord (https://discord.com/channels/909986013848412191/909986013848412194/1242282248754040883) and in our own experience, tapping the Accordion rapidly causes the content to be rendered, but the height to not expand correctly.

An inspection of the code seemed to show that the laid out height of the children was being overridden by the dynamic 'open' height, causing the state to be lost after toggling.

This fixes it to make the height state only contain the laid out height, leaving the animation 'open' height as a purely derived value.