### PR TITLE
fix: Input keyboard type and secure text entry support

### DIFF
--- a/code/ui/components-test/Input.web.test.tsx
+++ b/code/ui/components-test/Input.web.test.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom'
+import { Input } from '@tamagui/input'
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { Stack, TamaguiProvider, createTamagui } from '@tamagui/core'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+function InputTest(props: React.ComponentProps<typeof Input>) {
+  return (
+    <TamaguiProvider config={conf} defaultTheme="light">
+      <Stack>
+        <Input {...props} />
+      </Stack>
+    </TamaguiProvider>
+  )
+}
+
+describe('Input web keyboard type conversion', () => {
+  it('should convert number-pad to number type and numeric inputmode', () => {
+    const { container } = render(<InputTest keyboardType="number-pad" />)
+    const input = container.querySelector('input')
+    expect(input).toHaveAttribute('type', 'number')
+    expect(input).toHaveAttribute('inputmode', 'numeric')
+  })
+
+  it('should convert email-address to email type and email inputmode', () => {
+    const { container } = render(<InputTest keyboardType="email-address" />)
+    const input = container.querySelector('input')
+    expect(input).toHaveAttribute('type', 'email')
+    expect(input).toHaveAttribute('inputmode', 'email')
+  })
+
+  it('should convert phone-pad to tel type and tel inputmode', () => {
+    const { container } = render(<InputTest keyboardType="phone-pad" />)
+    const input = container.querySelector('input')
+    expect(input).toHaveAttribute('type', 'tel')
+    expect(input).toHaveAttribute('inputmode', 'tel')
+  })
+
+  it('should convert decimal-pad to text type with decimal inputmode', () => {
+    const { container } = render(<InputTest keyboardType="decimal-pad" />)
+    const input = container.querySelector('input')
+    expect(input).toHaveAttribute('type', 'text')
+    expect(input).toHaveAttribute('inputmode', 'decimal')
+  })
+})
+
+describe('Input web secure text entry', () => {
+  it('should convert secureTextEntry to password type', () => {
+    const { container } = render(<InputTest secureTextEntry={true} />)
+    const input = container.querySelector('input')
+    expect(input).toHaveAttribute('type', 'password')
+  })
+
+  it('should prioritize secureTextEntry over keyboardType', () => {
+    const { container } = render(
+      <InputTest secureTextEntry={true} keyboardType="number-pad" />
+    )
+    const input = container.querySelector('input')
+    expect(input).toHaveAttribute('type', 'password')
+  })
+})
+
+describe('Input web default type', () => {
+  it('should use text type and no inputmode when no props specified', () => {
+    const { container } = render(<InputTest />)
+    const input = container.querySelector('input')
+    expect(input).toHaveAttribute('type', 'text')
+    expect(input).not.toHaveAttribute('inputmode')
+  })
+})

--- a/code/ui/input/src/Input.tsx
+++ b/code/ui/input/src/Input.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { type HTMLInputTypeAttribute, type HTMLAttributes } from 'react'
 import { View, styled, useComposedRefs, useEvent, useTheme } from '@tamagui/core'
 import { registerFocusable } from '@tamagui/focusable'
+import type { InputModeOptions } from 'react-native'
 
 import { styledBody } from './shared'
 import type { InputProps } from './types'
@@ -93,11 +94,51 @@ export const Input = StyledInput.styleable<InputProps>((inProps, forwardedRef) =
 
   const finalProps = {
     ...rest,
-    inputMode,
     disabled,
     caretColor,
     id,
     enterKeyHint,
+    ...(process.env.TAMAGUI_TARGET === 'web'
+      ? {
+          type: (() => {
+            if (secureTextEntry) return 'password'
+            switch (keyboardType) {
+              case 'number-pad':
+              case 'numeric':
+                return 'number'
+              case 'email-address':
+                return 'email'
+              case 'phone-pad':
+                return 'tel'
+              case 'url':
+                return 'url'
+              default:
+                return 'text'
+            }
+          })() satisfies HTMLInputTypeAttribute,
+          inputMode: (() => {
+            switch (keyboardType) {
+              case 'number-pad':
+              case 'numeric':
+                return 'numeric'
+              case 'decimal-pad':
+                return 'decimal'
+              case 'email-address':
+                return 'email'
+              case 'phone-pad':
+                return 'tel'
+              case 'url':
+                return 'url'
+              default:
+                return undefined
+            }
+          })() satisfies HTMLAttributes<HTMLInputElement>['inputMode'],
+        }
+      : {
+          keyboardType,
+          secureTextEntry,
+          inputMode,
+        }),
     style: {
       ...(rest.style as any),
       ...(placeholderTextColor && {


### PR DESCRIPTION
Fixes #2926

- Added proper type conversion from React Native's keyboardType to HTML input type for the web
- Implemented `secureTextEntry` and `keyboardType` support for native

The component tests (`*.web.test.tsx`) in the codebase are currently not running. This should be addressed in a separate PR to ensure all web-specific tests are properly executed.