### PR TITLE
Fix code block horizontal scrolling behavior

### DIFF
--- a/code/tamagui.dev/components/RovingTabs.tsx
+++ b/code/tamagui.dev/components/RovingTabs.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, Tabs, YStack } from 'tamagui'
 import { Code } from './Code'
 import { useBashCommand, PACKAGE_MANAGERS } from '~/hooks/useBashCommand'
 import { Image } from '@tamagui/image-next'
+import { ScrollView } from 'react-native'
 
 export function RovingTabs({ className, children, code, size, ...rest }) {
   const { showTabs, transformedCommand, selectedPackageManager, setPackageManager } =
@@ -38,6 +39,32 @@ export function RovingTabs({ className, children, code, size, ...rest }) {
       setIntentIndicator(layout)
     }
   }
+
+  const codeContent = (
+    <ScrollView
+      style={{ width: '100%' }}
+      contentContainerStyle={{
+        minWidth: '100%',
+      }}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+    >
+      <Code
+        p="$4"
+        backgroundColor="transparent"
+        f={1}
+        className={className}
+        size={size ?? '$5'}
+        lineHeight={size ?? '$5'}
+        {...(showTabs && {
+          whiteSpace: 'nowrap',
+        })}
+        {...rest}
+      >
+        {showTabs ? transformedCommand : children}
+      </Code>
+    </ScrollView>
+  )
 
   return (
     <>
@@ -98,22 +125,12 @@ export function RovingTabs({ className, children, code, size, ...rest }) {
             </YStack>
 
             <Tabs.Content value={selectedPackageManager} forceMount>
-              <Code
-                p="$4"
-                backgroundColor="transparent"
-                f={1}
-                className={className}
-                size={size ?? '$5'}
-                lineHeight={size ?? '$5'}
-                {...rest}
-              >
-                {transformedCommand}
-              </Code>
+              {codeContent}
             </Tabs.Content>
           </YStack>
         </Tabs>
       ) : (
-        children
+        codeContent
       )}
     </>
   )

--- a/code/tamagui.dev/features/docs/DocsCodeBlock.tsx
+++ b/code/tamagui.dev/features/docs/DocsCodeBlock.tsx
@@ -208,25 +208,15 @@ export const DocCodeBlock = forwardRef((props: any, ref) => {
                 </XStack>
               )}
 
-              <RovingTabs className={className} size={size} {...rest}>
-                <ScrollView
-                  style={{ width: '100%' }}
-                  contentContainerStyle={{ minWidth: '100%' }}
-                  horizontal
-                  showsHorizontalScrollIndicator={false}
-                >
-                  <Code
-                    p="$4"
-                    backgroundColor="transparent"
-                    f={1}
-                    className={className}
-                    size={size ?? '$5'}
-                    lineHeight={size ?? '$5'}
-                    {...rest}
-                  >
-                    {children}
-                  </Code>
-                </ScrollView>
+              <RovingTabs
+                className={className}
+                size={size}
+                {...rest}
+                {...(showTabs && {
+                  width: '100%',
+                })}
+              >
+                {children}
               </RovingTabs>
             </Pre>
 


### PR DESCRIPTION
| Before | After|
----|---- 
| <img width="400" alt="スクリーンショット 2025-01-14 12 09 41" src="https://github.com/user-attachments/assets/e9d75f67-c497-4353-bbd7-0a56cb315e59" />  | <img width="400" alt="スクリーンショット 2025-01-14 12 09 54" src="https://github.com/user-attachments/assets/f090b783-2884-491f-8ab2-1fb0f063059a" /> |



## Changes
- Fixed an issue where bash commands were overflowing outside their container
- Unified scrolling behavior between bash commands and regular code blocks
- Improved code structure in RovingTabs component

## Testing
- [x] Bash commands are properly contained and horizontally scrollable
- [x] Regular code blocks maintain their original scrolling behavior
- [x] Styling remains consistent across all code block types