### PR TITLE
🐛 fix: Document

### DIFF
--- a/code/tamagui.dev/features/docs/InlineTabs.tsx
+++ b/code/tamagui.dev/features/docs/InlineTabs.tsx
@@ -2,7 +2,7 @@ import { useStore, useStoreSelector } from '@tamagui/use-store'
 import { forwardRef } from 'react'
 import type { TabsProps, TabsTabProps } from 'tamagui'
 import { Paragraph, Tabs, XStack, styled, withStaticProperties } from 'tamagui'
-import { type Href, useLocalSearchParams, useRouter } from 'one'
+import { type Href, useParams, useRouter } from 'one'
 
 class TabsStore {
   active = 'styled'
@@ -10,7 +10,7 @@ class TabsStore {
 
 function TabsComponent(props: TabsProps) {
   const router = useRouter()
-  const query = useLocalSearchParams()
+  const query = useParams()
   const store = useStore(TabsStore)
 
   const id = props.id || 'value'
@@ -20,7 +20,13 @@ function TabsComponent(props: TabsProps) {
     const url = new URL(location.href)
     url.searchParams.set(id, newValue)
     url.hash = '' // having this set messes with the scroll
-    router.replace(url as Href, {
+
+    const params = Object.fromEntries(url.searchParams?.entries() ?? [])
+
+    router.replace({
+      pathname: location.pathname,
+      params,
+    } as Href, {
       scroll: false,
     })
   }


### PR DESCRIPTION
Replace `useLocalSearchParams` with `useParams` in `InlineTabs` component for improved routing