### PR TITLE
feat(core): fallback to dataSet for Animated Views

### DIFF
--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -358,6 +358,7 @@ export const useComponentState = (
     supportsCSSVars,
     willBeAnimated,
     willBeAnimatedClient,
+    hasRNAnimation,
   }
 }
 
@@ -601,6 +602,7 @@ export function createComponent<
       supportsCSSVars,
       willBeAnimated,
       willBeAnimatedClient,
+      hasRNAnimation,
     } = useComponentState(props, componentContext, staticConfig, config!)
 
     const shouldForcePseudo = !!propsIn.forceStyle
@@ -745,6 +747,7 @@ export function createComponent<
       isAnimated,
       willBeAnimated,
       styledContextProps,
+      hasRNAnimation,
     } as const
 
     // HOOK 15 (-1 if no animation, -1 if disableSSR, -1 if no context, -1 if production)

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -304,7 +304,7 @@ export const getSplitStyles: StyleSplitter = (
     // this is all for partially optimized (not flattened)... maybe worth removing?
     if (process.env.TAMAGUI_TARGET === 'web') {
       // react-native-web ignore data-* attributes, we need this for AnimatedView
-      if (styleProps.isAnimated && keyInit.startsWith('data-')) {
+      if (styleProps.hasRNAnimation && keyInit.startsWith('data-')) {
         keyInit = keyInit.replace('data-', '')
         viewProps['dataSet'] ||= {}
         viewProps['dataSet'][keyInit] = valInit

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -303,6 +303,13 @@ export const getSplitStyles: StyleSplitter = (
 
     // this is all for partially optimized (not flattened)... maybe worth removing?
     if (process.env.TAMAGUI_TARGET === 'web') {
+      // react-native-web ignore data-* attributes, we need this for AnimatedView
+      if (styleProps.isAnimated && keyInit.startsWith('data-')) {
+        keyInit = keyInit.replace('data-', '')
+        viewProps['dataSet'] ||= {}
+        viewProps['dataSet'][keyInit] = valInit
+        continue
+      }
       if (isValidStyleKeyInit && valInitType === 'string') {
         if (valInit[0] === '_') {
           const isValidClassName = keyInit in validStyles

--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -2382,6 +2382,7 @@ export type SplitStyleProps = {
   isExiting?: boolean
   exitVariant?: string
   enterVariant?: string
+  hasRNAnimation?: boolean
 }
 
 // Presence

--- a/code/core/web/types/createComponent.d.ts
+++ b/code/core/web/types/createComponent.d.ts
@@ -22,6 +22,7 @@ export declare const useComponentState: (props: StackProps | TextProps | Record<
     supportsCSSVars: boolean | undefined;
     willBeAnimated: boolean;
     willBeAnimatedClient: boolean;
+    hasRNAnimation: boolean | undefined;
 };
 export declare function createComponent<ComponentPropTypes extends Record<string, any> = {}, Ref extends TamaguiElement = TamaguiElement, BaseProps = never, BaseStyles extends Object = never>(staticConfig: StaticConfig): TamaguiComponent<ComponentPropTypes, Ref, BaseProps, BaseStyles, {}>;
 export declare function Unspaced(props: {

--- a/code/core/web/types/types.d.ts
+++ b/code/core/web/types/types.d.ts
@@ -1430,6 +1430,7 @@ export type SplitStyleProps = {
     isExiting?: boolean;
     exitVariant?: string;
     enterVariant?: string;
+    hasRNAnimation?: boolean;
 };
 export interface PresenceContextProps {
     id: string;


### PR DESCRIPTION
**Animated** views will ignore `data-*` attributes
so we need to fallback to `dataSet` 