### PR TITLE
fix: external link error

### DIFF
--- a/code/tamagui.dev/data/docs/guides/create-tamagui-app.mdx
+++ b/code/tamagui.dev/data/docs/guides/create-tamagui-app.mdx
@@ -24,7 +24,7 @@ npm create tamagui@latest
 ```
 
 Check out
-[the source of the templates](https://github.com/tamagui/tamagui/tree/master/starters).
+[the source of the templates](https://github.com/tamagui/starter-free).
 
 A big shout out to [Fernando Rojo](https://twitter.com/fernandotherojo) for
 creating [Solito](https://solito.dev), a great library for sharing all your


### PR DESCRIPTION
When I try to access `npm create tamagui@latest` *Check out the source of the templates* , get a 404 error occurred. I believe the new template link should be this one.