### PR TITLE
Refine Purchase Flow

### DIFF
--- a/code/tamagui.dev/app/api/upgrade-subscription+api.ts
+++ b/code/tamagui.dev/app/api/upgrade-subscription+api.ts
@@ -2,7 +2,8 @@ import { apiRoute } from '~/features/api/apiRoute'
 import { ensureAuth } from '~/features/api/ensureAuth'
 import { stripe } from '~/features/stripe/stripe'
 
-const CHAT_SUPPORT_PRICE_ID = 'price_1NqKJ3FQGtHoG6xcQ8Y9X8X8'
+// Updated price ID for $200/month chat support
+const CHAT_SUPPORT_PRICE_ID = 'price_1QrukQFQGtHoG6xcMpB125IR' // Note: This should be updated with the actual price ID for $200/month
 const SUPPORT_TIER_PRICE_ID = 'price_1QrulKFQGtHoG6xcDs9OYTFu'
 
 export default apiRoute(async (req) => {

--- a/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
+++ b/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
@@ -37,6 +37,22 @@ import { useTakeoutStore } from './useTakeoutStore'
 
 class PurchaseModal {
   show = false
+  yearlyTotal = 0
+  monthlyTotal = 0
+  disableAutoRenew = false
+  chatSupport = false
+  supportTier = 0
+  selectedPrices = {
+    disableAutoRenew: false,
+    chatSupport: false,
+    supportTier: 0,
+  }
+}
+
+type SelectedPrices = {
+  disableAutoRenew: boolean
+  chatSupport: boolean
+  supportTier: number
 }
 
 export const purchaseModal = createStore(PurchaseModal)
@@ -111,42 +127,20 @@ const PurchaseModalContents = () => {
   }
 
   const handleCheckout = () => {
-    // Find the appropriate price IDs based on user selection
-    const selectedPrices = {
-      proPriceId: '',
-      supportPriceIds: [] as string[],
-    }
+    if (isProcessing) return
 
-    // Add Pro price based on auto-renew setting
-    const proPrice = disableAutoRenew
-      ? products?.pro.prices.find((p) => p.type === 'one_time')
-      : products?.pro.prices.find((p) => p.type === 'recurring')
-    if (proPrice) {
-      selectedPrices.proPriceId = proPrice.id
-    }
-
-    // Add support tier if selected
-    if (supportTier !== '0') {
-      const supportPrice = products?.support.prices.find(
-        (p) => p.description === `Tier ${supportTier}`
-      )
-      if (supportPrice) {
-        selectedPrices.supportPriceIds.push(supportPrice.id)
-      }
-    }
-
-    // Add chat support if selected
-    if (chatSupport) {
-      const chatSupportPrice = products?.support.prices.find(
-        (p) => p.description === 'Chat Support'
-      )
-      if (chatSupportPrice) {
-        selectedPrices.supportPriceIds.push(chatSupportPrice.id)
-      }
-    }
-
-    setSelectedPrices(selectedPrices)
+    // Show payment modal with current selections
     paymentModal.show = true
+    paymentModal.yearlyTotal = yearlyTotal
+    paymentModal.monthlyTotal = monthlyTotal
+    paymentModal.disableAutoRenew = disableAutoRenew
+    paymentModal.chatSupport = chatSupport
+    paymentModal.supportTier = Number(supportTier)
+    paymentModal.selectedPrices = {
+      disableAutoRenew, // Add this to replace proPriceId
+      chatSupport,
+      supportTier: Number(supportTier),
+    }
   }
 
   // Calculate direction for animation
@@ -154,7 +148,7 @@ const PurchaseModalContents = () => {
 
   // Calculate prices
   const basePrice = disableAutoRenew ? 400 : 240 // yearly base price
-  const chatSupportMonthly = chatSupport ? 100 : 0 // $100/month for chat support
+  const chatSupportMonthly = chatSupport ? 200 : 0 // $200/month for chat support
   const supportTierMonthly = Number(supportTier) * 800 // $800/month per tier
 
   // Keep yearly and monthly totals separate
@@ -527,9 +521,9 @@ const FaqTabContent = () => {
 
       <P>
         You get a private Discord channel just for your team and a highlighted role in
-        Discord chat. You can add up to 5 members to the private channel. We answer
+        Discord chat. You can add up to 2 members to the private channel. We answer
         questions within 2 business days, and will prioritize bugs above our base
-        subscribers.
+        subscribers. The Chat add-on costs $200/month.
       </P>
 
       <Question>What support do I get with Support tiers?</Question>
@@ -572,10 +566,10 @@ const SupportTabContent = ({
       </BigP>
 
       <YStack gap="$6" p="$4">
-        {/* <YStack gap="$3">
+        <YStack gap="$3">
           <XStack alignItems="center">
             <Label f={1} htmlFor="chat-support">
-              <P>Chat Support ($100/month)</P>
+              <P>Chat Support ($200/month)</P>
             </Label>
 
             <XStack maw={100}>
@@ -588,10 +582,10 @@ const SupportTabContent = ({
           </XStack>
 
           <P maw={500} size="$5" lineHeight="$6" o={0.8}>
-            A private Discord room just for your team, with responses prioritized over our
-            community chat.
+            A private Discord room just for your team with 2 invites, with responses
+            prioritized over our community chat.
           </P>
-        </YStack> */}
+        </YStack>
 
         <YStack gap="$3">
           <XStack ov="hidden" alignItems="center">
@@ -622,8 +616,9 @@ const SupportTabContent = ({
           </XStack>
 
           <P size="$5" lineHeight="$6" maw={500} o={0.8}>
-            Each tier adds 2 hours of prioritized development each month, and puts your
-            messages higher in our response queue.
+            Each tier adds 2 hours of prioritized development each month, puts your
+            messages higher in our response queue, and includes additional chat invites
+            (Tier 1: 6 invites, Tier 2: 10 invites, Tier 3: 14 invites).
           </P>
         </YStack>
       </YStack>

--- a/code/tamagui.dev/supabase/plan-migrations/06_insert_price_tamagui_chat.sql
+++ b/code/tamagui.dev/supabase/plan-migrations/06_insert_price_tamagui_chat.sql
@@ -1,11 +1,11 @@
 -- This file adds a price record for the "Tamagui Chat" add-on.
--- The add-on is priced at $100 per month.
+-- The add-on is priced at $200 per month.
 INSERT INTO prices (id, product_id, active, unit_amount, currency, type, interval, interval_count, trial_period_days, metadata)
 VALUES (
   'price_1QrukQFQGtHoG6xcMpB125IR',
   'prod_RlRdUMAas8elvJ', -- Tamagui Chat
   true,
-  10000,  -- equivalent to $100
+  20000,  -- equivalent to $200
   'usd',
   'recurring',
   'month',


### PR DESCRIPTION
1. Fixed the one-time purchase flow ($400) which was incorrectly handled
2. Added Chat Support as a new monthly service option ($200/month), being handled through upgrade-subscription API