### PR TITLE
Implement Bento bundle download in Account Modal

### DIFF
--- a/code/tamagui.dev/app/api/bento/zip-download+api.ts
+++ b/code/tamagui.dev/app/api/bento/zip-download+api.ts
@@ -1,0 +1,33 @@
+import type { Endpoint } from 'one'
+import { ensureAuth } from '~/features/api/ensureAuth'
+import { hasBentoAccess } from '~/features/bento/hasBentoAccess'
+import { getBentoBundleZip } from '~/features/auth/supabaseAdmin'
+
+export const GET: Endpoint = async (req) => {
+  // Extract the token from the Authorization header
+  const { user } = await ensureAuth({ req })
+
+  if (!user) {
+    return Response.json({ error: 'not_authenticated' }, { status: 401 })
+  }
+
+  // Check Bento access
+  const resultHasBentoAccess = await hasBentoAccess(user.id)
+  if (!resultHasBentoAccess) {
+    return Response.json({ error: 'not_authorized' }, { status: 401 })
+  }
+
+  try {
+    const zipFile = await getBentoBundleZip()
+
+    // Set appropriate headers for ZIP file download
+    const headers = new Headers()
+    headers.set('Content-Type', 'application/zip')
+    headers.set('Content-Disposition', 'attachment; filename=bento-bundle.zip')
+
+    return new Response(zipFile, { headers })
+  } catch (error) {
+    console.error('Error getting Bento bundle:', error)
+    return Response.json({ error: 'Failed to get Bento bundle' }, { status: 500 })
+  }
+}

--- a/code/tamagui.dev/features/auth/supabaseAdmin.ts
+++ b/code/tamagui.dev/features/auth/supabaseAdmin.ts
@@ -543,3 +543,16 @@ export async function populateStripeData() {
     console.info('populated price ', price.nickname)
   }
 }
+
+export const getBentoBundleZip = async () => {
+  const { data, error } = await supabaseAdmin.storage
+    .from('bento')
+    .download('bento-bundle.zip')
+
+  if (error) {
+    console.error('Error downloading Bento bundle:', error)
+    throw new Error('Failed to download Bento bundle')
+  }
+
+  return data
+}

--- a/code/tamagui.dev/features/bento/hasBentoAccess.ts
+++ b/code/tamagui.dev/features/bento/hasBentoAccess.ts
@@ -2,20 +2,28 @@ import { supabaseAdmin } from '~/features/auth/supabaseAdmin'
 
 export const hasBentoAccess = async (userId: string) => {
   const result = await supabaseAdmin
-    .from('product_ownership')
+    .from('subscriptions')
     .select(`
       *,
-      prices (
-        *,
-        products (
-          *
+      subscription_items (
+        prices (
+          *,
+          products (
+            name
+          )
         )
       )
     `)
     .eq('user_id', userId)
-    .eq('prices.products.name', 'Bento')
+  // .in('status', ['active', 'trialing'])
 
-  return Boolean(result?.data?.length)
+  return Boolean(
+    result.data?.some((subscription) =>
+      subscription.subscription_items?.some(
+        (item) => item.prices?.products?.name === 'Tamagui Pro'
+      )
+    )
+  )
 }
 
 export const hasBentoAccessV2 = async (userId: string) => {


### PR DESCRIPTION
- Add `getBentoBundleZip` function to fetch ZIP from Supabase storage
- Create new `/api/bento/zip-download` endpoint for authenticated downloads
- Update Account Modal's Bento download button to use the new endpoint