### PR TITLE
fix: use default font from tamagui config, if provided, before using '$body'

### DIFF
--- a/code/core/font-size/src/getFontSize.ts
+++ b/code/core/font-size/src/getFontSize.ts
@@ -1,17 +1,16 @@
 import type { FontSizeTokens, FontTokens, TamaguiInternalConfig } from '@tamagui/core'
 import { getConfig, isVariable } from '@tamagui/core'
+import { getSetting } from "@tamagui/web/types/config"
 
 type GetFontSizeOpts = {
   relativeSize?: number
   font?: FontTokens
 }
 
-const getFontKey = (conf: TamaguiInternalConfig, opts?: GetFontSizeOpts) => {
+const getFontKey = (opts?: GetFontSizeOpts) => {
   const FALLBACK_FONT_KEY = '$body'
 
-  const tokenizedDefaultFont = conf.settings?.defaultFont ? `$${conf.settings.defaultFont}` : undefined;
-
-  return opts?.font || tokenizedDefaultFont || FALLBACK_FONT_KEY
+  return opts?.font || getSetting("defaultFont") ? `$${getSetting("defaultFont")}` : undefined || FALLBACK_FONT_KEY
 }
 
 export const getFontSize = (
@@ -34,7 +33,7 @@ export const getFontSizeVariable = (
     return inSize
   }
   const conf = getConfig()
-  return conf.fontsParsed[getFontKey(conf, opts)].size[token]
+  return conf.fontsParsed[getFontKey(opts)].size[token]
 }
 
 export const getFontSizeToken = (
@@ -47,7 +46,7 @@ export const getFontSizeToken = (
   // backwards compat
   const relativeSize = opts?.relativeSize || 0
   const conf = getConfig()
-  const fontSize = conf.fontsParsed[getFontKey(conf, opts)].size
+  const fontSize = conf.fontsParsed[getFontKey(opts)].size
   const size =
     (inSize === '$true' && !('$true' in fontSize) ? '$4' : inSize) ??
     ('$true' in fontSize ? '$true' : '$4')

--- a/code/core/font-size/src/getFontSize.ts
+++ b/code/core/font-size/src/getFontSize.ts
@@ -7,9 +7,9 @@ type GetFontSizeOpts = {
   font?: FontTokens
 }
 
-const getFontKey = (opts?: GetFontSizeOpts) => {
-  const FALLBACK_FONT_KEY = '$body'
+const FALLBACK_FONT_KEY = '$body'
 
+const getFontKey = (opts?: GetFontSizeOpts) => {
   return opts?.font || getSetting("defaultFont") ? `$${getSetting("defaultFont")}` : undefined || FALLBACK_FONT_KEY
 }
 

--- a/code/core/font-size/src/getFontSize.ts
+++ b/code/core/font-size/src/getFontSize.ts
@@ -9,7 +9,9 @@ type GetFontSizeOpts = {
 const getFontKey = (conf: TamaguiInternalConfig, opts?: GetFontSizeOpts) => {
   const FALLBACK_FONT_KEY = '$body'
 
-  return opts?.font || conf.settings?.defaultFont || FALLBACK_FONT_KEY
+  const tokenizedDefaultFont = conf.settings?.defaultFont ? `$${conf.settings.defaultFont}` : undefined;
+
+  return opts?.font || tokenizedDefaultFont || FALLBACK_FONT_KEY
 }
 
 export const getFontSize = (

--- a/code/core/font-size/src/getFontSize.ts
+++ b/code/core/font-size/src/getFontSize.ts
@@ -1,9 +1,15 @@
-import type { FontSizeTokens, FontTokens } from '@tamagui/core'
+import type { FontSizeTokens, FontTokens, TamaguiInternalConfig } from '@tamagui/core'
 import { getConfig, isVariable } from '@tamagui/core'
 
 type GetFontSizeOpts = {
   relativeSize?: number
   font?: FontTokens
+}
+
+const getFontKey = (conf: TamaguiInternalConfig, opts?: GetFontSizeOpts) => {
+  const FALLBACK_FONT_KEY = '$body'
+
+  return opts?.font || conf.settings?.defaultFont || FALLBACK_FONT_KEY
 }
 
 export const getFontSize = (
@@ -26,7 +32,7 @@ export const getFontSizeVariable = (
     return inSize
   }
   const conf = getConfig()
-  return conf.fontsParsed[opts?.font || '$body'].size[token]
+  return conf.fontsParsed[getFontKey(conf, opts)].size[token]
 }
 
 export const getFontSizeToken = (
@@ -39,7 +45,7 @@ export const getFontSizeToken = (
   // backwards compat
   const relativeSize = opts?.relativeSize || 0
   const conf = getConfig()
-  const fontSize = conf.fontsParsed[opts?.font || '$body'].size
+  const fontSize = conf.fontsParsed[getFontKey(conf, opts)].size
   const size =
     (inSize === '$true' && !('$true' in fontSize) ? '$4' : inSize) ??
     ('$true' in fontSize ? '$true' : '$4')

--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -418,7 +418,7 @@ export const getTokenForKey = (
         case 'lineHeight':
         case 'letterSpacing':
         case 'fontWeight': {
-          const defaultFont = conf.defaultFont || conf.settings?.defaultFont || '$body'
+          const defaultFont = conf.defaultFont || (conf.settings?.defaultFont ? `$${conf.settings.defaultFont}` : undefined) || '$body'
           const fam = fontFamily || defaultFont
           if (fam) {
             const fontsParsed = context?.language

--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -2,7 +2,6 @@ import { isAndroid } from '@tamagui/constants'
 import { tokenCategories } from '@tamagui/helpers'
 
 import { getConfig, getSetting } from '../config'
-import { isDevTools } from '../constants/isDevTools'
 import type { Variable } from '../createVariable'
 import { getVariableValue, isVariable } from '../createVariable'
 import type {

--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -1,7 +1,7 @@
 import { isAndroid } from '@tamagui/constants'
 import { tokenCategories } from '@tamagui/helpers'
 
-import { getConfig } from '../config'
+import { getConfig, getSetting } from '../config'
 import { isDevTools } from '../constants/isDevTools'
 import type { Variable } from '../createVariable'
 import { getVariableValue, isVariable } from '../createVariable'
@@ -418,7 +418,7 @@ export const getTokenForKey = (
         case 'lineHeight':
         case 'letterSpacing':
         case 'fontWeight': {
-          const defaultFont = conf.defaultFont || (conf.settings?.defaultFont ? `$${conf.settings.defaultFont}` : undefined) || '$body'
+          const defaultFont = conf.defaultFont || (getSetting("defaultFont") ? `$${getSetting("defaultFont")}` : undefined) || '$body'
           const fam = fontFamily || defaultFont
           if (fam) {
             const fontsParsed = context?.language

--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -418,7 +418,7 @@ export const getTokenForKey = (
         case 'lineHeight':
         case 'letterSpacing':
         case 'fontWeight': {
-          const defaultFont = conf.defaultFont || '$body'
+          const defaultFont = conf.defaultFont || conf.settings?.defaultFont || '$body'
           const fam = fontFamily || defaultFont
           if (fam) {
             const fontsParsed = context?.language


### PR DESCRIPTION
## Current Behavior

Currently, if you don't use the `body` key in `fonts` passed into `createTamagui`, and then try to use `Button` from `tamagui` without setting its `fontFamily` prop, `tamagui` will throw an error:

```
TypeError: Cannot read property 'size' of undefined
```

This is because `getFontSizeVariable` and `getFontSizeToken` fallback to using `'$body'` if no `font` prop is provided (in this case, it would be via `Button`'s `fontFamily` prop).

## Expected Behavior

The `config.settings.defaultFont` value, if present, is used as a default fallback value when using `Button` from `tamagui`.

## Platform (Web, iOS, Android)

iOS, Android

## Tamagui Version
1.108.4

## Example

```
// tamaguiConfig.ts

import { createTamagui } from 'tamagui';

const tamaguiConfig = createTamagui({
  ...
  fonts: {
    primary: returnOfCreateFont
  },
  settings: {
    ...,
    defaultFont: 'primary',
  },
});

type TamaguiConfig = typeof tamaguiConfig;

declare module 'tamagui' {
  // overrides TamaguiCustomConfig so your custom types
  // work everywhere you import `tamagui`

  // eslint-disable-next-line @typescript-eslint/no-empty-interface
  interface TamaguiCustomConfig extends TamaguiConfig {}
}

export default tamaguiConfig;
```

```
// MyButton.tsx

import { Button } from 'tamagui';

const MyButton = ({ children, ...props }: MyButtonProps) => (
  <Button {...props}>{children}</Button>
);
```