### PR TITLE
add "packageManager" field in package.json for corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
       "parser": "typescript"
     }
   },
+  "packageManager": "yarn@4.4.0",
   "dependencies": {
     "@biomejs/biome": "^1.8.3",
     "@manypkg/cli": "^0.19.1",


### PR DESCRIPTION
For developers with [Corepack](https://nodejs.org/docs/latest-v20.x/api/corepack.html) enabled, the `"packageManager"` field in `package.json` will be used by Corepack to automatically determine which version of the package manager should be used for the current project.

https://nodejs.org/docs/latest-v20.x/api/packages.html#packagemanager

## Background

When developers with Corepack enabled run the `yarn` command, the `"packageManager"` field in the root `package.json` will be automatically added with the following message shown:

```
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager

1.22.22
```

...while this might not be ideal since it'll make the git working tree dirty.

The correct `yarn` version may still be used since in the project's `.yarnrc.yml` there's the [`yarnPath`](https://yarnpkg.com/configuration/yarnrc#yarnPath) setting pointing to a yarn 4.4.0 version, but they (yarn) have stated that "The yarnPath setting used to be the preferred way to install Yarn within a project, but we now recommend to use Corepack in most cases."