### PR TITLE
docs(headings): correct install banner package to text

### DIFF
--- a/code/tamagui.dev/data/docs/components/headings/1.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/headings/1.0.0.mdx
@@ -11,7 +11,7 @@ demoName: Headings
 
 <Description>Heading components that mimic HTML equivalents.</Description>
 
-<InstallBanner name="@tamagui/headings" />
+<InstallBanner name="@tamagui/text" />
 
 <HeroContainer>
   <HeadingsDemo />


### PR DESCRIPTION
The Headings documentation says to use `@tamagui/headings` but the components are in the package `@tamagui/text`.
See https://tamagui.dev/ui/headings?subpath=headings

This PR corrects to the text package