### PR TITLE
docs: fix typo in `exports-withLayoutContext.mdx`

### DIFF
--- a/code/ooo/data/docs/exports-withLayoutContext.mdx
+++ b/code/ooo/data/docs/exports-withLayoutContext.mdx
@@ -5,7 +5,7 @@ description: Create your own layouts.
 
 Today there are a few built-in navigators: [Slot](/docs/components-Slot), [Stack](/docs/components-Stack), etc. But you may want to create your own.
 
-A good example of this is the new [`react-native-bottom-tabs` libray](https://github.com/okwasniewski/react-native-bottom-tabs) library, that exports a React Navigation compatible navigator.
+A good example of this is the new [`react-native-bottom-tabs`](https://github.com/okwasniewski/react-native-bottom-tabs) library, that exports a React Navigation compatible navigator.
 
 To make any React Navigation navigator work inside a One layout, use `withLayoutContext`:
 


### PR DESCRIPTION
fixed a typo, so good to have native bottom tabs supported! 