### PR TITLE
list item uses theme background

### DIFF
--- a/code/kitchen-sink/src/usecases/ListItem.tsx
+++ b/code/kitchen-sink/src/usecases/ListItem.tsx
@@ -1,0 +1,64 @@
+import { ListItem, Stack, Theme } from 'tamagui'
+import { ChevronRight } from '@tamagui/lucide-icons'
+
+export const ThemedListItem = () => (
+  <Stack gap="$4">
+    <ListItem
+      id="themed-list-item-default"
+      title="Default"
+      subTitle="Default list item"
+      icon={ChevronRight}
+      size="$3"
+      borderRadius="$3"
+    />
+    <Theme name="light">
+      <ListItem
+        id="themed-list-item-light"
+        title='<Theme ="light"/>'
+        subTitle="Forcing light theme"
+        icon={ChevronRight}
+        size="$3"
+        borderRadius="$3"
+        onPress={() => console.info('Light theme list item pressed')}
+      />
+    </Theme>
+
+    <Theme name="dark">
+      <ListItem
+        id="themed-list-item-dark"
+        title='<Theme ="dark"/>'
+        subTitle="Forcing dark theme"
+        icon={ChevronRight}
+        size="$3"
+        borderRadius="$3"
+        onPress={() => console.info('Dark theme list item pressed')}
+      />
+    </Theme>
+
+    <Theme name="light">
+      <ListItem
+        id="themed-list-item-light-inverse"
+        title="<ListItem themeInverse/>"
+        subTitle="Forcing light theme with inverse"
+        icon={ChevronRight}
+        size="$3"
+        borderRadius="$3"
+        themeInverse
+        onPress={() => console.info('Light theme inverse list item pressed')}
+      />
+    </Theme>
+
+    <Theme name="dark">
+      <ListItem
+        id="themed-list-item-dark-inverse"
+        title="<ListItem themeInverse/>"
+        subTitle="Forcing dark theme with inverse"
+        icon={ChevronRight}
+        size="$3"
+        borderRadius="$3"
+        themeInverse
+        onPress={() => console.info('Dark theme inverse list item pressed')}
+      />
+    </Theme>
+  </Stack>
+)

--- a/code/kitchen-sink/src/usecases/index.ts
+++ b/code/kitchen-sink/src/usecases/index.ts
@@ -48,3 +48,4 @@ export { StyledStyledStyleableInputOnFocus } from './StyledStyledStyleableInputO
 export { FocusVisibleButton } from './FocusVisibleButton'
 export { FocusVisibleButtonPointer } from './FocusVisibleButtonPointer'
 export { FocusVisibleButtonWithFocusStyle } from './FocusVisibleButtonWithFocusStyle'
+export { ThemedListItem } from './ListItem'

--- a/code/ui/list-item/src/ListItem.tsx
+++ b/code/ui/list-item/src/ListItem.tsx
@@ -15,6 +15,7 @@ import type {
 } from '@tamagui/web'
 import { Spacer, getTokens, getVariableValue, styled, useProps } from '@tamagui/web'
 import type { FunctionComponent, ReactNode } from 'react'
+import { useTheme } from '@tamagui/core'
 
 type ListItemIconProps = { color?: any; size?: any }
 type IconProp = JSX.Element | FunctionComponent<ListItemIconProps> | null
@@ -78,7 +79,6 @@ export const ListItemFrame = styled(ThemeableStack, {
         maxWidth: '100%',
         overflow: 'hidden',
         flexDirection: 'row',
-        backgroundColor: '$background',
         cursor: 'default',
       },
     },
@@ -283,7 +283,14 @@ export const useListItem = (
 const ListItemComponent = ListItemFrame.styleable<ListItemExtraProps>(
   function ListItem(props, ref) {
     const { props: listItemProps } = useListItem(props)
-    return <ListItemFrame ref={ref} {...listItemProps} />
+    const theme = useTheme()
+    return (
+      <ListItemFrame
+        ref={ref}
+        {...listItemProps}
+        backgroundColor={theme.background?.val}
+      />
+    )
   }
 )
 

--- a/code/ui/list-item/src/ListItem.tsx
+++ b/code/ui/list-item/src/ListItem.tsx
@@ -15,7 +15,6 @@ import type {
 } from '@tamagui/web'
 import { Spacer, getTokens, getVariableValue, styled, useProps } from '@tamagui/web'
 import type { FunctionComponent, ReactNode } from 'react'
-import { useTheme } from '@tamagui/core'
 
 type ListItemIconProps = { color?: any; size?: any }
 type IconProp = JSX.Element | FunctionComponent<ListItemIconProps> | null
@@ -70,6 +69,7 @@ export const ListItemFrame = styled(ThemeableStack, {
   variants: {
     unstyled: {
       false: {
+        backgroundColor: '$background',
         size: '$true',
         alignItems: 'center',
         justifyContent: 'space-between',
@@ -283,14 +283,7 @@ export const useListItem = (
 const ListItemComponent = ListItemFrame.styleable<ListItemExtraProps>(
   function ListItem(props, ref) {
     const { props: listItemProps } = useListItem(props)
-    const theme = useTheme()
-    return (
-      <ListItemFrame
-        ref={ref}
-        {...listItemProps}
-        backgroundColor={theme.background?.val}
-      />
-    )
+    return <ListItemFrame ref={ref} {...listItemProps} />
   }
 )
 


### PR DESCRIPTION
Attempt at fixing https://github.com/tamagui/tamagui/issues/3032

Not sure this is the ideal way to amend `ListItem`, but a test case is in `usecases` if not that can be used as a reference.

With fix:
<img width="595" alt="image" src="https://github.com/user-attachments/assets/99e5a079-8b65-408c-a985-f66db3647fca">

Without fix:
<img width="578" alt="image" src="https://github.com/user-attachments/assets/d7688e8c-4995-41f5-9d11-65e4ca7f94bf">

Without fix dark mode:
<img width="576" alt="image" src="https://github.com/user-attachments/assets/9685a433-daad-4041-ad6c-107560e573fd">


