### PR TITLE
fix: importing tooltip stuff should behave as expect on RN

### DIFF
--- a/code/ui/tooltip/src/Tooltip.native.tsx
+++ b/code/ui/tooltip/src/Tooltip.native.tsx
@@ -11,6 +11,12 @@ const RenderNull = (props: any) => {
   return null
 }
 
+export const TooltipGroup = () => null
+
+export const closeOpenTooltips = () => {
+  /* noop */
+}
+
 export const Tooltip = withStaticProperties(RenderChildren, {
   Anchor: RenderChildren,
   Arrow: RenderNull,

--- a/code/ui/tooltip/types/Tooltip.native.d.ts
+++ b/code/ui/tooltip/types/Tooltip.native.d.ts
@@ -1,3 +1,5 @@
+export declare const TooltipGroup: () => null;
+export declare const closeOpenTooltips: () => void;
 export declare const Tooltip: ((props: any) => any) & {
     Anchor: (props: any) => any;
     Arrow: (props: any) => null;


### PR DESCRIPTION
On RN, doing this

```tsx
import { closeOpenTooltips } from 'tamagui'
closeOpenTooltips()
```

will cause a weird error, due to `closeOpenTooltips` not being exported in `.native` and the bundler will try to import `closeOpenTooltips` from the wrong package since in `tamagui` `index.native.js` there's a lot of `export * from "..."`.