### PR TITLE
Remove `read:org scope` from GitHub OAuth login

### DIFF
--- a/code/tamagui.dev/app/(site)/account.tsx
+++ b/code/tamagui.dev/app/(site)/account.tsx
@@ -334,7 +334,6 @@ const GithubConnection = () => {
       provider,
       options: {
         redirectTo: `${window.location.origin}/account`,
-        scopes: 'read:org',
       },
     })
     if (error) {

--- a/code/tamagui.dev/app/(site)/login.tsx
+++ b/code/tamagui.dev/app/(site)/login.tsx
@@ -93,7 +93,6 @@ function SignIn() {
       provider,
       options: {
         redirectTo,
-        scopes: 'read:org',
       },
     })
     if (error) {
@@ -126,11 +125,6 @@ function SignIn() {
           >
             Continue with GitHub
           </Button>
-
-          <Paragraph ta="center" color="$color8">
-            Note: If part of a sponsoring organization, you'll need to grant access to
-            your org when logging in to access sponsor benefits.
-          </Paragraph>
 
           {!emailAuthDisabledFlag && (
             <>


### PR DESCRIPTION
Fix: https://discord.com/channels/909986013848412191/1178185454386941982/1335990827809243227

I removed the `read:org` scope from GitHub OAuth login to minimize required permissions.

I initially tried to remove permissions from existing users as well, but it seems that Supabase Dashboard's Authentication doesn't store scope information, so we couldn't dynamically change scopes on our side.

However, this is not a big issue because:
- New users won't be asked for this permission when logging in
- For existing users, when they disconnect and reconnect their GitHub account, the scope will be automatically minimized