### PR TITLE
docs: add unmountChildrenWhenHidden in props table

### DIFF
--- a/code/tamagui.dev/data/docs/components/sheet/1.59.0.mdx
+++ b/code/tamagui.dev/data/docs/components/sheet/1.59.0.mdx
@@ -282,6 +282,13 @@ Contains every component for the sheet.
       description:
         'Native-only flag that will make the sheet move up when the mobile keyboard opens so the focused input remains visible.',
     },
+      {
+      name: 'unmountChildrenWhenHidden',
+      type: 'boolean',
+      default: 'false',
+      description:
+        'Flag to enable unmounting the children after the exit animation has completed.',
+    },
   ]}
 />
 


### PR DESCRIPTION
would like to close #2836 

Let me tell you this, the bento portion of this monorepo is very difficult to deal with as an external contributor. Both for this and for the kitchen-sink I had to manually go and remove every references to bento within the code to be able to start the projects. I tried to find info on how to effectively deal with it while contributing but didn't find anything useful.

Also the contributing documentation is sparse, sometimes vague and currently very little maintained.
If there is a true will into enabling external contributors, there is some work to do (more info down below).

Is it ok to manually edit the last version of the sheet's mdx file or should I generate a new one containing the latest version of tamagui with some command?


_Examples:_ 

1. I tried to follow this anchor from the [CONTRIBUTING.md](https://github.com/tamagui/tamagui/blob/master/CONTRIBUTING.md#documentation-contributions) but it leads nowhere
2. In the contributing section of the [root's README](https://github.com/tamagui/tamagui?tab=readme-ov-file#contributing) this link leads to a 404
3. There is no README in the tamagui.dev package.
4. In the CONTRIBUTING.md file the `yarn site` commands are still not updated to the new next-site (but I don't know anything about it).
