### PR TITLE
fix props autocomplete when react-native is not installed

### DIFF
--- a/code/core/web/package.json
+++ b/code/core/web/package.json
@@ -47,6 +47,7 @@
     "csstype": "^3.0.10",
     "react": "*",
     "react-dom": "*",
+    "react-native": "^0.76.5",
     "typescript": "^5.7.2",
     "vitest": "^3.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9417,6 +9417,7 @@ __metadata:
     csstype: "npm:^3.0.10"
     react: "npm:*"
     react-dom: "npm:*"
+    react-native: "npm:^0.76.5"
     typescript: "npm:^5.7.2"
     vitest: "npm:^3.0.2"
   peerDependencies:


### PR DESCRIPTION
If you don't have react-native installed in your project you'll loose autocomplete because @tamagui/web imports props from it. This PR adds react-native as a dev dependency to @tamagui/web so both  @tamagui/web and @tamagui/core packages can be used without people installing react-native - e.g. targeting only web platform.