### PR TITLE
replicate issue #2980

### DIFF
--- a/code/starters/expo-router/app/(tabs)/_layout.tsx
+++ b/code/starters/expo-router/app/(tabs)/_layout.tsx
@@ -27,7 +27,12 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <Atom color={color} />,
           headerRight: () => (
             <Link href="/modal" asChild>
-              <Button mr="$4" bg="$purple8" color="$purple12">
+              <Button
+                mr="$4"
+                bg="$purple8"
+                color="$purple12"
+                $theme-dark={{ bg: '$red8' }}
+              >
                 Hello!
               </Button>
             </Link>


### PR DESCRIPTION
`cd code/starters/expo-router`
`yarn start` open in iOS simulator

Toggle light/dark mode with `shift + cmd  + A`

hello button in top right should be `purple` in light mode, and `red` in dark mode - it is `red` in light mode as well