### PR TITLE
[tamagui] Updates for `package.json`

### DIFF
--- a/code/ui/tamagui/package.json
+++ b/code/ui/tamagui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tamagui",
   "version": "1.116.14",
+  "description": "Style and UI for React (web and native) meet an optimizing compiler",
   "removeSideEffects": true,
   "alsoPublishAs_disabled": [
     "@tamagui/ui"
@@ -137,7 +138,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/tamagui/tamagui.git",
-    "directory": "packages/tamagui"
+    "directory": "code/ui/tamagui"
   },
   "gitHead": "a49cc7ea6b93ba384e77a4880ae48ac4a5635c14",
   "peerDependencies": {


### PR DESCRIPTION
# Why

Tamagui entry lacks the description in React Native Directory:
* https://reactnative.directory/?search=tamagui

# How

For monorepo packages we relay on [`description` in `package.json`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#description-1), with no fallback to GitHub repository description.

Not sure if this is the correct/ideal description of the package, just copied over what was the highlight sentence in the main repo.

In the process, I have also spotted that `repository` entry points to the incorrect directory inside monorepo.