### PR TITLE
docs: add JSDoc to Button, Image, Input, TextArea, and Stacks

### DIFF
--- a/code/ui/button/src/Button.tsx
+++ b/code/ui/button/src/Button.tsx
@@ -193,7 +193,10 @@ const ButtonComponent = ButtonFrame.styleable<ButtonExtraProps>(
     return <ButtonFrame data-disable-theme {...buttonProps} ref={ref} />
   }
 )
-
+/**
+ * @summary A Button is a clickable element that can be used to trigger actions such as submitting forms, navigating to other pages, or performing other actions.
+ * @see — Docs https://tamagui.dev/ui/button
+ */
 const Button = withStaticProperties(ButtonComponent, {
   Text: ButtonText,
   Icon: ButtonIcon,

--- a/code/ui/image/src/Image.tsx
+++ b/code/ui/image/src/Image.tsx
@@ -50,6 +50,10 @@ type ImageType = FC<ImageProps> & {
 
 let hasWarned = false
 
+/**
+ * @summary An image is a component that displays an image.
+ * @see — Docs https://tamagui.dev/ui/image
+ */
 export const Image = StyledImage.styleable<ImageProps>((inProps, ref) => {
   const [props, style] = usePropsAndStyle(inProps)
   const { src, source, objectFit, ...rest } = props

--- a/code/ui/input/src/Input.tsx
+++ b/code/ui/input/src/Input.tsx
@@ -7,6 +7,10 @@ import { styledBody } from './shared'
 import type { InputProps } from './types'
 const StyledInput = styled(View, styledBody[0], styledBody[1])
 
+/**
+ * @summary An input is a text field that allows users to enter text.
+ * @see — Docs https://tamagui.dev/ui/inputs#input
+ */
 export const Input = StyledInput.styleable<InputProps>((inProps, forwardedRef) => {
   const {
     // some of destructed props are just to avoid passing them to ...rest because they are not in web.

--- a/code/ui/input/src/TextArea.tsx
+++ b/code/ui/input/src/TextArea.tsx
@@ -2,6 +2,10 @@ import { styled } from '@tamagui/web'
 import { Input } from './Input'
 import { defaultStyles, textAreaSizeVariant } from './shared'
 
+/**
+ * @summary A text area is a multi-line input field that allows users to enter text.
+ * @see — Docs https://tamagui.dev/ui/inputs#textarea
+ */
 export const TextArea = styled(Input, {
   name: 'TextArea',
   tag: 'textarea',

--- a/code/ui/stacks/src/Stacks.tsx
+++ b/code/ui/stacks/src/Stacks.tsx
@@ -46,6 +46,10 @@ const variants = {
   inset: getInset,
 } as const
 
+/**
+ * @summary A view that arranges its children in a vertical line.
+ * @see — Docs https://tamagui.dev/ui/stacks#xstack-ystack-zstack
+ */
 export const YStack = styled(View, {
   flexDirection: 'column',
   variants,
@@ -53,6 +57,10 @@ export const YStack = styled(View, {
 
 YStack['displayName'] = 'YStack'
 
+/**
+ * @summary A view that arranges its children in a horizontal line.
+ * @see — Docs https://tamagui.dev/ui/stacks#xstack-ystack-zstack
+ */
 export const XStack = styled(View, {
   flexDirection: 'row',
   variants,
@@ -60,6 +68,10 @@ export const XStack = styled(View, {
 
 XStack['displayName'] = 'XStack'
 
+/**
+ * @summary A view that stacks its children on top of each other.
+ * @see — Docs https://tamagui.dev/ui/stacks#xstack-ystack-zstack
+ */
 export const ZStack = styled(
   YStack,
   {


### PR DESCRIPTION
Added JSDoc documentation to improve IDE experience:
- Added `@summary` tags with brief component descriptions
- Added `@see` tags with links to documentation
- Updated components:
  - Input
  - Button
  - Image
  - YStack/XStack/ZStack
  - TextArea