### PR TITLE
chore(expo-router): Update @tamagui/metro-plugin version

### DIFF
--- a/code/starters/expo-router/package.json
+++ b/code/starters/expo-router/package.json
@@ -44,7 +44,7 @@
     "@expo/metro-config": "~0.18.4",
     "@expo/metro-runtime": "~3.2.1",
     "@tamagui/babel-plugin": "^1.108.3",
-    "@tamagui/metro-plugin": "1.108.2",
+    "@tamagui/metro-plugin": "1.108.3",
     "@types/react": "~18.2.79",
     "@types/react-native": "^0.73.0",
     "typescript": "^5.5.2"


### PR DESCRIPTION
- Updated @tamagui/metro-plugin from version 1.108.2 to 1.108.3 in package.json

Implementation reason: This update ensures compatibility with the latest features and bug fixes provided by the @tamagui/metro-plugin, improving the overall stability and performance of the project.