### PR TITLE
fix: allow intermediate theme keys on `Theme` type definition

### DIFF
--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -440,7 +440,7 @@ export type UseThemeWithStateProps = ThemeProps & {
 type ArrayIntersection<A extends any[]> = A[keyof A]
 
 type GetAltThemeNames<S> =
-  | (S extends `${string}_${infer Alt}` ? GetAltThemeNames<Alt> : S)
+  | (S extends `${infer Theme}_${infer Alt}` ? Theme | GetAltThemeNames<Alt> : S)
   | S
 
 export type SpacerUniqueProps = {

--- a/code/core/web/types/types.d.ts
+++ b/code/core/web/types/types.d.ts
@@ -272,7 +272,7 @@ export type UseThemeWithStateProps = ThemeProps & {
     needsUpdate?: () => boolean;
 };
 type ArrayIntersection<A extends any[]> = A[keyof A];
-type GetAltThemeNames<S> = (S extends `${string}_${infer Alt}` ? GetAltThemeNames<Alt> : S) | S;
+type GetAltThemeNames<S> = (S extends `${infer Theme}_${infer Alt}` ? Theme | GetAltThemeNames<Alt> : S) | S;
 export type SpacerUniqueProps = {
     size?: SpaceValue | number;
     flex?: boolean | number;


### PR DESCRIPTION
Previously mentioned on #3089, the `GetAltThemeNames<S>` type does not properly capture intermediate theme names.

Given theme definitions for `light`, `light_Button`, and `light_secondary_Button`, it should be possible to pass `secondary` as a theme.

This PR adds support for those theme keys.