### PR TITLE
fix(slider): prevent slider-active-track to capture event instead of slider-track. so it gives different locationY

### DIFF
--- a/code/ui/slider/src/Slider.tsx
+++ b/code/ui/slider/src/Slider.tsx
@@ -341,6 +341,7 @@ export const SliderTrackActiveFrame = styled(SliderFrame, {
   name: 'SliderTrackActive',
   backgroundColor: '$background',
   position: 'absolute',
+  pointerEvents: 'box-none',
 })
 
 type SliderTrackActiveProps = GetProps<typeof SliderTrackActiveFrame>


### PR DESCRIPTION

## Current behavior

When you tap on the slider track in the vertical slider, it doesn't move properly. (Android, IOS)

https://github.com/user-attachments/assets/bfb5f178-1d0a-44f8-adbd-9cdd4e687eeb

## New Behavior

When you tap on the slider track, it moves correctly.  

https://github.com/user-attachments/assets/c2928cfa-9636-4caf-bc25-aef1d5cc91e5