### PR TITLE
fix(bento-get): Correct event listener cleanup for token changes and npx

### DIFF
--- a/code/packages/bento-get/src/app/AuthGuard.tsx
+++ b/code/packages/bento-get/src/app/AuthGuard.tsx
@@ -1,15 +1,15 @@
+import React from 'react'
 import { Alert } from '@inkjs/ui'
 import { Box } from 'ink'
 import { useNavigate } from 'react-router-dom'
 import { useInstallComponent } from '../hooks/useInstallComponent.js'
 import { debugLog } from '../commands/index.js'
-import { useEffect } from 'react'
 
 export const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const navigate = useNavigate()
   const { error } = useInstallComponent()
 
-  useEffect(() => {
+  React.useEffect(() => {
     debugLog({
       errorStatus: error?.status,
       useInstallComponentError: error,

--- a/code/packages/bento-get/src/cli-components/SearchBar.tsx
+++ b/code/packages/bento-get/src/cli-components/SearchBar.tsx
@@ -1,7 +1,7 @@
 import Fuse from 'fuse.js'
 import { Box, Text } from 'ink'
 import TextInput from 'ink-text-input'
-import React, { useEffect } from 'react'
+import React from 'react'
 import { useLocation } from 'react-router-dom'
 
 import { ResultsCounter } from '../cli-components/index.js'
@@ -20,7 +20,7 @@ export const SearchBar = () => {
     return fuse.search(query)
   }
 
-  useEffect(() => {
+  React.useEffect(() => {
     // When navigation location changes, reset search Input
     appContext.setSearchInput('')
   }, [location.pathname])

--- a/code/packages/bento-get/src/commands/index.tsx
+++ b/code/packages/bento-get/src/commands/index.tsx
@@ -1,5 +1,5 @@
+import React from 'react'
 import { useApp, useInput } from 'ink'
-import { useMemo, useState } from 'react'
 import {
   MemoryRouter,
   Navigate,
@@ -28,22 +28,24 @@ export const debugLog = (...args: any[]) => {
 function BentoGet() {
   const navigate = useNavigate()
   const location = useLocation()
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
-  const [searchResults, setSearchResults] = useState<Array<{ item: ComponentSchema }>>([])
-  const [selectedResultIndex, setSelectedResultIndex] = useState(-1)
-  const [searchInput, setSearchInput] = useState('')
-  const [confirmationPending, setConfirmationPending] = useState(true)
-  const [installState, setInstallState] = useState<InstallState>({
+  const [isLoggedIn, setIsLoggedIn] = React.useState(false)
+  const [searchResults, setSearchResults] = React.useState<
+    Array<{ item: ComponentSchema }>
+  >([])
+  const [selectedResultIndex, setSelectedResultIndex] = React.useState(-1)
+  const [searchInput, setSearchInput] = React.useState('')
+  const [confirmationPending, setConfirmationPending] = React.useState(true)
+  const [installState, setInstallState] = React.useState<InstallState>({
     installingComponent: null,
     installedComponents: [],
     shouldOpenBrowser: false,
     isTokenInstalled: false,
     componentToInstall: null,
   })
-  const [isCopyingToClipboard, setCopyingToClipboard] = useState(false)
+  const [isCopyingToClipboard, setCopyingToClipboard] = React.useState(false)
   const { exit } = useApp()
 
-  const appContextValues = useMemo(
+  const appContextValues = React.useMemo(
     () => ({
       tokenStore,
       isCopyingToClipboard,

--- a/code/packages/bento-get/src/hooks/useInstallComponent.tsx
+++ b/code/packages/bento-get/src/hooks/useInstallComponent.tsx
@@ -1,7 +1,6 @@
+import React from 'react'
 import { existsSync, promises as fsPromises, mkdirSync } from 'node:fs'
 import path from 'node:path'
-
-import React from 'react'
 
 import { AppContext } from '../data/AppContext.js'
 import type { InstallState } from '../data/AppContext.js'

--- a/code/packages/bento-get/src/screens/CodeAuthScreen.tsx
+++ b/code/packages/bento-get/src/screens/CodeAuthScreen.tsx
@@ -20,12 +20,18 @@ export const CodeAuthScreen = () => {
     }
   }, [])
 
-  appContext.tokenStore.onDidChange('token', () => {
-    appContext.setInstallState((prev) => ({
-      ...prev,
-      isTokenInstalled: true,
-    }))
-  })
+  React.useEffect(() => {
+    const unsubscribe = appContext.tokenStore.onDidChange('token', () => {
+      appContext.setInstallState((prev) => ({
+        ...prev,
+        isTokenInstalled: true,
+      }))
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [appContext.tokenStore, appContext.setInstallState])
 
   React.useEffect(() => {
     if (appContext.isCopyingToClipboard) {

--- a/code/packages/bento-get/types/app/AuthGuard.d.ts
+++ b/code/packages/bento-get/types/app/AuthGuard.d.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 export declare const AuthGuard: ({ children }: {
     children: React.ReactNode;
 }) => import("react/jsx-runtime").JSX.Element;


### PR DESCRIPTION
- Updated the token change listener in CodeAuthScreen to properly unsubscribe when the component unmounts
- Wrapped the listener in a useEffect hook to ensure proper lifecycle management
- move useEffect back to React.useEffect for `npx`

Implementation reason: The fix addresses a potential memory leak by ensuring that the event listener is properly removed when the component is unmounted. This change improves the overall performance and stability of the application.

Users using `npx bento-get` instead of `yarn dlx bento-get` were getting import errors in production build.
