### PR TITLE
fix: design system doc links

### DIFF
--- a/code/tamagui.dev/data/docs/guides/design-systems.mdx
+++ b/code/tamagui.dev/data/docs/guides/design-systems.mdx
@@ -6,9 +6,9 @@ description: Put together your own design system.
 To skip to some real examples:
 
 - `create-tamagui` is itself a
-  [well structured monorepo](https://github.com/tamagui/tamagui/tree/master/starters).
+  [well structured monorepo](https://github.com/tamagui/tamagui/tree/master/code/starters).
 - More complete, the
-  [tamagui](https://github.com/tamagui/tamagui/tree/master/packages/tamagui)
+  [tamagui](https://github.com/tamagui/tamagui/tree/master/code/ui/tamagui)
   package itself.
 
 Tamagui allows you to build our your own set of components that are optimized


### PR DESCRIPTION
Actually the links on design system documentation page are pointing to a invalid address on repo.

How to reproduce:

- Access https://tamagui.dev/docs/guides/design-systems
- Click on "create-tamagui is itself a well structured monorepo." or "More complete, the tamagui package itself." line.

