### PR TITLE
Remove unnecessary console.warn from SheetImplementationCustom.tsx

### DIFF
--- a/code/ui/sheet/src/SheetImplementationCustom.tsx
+++ b/code/ui/sheet/src/SheetImplementationCustom.tsx
@@ -444,7 +444,6 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
     //   portal: true,
     // })
 
-    console.warn('animatedStyle', animatedStyle)
 
     let contents = (
       <ParentSheetContext.Provider value={nextParentContext}>


### PR DESCRIPTION
The warning provides no actionable information for the developer, causing unnecessary confusion during debugging.

The issue was initially described by me in Issue #3114 