### PR TITLE
Migrate to New Tamagui Start and Support/Chat Plans

### DIFF
--- a/code/tamagui.dev/supabase/plan-migrations/01_cancel_existing_subscriptions.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/01_cancel_existing_subscriptions.sql
@@ -1,0 +1,9 @@
+-- This file cancels all active and trialing subscriptions.
+-- It is used to cancel the old Takeout and Bento subscriptions
+-- in preparation for migrating to the new Tamagui subscription models.
+UPDATE subscriptions
+SET status = 'canceled',
+    canceled_at = NOW(),
+    cancel_at = NOW(),
+    cancel_at_period_end = true
+WHERE status IN ('active', 'trialing');

--- a/code/tamagui.dev/supabase/plan-migrations/02_insert_product_tamagui_start.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/02_insert_product_tamagui_start.sql
@@ -1,0 +1,12 @@
+-- This file creates a new product record for the unified "Tamagui Start" plan.
+-- The Tamagui Start plan integrates Takeout, Bento, Theme AI, Chat AI,
+-- Discord #support, and Early Access features into a single subscription.
+INSERT INTO products (id, active, name, description, image, metadata)
+VALUES (
+  'prod_tamagui_start',
+  true,
+  'Tamagui Start',
+  'Unified plan including Takeout, Bento, Theme AI, Chat AI, Discord #support and early access to new features.',
+  '', -- TODO: Add image
+  '{"features": ["Takeout", "Bento", "Theme AI", "Chat AI", "Discord #support", "Early access"]}'
+);

--- a/code/tamagui.dev/supabase/plan-migrations/03_insert_product_tamagui_chat.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/03_insert_product_tamagui_chat.sql
@@ -1,0 +1,10 @@
+-- This file creates a new product record for the "Tamagui Chat" add-on.
+-- Tamagui Chat provides access to a private Discord room for team collaboration.
+INSERT INTO products (id, active, name, description, metadata)
+VALUES (
+  'prod_tamagui_chat',
+  true,
+  'Tamagui Chat',
+  'Access to a private Discord room for your team for collaboration.',
+  '{"plan": "chat"}'
+);

--- a/code/tamagui.dev/supabase/plan-migrations/04_insert_product_tamagui_support.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/04_insert_product_tamagui_support.sql
@@ -1,0 +1,10 @@
+-- This file creates a new product record for the "Tamagui Support" add-on.
+-- Tamagui Support offers prioritized development support at $1000 per tier per month.
+INSERT INTO products (id, active, name, description, metadata)
+VALUES (
+  'prod_tamagui_support',
+  true,
+  'Tamagui Support',
+  'Receive prioritized development support: Each tier provides 2 hours of prioritized development per month at $1000 per tier.',
+  '{"plan": "support", "tier_hours": 2, "price_per_tier": 1000}'
+);

--- a/code/tamagui.dev/supabase/plan-migrations/05_insert_price_tamagui_start.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/05_insert_price_tamagui_start.sql
@@ -1,0 +1,16 @@
+-- This file adds a price record for the "Tamagui Start" plan.
+-- The plan is priced at $200 per year.
+-- The metadata may include information about auto-renewal options.
+INSERT INTO prices (id, product_id, active, unit_amount, currency, type, interval, interval_count, trial_period_days, metadata)
+VALUES (
+  'price_tamagui_start_yearly',
+  'prod_tamagui_start',
+  true,
+  20000,  -- equivalent to $200
+  'usd',
+  'recurring',
+  'year',
+  1,
+  NULL,
+  '{"auto_renew": true}'
+);

--- a/code/tamagui.dev/supabase/plan-migrations/06_insert_price_tamagui_chat.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/06_insert_price_tamagui_chat.sql
@@ -1,0 +1,15 @@
+-- This file adds a price record for the "Tamagui Chat" add-on.
+-- The add-on is priced at $100 per month.
+INSERT INTO prices (id, product_id, active, unit_amount, currency, type, interval, interval_count, trial_period_days, metadata)
+VALUES (
+  'price_tamagui_chat_monthly',
+  'prod_tamagui_chat',
+  true,
+  10000,  -- equivalent to $100
+  'usd',
+  'recurring',
+  'month',
+  1,
+  NULL,
+  '{"plan": "chat"}'
+);

--- a/code/tamagui.dev/supabase/plan-migrations/07_insert_price_tamagui_support.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/07_insert_price_tamagui_support.sql
@@ -1,0 +1,16 @@
+-- This file adds a price record for the "Tamagui Support" add-on.
+-- It is set at $1000 per tier per month.
+-- Users will specify the number of tiers (quantity) when subscribing.
+INSERT INTO prices (id, product_id, active, unit_amount, currency, type, interval, interval_count, trial_period_days, metadata)
+VALUES (
+  'price_tamagui_support_monthly',
+  'prod_tamagui_support',
+  true,
+  100000,  -- equivalent to $1000 per tier
+  'usd',
+  'recurring',
+  'month',
+  1,
+  NULL,
+  '{"plan": "support", "description": "Each tier provides 2 hours of prioritized development."}'
+);


### PR DESCRIPTION
This PR cancels the old Takeout and Bento subscriptions and sets up new product and pricing records for our updated revenue model as part of #3182 

Changes include:
- Updating the subscriptions table to cancel active and trial subscriptions.
- Adding new product records in the products table for:
  - Tamagui Start (unified plan including Takeout, Bento, Theme AI, Chat AI, Discord #support, and Early access).
  - Tamagui Chat (private Discord room access for teams).
  - Tamagui Support (prioritized development support at $1000 per tier per month).
- Adding new price records in the prices table for:
  - Tamagui Start at $200 per year.
  - Tamagui Chat at $100 per month.
  - Tamagui Support at $1000 per tier per month.

## Note:
These SQL files have not been tested yet. Currently, we do not have a dedicated development environment and only have production data. We need to set up a dev environment and import the production data there for proper testing before rolling this out to production.
