### PR TITLE
fix(ui): change cursor default to inherit in ListItemText

### DIFF
--- a/code/ui/list-item/src/ListItem.tsx
+++ b/code/ui/list-item/src/ListItem.tsx
@@ -79,6 +79,7 @@ export const ListItemFrame = styled(ThemeableStack, {
         overflow: 'hidden',
         flexDirection: 'row',
         backgroundColor: '$background',
+        cursor: 'default',
       },
     },
 
@@ -127,7 +128,7 @@ export const ListItemText = styled(SizableText, {
         flexGrow: 1,
         flexShrink: 1,
         ellipse: true,
-        cursor: 'default',
+        cursor: 'inherit',
       },
     },
   } as const,


### PR DESCRIPTION
The Text components inside the ListItem were previously set to cursor: default, causing an issue where even if the ListItem had cursor: pointer, the cursor would still display as default. This behavior prevented the intended cursor style from being inherited from the parent.

To resolve this, I’ve changed cursor: default to cursor: inherit in ListItemText, allowing the Text components to inherit the cursor style from their parent elements. Additionally, I’ve set cursor: default as the default style for ListItemFrame to maintain consistency where needed.


| AS-IS | TO-BE |
|----------|----------|
| <img width="816" alt="스크린샷 2024-09-07 오전 2 57 31" src="https://github.com/user-attachments/assets/4ac93449-9392-4bf7-bdde-a13f0188d523"> | <img width="1091" alt="스크린샷 2024-09-07 오전 2 58 17" src="https://github.com/user-attachments/assets/dad84b25-2747-44ce-ab23-cf44e4d878f9"> |