### PR TITLE
Allow type prop on new Input.tsx

### DIFF
--- a/code/ui/input/src/Input.tsx
+++ b/code/ui/input/src/Input.tsx
@@ -117,7 +117,7 @@ export const Input = StyledInput.styleable<InputProps>((inProps, forwardedRef) =
               case 'url':
                 return 'url'
               default:
-                return 'text'
+                return rest?.type ?? 'text'
             }
           })() satisfies HTMLInputTypeAttribute,
           inputMode: (() => {

--- a/code/ui/input/src/Input.tsx
+++ b/code/ui/input/src/Input.tsx
@@ -105,6 +105,7 @@ export const Input = StyledInput.styleable<InputProps>((inProps, forwardedRef) =
     ...(process.env.TAMAGUI_TARGET === 'web'
       ? {
           type: (() => {
+            if (rest?.type) return rest.type
             if (secureTextEntry) return 'password'
             switch (keyboardType) {
               case 'number-pad':
@@ -117,7 +118,7 @@ export const Input = StyledInput.styleable<InputProps>((inProps, forwardedRef) =
               case 'url':
                 return 'url'
               default:
-                return rest?.type ?? 'text'
+                return 'text'
             }
           })() satisfies HTMLInputTypeAttribute,
           inputMode: (() => {


### PR DESCRIPTION
Allow the use of `time` or any other input related types. Currently there is a map and I am unsure why this is not allowing all input type variants.