### PR TITLE
docs: fix imports for ListItem customization example

### DIFF
--- a/code/tamagui.dev/data/docs/components/list-item/1.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/list-item/1.0.0.mdx
@@ -69,8 +69,9 @@ ListItem only supports a limited subset of text props directly, and doesn't acce
 import { forwardRef } from 'react'
 import {
   ListItemFrame,
-  ListItemProps,
   ListItemText,
+  ListItemTitle,
+  ListItemSubtitle,
   styled,
   themeable,
   useListItem,


### PR DESCRIPTION
ListItemProps is unused, ListItemTitle and ListItemSubtitle are required.