### PR TITLE
Fix capitalization of GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ When opening issues please make sure that they adhere to these guidelines:
   - Make sure that your bug is Tamagui specific and not an integration with other libraries that we might not support yet. (Seek help in discord for these).
   - Use the Reproducible Bug Report template for all bug reports.
 
-For now this is the only Github issue we support, for any other kinds of issues or general questions please join our discord and feel free to ask for help in the `help-casual` channel or open a help discussion in the `help board`.
+For now this is the only GitHub issue we support, for any other kinds of issues or general questions please join our discord and feel free to ask for help in the `help-casual` channel or open a help discussion in the `help board`.
 
 If your issue does not adhere to these guidelines, in order to save everyone's time we will close it on sight.
 

--- a/code/ooo/data/docs/common-issues.mdx
+++ b/code/ooo/data/docs/common-issues.mdx
@@ -2,7 +2,7 @@
 title: Common Issues
 ---
 
-This documented collects tips and tricks for debugging common issues. If you'd like to see a workaround documented here, please [submit it to our Github issues](https://github.com/onejs/one).
+This documented collects tips and tricks for debugging common issues. If you'd like to see a workaround documented here, please [submit it to our GitHub issues](https://github.com/onejs/one).
 
 ### General errors when server rendering
 

--- a/code/ooo/data/docs/routing-modes.mdx
+++ b/code/ooo/data/docs/routing-modes.mdx
@@ -58,9 +58,9 @@ It's downsides include a slower initial load time, and worse SEO. Though we are 
 
 If you name a route with the `+ssr` suffix, like `app/issues+ssr.tsx`, you will get a server rendered page. This mode will generate the JS for both server and client at build-time, but instead of rendering out the HTML and CSS right then, it will instead wait for a request to the production server before it imports the server JS, renders the page, and then returns the HTML and CSS.
 
-This mode is great for thing that need to be dynamically rendered more often than whenever you deploy. One example is something more like Github Issues. By server rendering a page like this, you get faster initial loads, and better SEO than a SPA-type page. But it is the most expensive in terms of cost - each request will now run a full render of the route, and also the slower than SSG in terms of initial response time, at least by default.
+This mode is great for thing that need to be dynamically rendered more often than whenever you deploy. One example is something more like GitHub Issues. By server rendering a page like this, you get faster initial loads, and better SEO than a SPA-type page. But it is the most expensive in terms of cost - each request will now run a full render of the route, and also the slower than SSG in terms of initial response time, at least by default.
 
-In the case of a Github Issues type page, what you'd do is cache the SSR response on a CDN, and then clear the CDN cache whenever data for that page updates. This is complex, and generally SSR is the most complex of the three render modes to support. Because it is more complex and more expensive, we generally recommend using SPA or SSG unless you are certain you can afford to pay for the extra render cost, and/or cache responses without too much trouble.
+In the case of a GitHub Issues type page, what you'd do is cache the SSR response on a CDN, and then clear the CDN cache whenever data for that page updates. This is complex, and generally SSR is the most complex of the three render modes to support. Because it is more complex and more expensive, we generally recommend using SPA or SSG unless you are certain you can afford to pay for the extra render cost, and/or cache responses without too much trouble.
 
 ### API
 

--- a/code/packages/lucide-icons/src/icons/github.tsx
+++ b/code/packages/lucide-icons/src/icons/github.tsx
@@ -44,6 +44,6 @@ const Icon = (props) => {
 
 };
 
-Icon.displayName = 'Github';
+Icon.displayName = 'GitHub';
 
 export const Github = React.memo<IconProps>(themed(Icon));

--- a/code/tamagui.dev/app/(site)/takeout.tsx
+++ b/code/tamagui.dev/app/(site)/takeout.tsx
@@ -1469,7 +1469,7 @@ const Points = () => (
     <Point>+150 icon packs</Point>
     <Point>2 all new theme suites: Pastel & Neon</Point>
     <Point>All of Google fonts fonts</Point>
-    <Point>Github template with PR bot for updates</Point>
+    <Point>GitHub template with PR bot for updates</Point>
     <Point>Fully tested CI/CD: unit, integration, web and native</Point>
     <Point>Preview deploys for web, app-store builds with EAS</Point> */}
     {Object.entries(points).map(([key, group]) => (

--- a/code/tamagui.dev/data/blog/version-one-release-candidate.mdx
+++ b/code/tamagui.dev/data/blog/version-one-release-candidate.mdx
@@ -65,7 +65,7 @@ The V1 blog post will cover these in more detail. You can see the accompanying d
 
 ### CI, Testing and Release
 
-A complete CI/CD pipeline in Github Actions lints, tests, and type checks everything before release. Our release script has added many checks and features for making sure things go out smoothly.
+A complete CI/CD pipeline in GitHub Actions lints, tests, and type checks everything before release. Our release script has added many checks and features for making sure things go out smoothly.
 
 Testing now covers far more of `core` and `static`, as well as a complete integration test that verifies the entire flow of starting a Tamagui app with `npm create tamagui` all the way to Playwright ensuring the final output is correct and functional.
 
@@ -75,7 +75,7 @@ The best part of this post is how active the community has become.
 
 The Discord has many posts every day. We've had 33 new contributors to the repo, with many of the most significant contributions coming over the last three months.
 
-And I've personally met my goal of 10 Github Sponsors for the year, something especially cool given it wasn't promoted beyond [a Twitter thread](https://twitter.com/natebirdman/status/1563229065104203776).
+And I've personally met my goal of 10 GitHub Sponsors for the year, something especially cool given it wasn't promoted beyond [a Twitter thread](https://twitter.com/natebirdman/status/1563229065104203776).
 
 Be sure to check [the Community page](/community) for more goodies like a Figma design system file, example repos, sponsors, and other helpful links.
 

--- a/code/tamagui.dev/data/blog/version-one.mdx
+++ b/code/tamagui.dev/data/blog/version-one.mdx
@@ -635,7 +635,7 @@ There are many exciting features on the table as well, including:
 
 ## Sponsors
 
-<IntroParagraph>Tamagui is fully funded by Github Sponsors.</IntroParagraph>
+<IntroParagraph>Tamagui is fully funded by GitHub Sponsors.</IntroParagraph>
 
 I love working on Tamagui, and there's a wealth of concrete and interesting ways for it to mature. The motivation is to take things slowly, do them right, and stay fully OSS.
 

--- a/code/tamagui.dev/features/site/header/Header.tsx
+++ b/code/tamagui.dev/features/site/header/Header.tsx
@@ -190,7 +190,7 @@ export const HeaderContents = React.memo((props: HeaderProps) => {
                     o: 0.8,
                   }}
                 >
-                  Github
+                  GitHub
                 </SizableText>
               </XStack>
             </XStack>

--- a/code/tamagui.dev/features/site/purchase/helpers.tsx
+++ b/code/tamagui.dev/features/site/purchase/helpers.tsx
@@ -276,7 +276,7 @@ export const TakeoutTable = ({
         <YStack width="80%">
           <Paragraph size="$6">GitHub Seats</Paragraph>
           <Paragraph className="text-wrap-balance" size="$3" theme="alt1">
-            Open PRs and issues on the Github repo
+            Open PRs and issues on the GitHub repo
           </Paragraph>
         </YStack>
         <XStack f={1} ai="center" gap="$2" jc="center">

--- a/code/tamagui.dev/features/takeout/TakeoutPolicy.tsx
+++ b/code/tamagui.dev/features/takeout/TakeoutPolicy.tsx
@@ -8,7 +8,7 @@ export const TakeoutPolicy = () => {
       <H3>Delivery</H3>
 
       <Paragraph>
-        Tamagui LLC will deliver to you access to a Github repository that contains the
+        Tamagui LLC will deliver to you access to a GitHub repository that contains the
         Takeout stack code. This code includes all the functionality to build and ship
         apps using Tamagui on React Native, supporting the most recent two versions of iOS
         and Android, as well as building and shipping websites that support Chrome,
@@ -40,8 +40,8 @@ export const TakeoutPolicy = () => {
 
       <Paragraph>
         The Takeout subscription is yearly at the rate of the purchase price. It will keep
-        your access to the Takeout Github repository, as well as to updates via the
-        TakeoutBot Github Bot. You may cancel this at any time from{' '}
+        your access to the Takeout GitHub repository, as well as to updates via the
+        TakeoutBot GitHub Bot. You may cancel this at any time from{' '}
         <a href="https://tamagui.dev/account">your account</a> by going to Subscriptions
         and then hitting "Cancel," or you can email us at support@tamagui.dev.
       </Paragraph>

--- a/code/tamagui.dev/features/user/claim-product.ts
+++ b/code/tamagui.dev/features/user/claim-product.ts
@@ -120,7 +120,7 @@ const claimRepositoryAccess: ClaimFunction = async ({ user, metadata, request })
         repository_name: repoName,
         permission,
       },
-      message: `Successfully invited. Check your email or Github notifications (${userPrivate.github_user_name}) for an invitation to the repository.`,
+      message: `Successfully invited. Check your email or GitHub notifications (${userPrivate.github_user_name}) for an invitation to the repository.`,
     }
   } catch (error) {
     console.error(


### PR DESCRIPTION
There are a number of places where GitHub is incorrectly capitalized as Github. This corrects those errors.