### PR TITLE
Fix theme type-checking errors

### DIFF
--- a/code/packages/next-theme/src/NextThemeProvider.tsx
+++ b/code/packages/next-theme/src/NextThemeProvider.tsx
@@ -118,7 +118,7 @@ export const NextThemeProvider: React.FunctionComponent<ThemeProviderProps> = me
 
       const colorScheme =
         // If theme is forced to light or dark, use that
-        forcedTheme && colorSchemes.includes(forcedTheme)
+        forcedTheme && colorSchemes.includes(forcedTheme as "light" | "dark")
           ? forcedTheme
           : // If regular theme is light or dark
             theme && colorSchemes.includes(theme)
@@ -167,7 +167,7 @@ export const NextThemeProvider: React.FunctionComponent<ThemeProviderProps> = me
         toggle,
         forcedTheme,
         resolvedTheme: theme === 'system' ? resolvedTheme : theme,
-        themes: enableSystem ? [...themes, 'system'] : themes,
+        themes: enableSystem ? [...themes, 'system'] : themes as string[],
         systemTheme,
       } as const
       return value


### PR DESCRIPTION
Trying to upgrade Tamagui from ^1.120.0 to ^1.123.17 recently, I got some TS type-checking errors in Jonline's Tamagui FE: https://github.com/JonLatane/jonline/tree/main/frontends/tamagui

This should fix them, and should be pretty safe. 