### PR TITLE
Pass props to inner View of Accordion.HeightAnimator

### DIFF
--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -8,7 +8,7 @@ import type { H3 } from '@tamagui/text'
 import { H1 } from '@tamagui/text'
 import { useControllableState } from '@tamagui/use-controllable-state'
 import { useDirection } from '@tamagui/use-direction'
-import type { GetProps, GetRef, Stack, TamaguiElement } from '@tamagui/web'
+import type { GetProps, GetRef, Stack, TamaguiElement, ViewProps } from '@tamagui/web'
 import { View, useEvent } from '@tamagui/web'
 import { createStyledContext, styled } from '@tamagui/web'
 import * as React from 'react'
@@ -579,7 +579,7 @@ const AccordionContent = AccordionContentFrame.styleable(function AccordionConte
   )
 })
 
-const HeightAnimator = View.styleable((props, ref) => {
+const HeightAnimator = View.styleable<{ innerViewProps?: ViewProps }>(({ innerViewProps = {}, ...props}, ref) => {
   const itemContext = useAccordionItemContext()
   const { children, ...rest } = props
   const [height, setHeight] = React.useState(0)
@@ -599,6 +599,7 @@ const HeightAnimator = View.styleable((props, ref) => {
   return (
     <View ref={ref} height={height} {...rest}>
       <View
+        {...innerViewProps}
         position="absolute"
         //@ts-ignore
         onLayout={onLayout}


### PR DESCRIPTION
I'm using the `Accordion` component and found that I need to style the inner `View` for the `HeightAnimator`, as its position is `absolute`.

This PR primarily serves as a proposal for one way to do it. I'd be happy to adapt this as directed or for another approach to be implemented. Let me know how I can help!

Thanks again! ❤️