### PR TITLE
fix: Remove the sideEffects note from tutorial

### DIFF
--- a/code/ooo/data/docs/installation.mdx
+++ b/code/ooo/data/docs/installation.mdx
@@ -42,9 +42,6 @@ Let's begin with our package.json:
 }
 ```
 
-Note the `sideEffects` field - for production builds, this will enable much better tree shaking.
-
-
 It is strongly recommended to pin the `one` version for production stability:
 
 ```bash


### PR DESCRIPTION
## Side effect fix

The sideEffect note is not true. It's only true for library code not the application code.

Below is from [webpack docs](https://webpack.js.org/configuration/optimization/) but this applies to vite and all other bundlers as well.

![image](https://github.com/user-attachments/assets/119eb34c-1195-4f6d-a1f1-583e70babc2f)

I kept sideEffect: true in the package.json though because it's still a nice practice since sometimes users may move to a monorepo setup in which subpackages it is true and this allows the copy pasted package.json to be set up by default. There is no downside to explicitly stating it

## Other issues found

I found other minor issues in getting started that I'm unsure were worth fixing or addressing:

- if you use npm you must do `--force` or set legacy deps to true because of some mismatched legacy deps. Since project is in beta I think this is fine
- There is no tsconfig setup which will cause ts to be mad we are not importing react based on the default ts configuration. This seems very minor though
- Using pnpm I could not get the app to start. It's common for a dev to not listen to the docs and use whatever package manager they prefer. If this wasn't beta I would suggest explicitly calling out devs can use yarn
- If user is using pnpm, implicit dependencies such as vite must be installed too. The getting started guide shoud either include vite in the package.json or update one to add vite as a peer dependency. 