### PR TITLE
🐛 fix: wrap ThemePage return in YStack for improved layout structure

### DIFF
--- a/code/tamagui.dev/app/(site)/theme+spa.tsx
+++ b/code/tamagui.dev/app/(site)/theme+spa.tsx
@@ -64,14 +64,14 @@ export default function ThemePage() {
   }, [])
 
   return (
-    <>
+    <YStack>
       {loaded && <ThemeBuilderModal />}
 
       <PreviewTheme key={`${loaded}${themeName}`}>
         <StudioPreviewComponentsBar scrollView={document.documentElement} />
         <StudioPreviewComponents />
       </PreviewTheme>
-    </>
+    </YStack>
   )
 }
 


### PR DESCRIPTION
`/theme:`

<img width="1440" alt="Screenshot 2025-01-15 at 22 50 08" src="https://github.com/user-attachments/assets/da6ca200-8fc5-456c-9da7-c33ec6ead729" />
