### PR TITLE
fix: allow custom color type for input

### DIFF
--- a/code/ui/input/src/types.ts
+++ b/code/ui/input/src/types.ts
@@ -1,4 +1,4 @@
-import type { ColorTokens, StackProps, TamaguiComponentPropsBase } from '@tamagui/web'
+import type { ColorTokens, StackProps, TamaguiComponentPropsBase, TextProps } from '@tamagui/web'
 import type { TextInputProps, InputModeOptions } from 'react-native'
 
 type DetailedInputProps = React.DetailedHTMLProps<
@@ -11,7 +11,8 @@ export type InputProps = StackProps &
     DetailedInputProps,
     'className' | 'children' | 'value' | 'size' | keyof StackProps
   > &
-  DetailedInputProps['style'] &
+  Pick<TextProps, 'color'> &
+  Omit<DetailedInputProps['style'], 'color'> &
   Omit<
     TextInputProps,
     | 'inputMode'


### PR DESCRIPTION
I had issue setting the color of the Input component exported from `@tamagui/input`.
The typing for the color prop comes from `DetailedInputProps['style']` which is the basic HTML color type. It's not completely true since it accepts custom theme values coming from tamagui. 

What I've done is simply exclude the color property from `DetailedInputProps['style']` to use the one coming from `TextProps` from `@tamagui/web`.