### PR TITLE
Update theme-builder guide createTheme params

### DIFF
--- a/code/tamagui.dev/data/docs/guides/theme-builder.mdx
+++ b/code/tamagui.dev/data/docs/guides/theme-builder.mdx
@@ -26,7 +26,7 @@ This guide goes into `createThemeBuilder`. If you want to [skip to the API, chec
   This guide is for more advanced use cases.
 </Notice>
 
-Before we dive in, here's a minimal createThemeBuilder example to understand what we're building towards. It generates `light`, `dark`, `light_subtle`, and `dark_subtle` themes using all the concepts we'll cover in this guide: palettes, templates, masks, and themes:
+Before we dive in, here's a minimal createThemeBuilder example to understand what we're building towards. It generates `light`, `dark`, `light_subtle`, and `dark_subtle` themes using all the concepts we'll cover in this guide: palettes, templates, and themes:
 
 <Notice>
   Note that the @tamagui/theme-builder package requires TypeScript 5 or greater
@@ -93,7 +93,7 @@ You can also use the new `@tamagui/cli` package to enable `npx tamagui generate-
 
 ### The Concepts
 
-The way the new ThemeBuilder works is through three main concepts: a palette, a template, and a mask. It's worth understanding each and how they relate to a design system before getting your hands dirty.
+The way the new ThemeBuilder works is through two main concepts: a palette and a template. It's worth understanding each and how they relate to a design system before getting your hands dirty.
 
 But first - what is a theme?
 

--- a/code/tamagui.dev/data/docs/guides/theme-builder.mdx
+++ b/code/tamagui.dev/data/docs/guides/theme-builder.mdx
@@ -202,7 +202,7 @@ const createTheme = (palette: string[], colorTemplate: {
   color: palette[colorTemplate.color],
 })
 
-createTheme(dark_blue)
+createTheme(dark_blue, { background: 0, color: 11 })
 // => {
 //   background: 'hsl(212, 35.0%, 9.2%)',
 //   color: 'hsl(206, 98.0%, 95.8%)'


### PR DESCRIPTION
Fix theme-builder guide by including missing createTheme hard-coded mapper function params. Also remove mentions of masks, a concept which was previously removed from the guide for the sake of simplicity.