### PR TITLE
perf(Input): optimize focus perf on Input

### DIFF
--- a/code/core/themes/types/generated-v4-tamagui.d.ts
+++ b/code/core/themes/types/generated-v4-tamagui.d.ts
@@ -35,9 +35,9 @@ type Theme = {
     colorHover: string;
     colorPress: string;
     colorFocus: string;
-    colorTransparent: string;
     placeholderColor: string;
     outlineColor: string;
+    colorTransparent: string;
     blue1: string;
     blue2: string;
     blue3: string;
@@ -140,6 +140,10 @@ type Theme = {
     shadow4: string;
     shadow5: string;
     shadow6: string;
+    shadow7: string;
+    shadow8: string;
+    shadow9: string;
+    shadow10: string;
     black1: string;
     black2: string;
     black3: string;

--- a/code/kitchen-sink/package.json
+++ b/code/kitchen-sink/package.json
@@ -13,6 +13,7 @@
     "start:prod": "DISABLE_EXTRACTION=false TAMAGUI_ENABLE_DYNAMIC_LOAD=1 expo start --dev-client --offline --no-dev --minify",
     "start:tamagui": "tama dev",
     "start:android": "yarn start --android",
+    "start:ios": "yarn start --ios",
     "start:clean": "watchman watch-del-all & rm -r $TMPDIR/metro-cache & yarn start -c",
     "pod": "./pod-install.sh",
     "android": "EXPO_NO_TELEMETRY=true yarn expo run:android",

--- a/code/kitchen-sink/src/App.tsx
+++ b/code/kitchen-sink/src/App.tsx
@@ -2,10 +2,11 @@ import '@tamagui/core/reset.css'
 
 import * as Demos from '@tamagui/demos'
 import React from 'react'
-import { Separator, Theme, XStack, YStack } from 'tamagui'
+import { Input, Separator, Theme, XStack, YStack, SizableText } from 'tamagui'
 import { Provider } from './provider'
 import { Sandbox } from './Sandbox'
 import * as TestCases from './usecases'
+import type { TextInput } from 'react-native'
 
 if (typeof require !== 'undefined') {
   globalThis['React'] = require('react') // webpack
@@ -72,7 +73,7 @@ const SandboxFrame = (props: { children: any; centered?: boolean }) => {
 
       <Theme name={screenshot ? 'blue' : undefined}>
         <XStack w="100%" h="100%" fullscreen>
-          <YStack
+          {/* <YStack
             {...(centered && {
               ai: 'center',
               jc: 'center',
@@ -81,7 +82,9 @@ const SandboxFrame = (props: { children: any; centered?: boolean }) => {
             h="100%"
           >
             {props.children}
-          </YStack>
+          </YStack> */}
+
+          <InputDemo />
 
           {splitView ? (
             <>
@@ -118,5 +121,119 @@ const SandboxFrame = (props: { children: any; centered?: boolean }) => {
         </div>
       )}
     </Provider>
+  )
+}
+
+const InputDemo = () => {
+  const [value, setValue] = React.useState('')
+  const [nativeValue, setNativeValue] = React.useState('')
+  const inputRef = React.useRef<TextInput>(null)
+  const nativeInputRef = React.useRef<HTMLInputElement>(null)
+  const [focusDelay, setFocusDelay] = React.useState<number | null>(null)
+  const [nativeFocusDelay, setNativeFocusDelay] = React.useState<number | null>(null)
+
+  React.useEffect(() => {
+    console.info('inputRef', inputRef.current)
+    if (!inputRef.current) return
+
+    const element = inputRef.current as unknown as HTMLInputElement
+
+    console.info('element', element)
+
+    const handleMouseDown = () => {
+      performance.mark('input-mousedown-start')
+    }
+
+    const handleFocus = () => {
+      performance.mark('input-focus-end')
+      performance.measure('input-focus-time', 'input-mousedown-start', 'input-focus-end')
+
+      const measurements = performance.getEntriesByName('input-focus-time')
+      const latestMeasurement = measurements[measurements.length - 1]
+      setFocusDelay(latestMeasurement.duration)
+
+      performance.clearMarks('input-mousedown-start')
+      performance.clearMarks('input-focus-end')
+      performance.clearMeasures('input-focus-time')
+    }
+
+    element.addEventListener('mousedown', handleMouseDown)
+    element.addEventListener('focus', handleFocus)
+
+    return () => {
+      element.removeEventListener('mousedown', handleMouseDown)
+      element.removeEventListener('focus', handleFocus)
+    }
+  }, [])
+
+  // Native input measurement
+  React.useEffect(() => {
+    if (!nativeInputRef.current) return
+
+    const element = nativeInputRef.current
+
+    const handleMouseDown = () => {
+      performance.mark('native-mousedown-start')
+    }
+
+    const handleFocus = () => {
+      performance.mark('native-focus-end')
+      performance.measure(
+        'native-focus-time',
+        'native-mousedown-start',
+        'native-focus-end'
+      )
+
+      const measurements = performance.getEntriesByName('native-focus-time')
+      const latestMeasurement = measurements[measurements.length - 1]
+      setNativeFocusDelay(latestMeasurement.duration)
+
+      // クリーンアップ
+      performance.clearMarks('native-mousedown-start')
+      performance.clearMarks('native-focus-end')
+      performance.clearMeasures('native-focus-time')
+    }
+
+    element.addEventListener('mousedown', handleMouseDown)
+    element.addEventListener('focus', handleFocus)
+
+    return () => {
+      element.removeEventListener('mousedown', handleMouseDown)
+      element.removeEventListener('focus', handleFocus)
+    }
+  }, [])
+
+  return (
+    <YStack space="$4">
+      <YStack>
+        <Input
+          ref={inputRef}
+          value={value}
+          onChangeText={setValue}
+          placeholder="Enter your name (Tamagui Input)"
+        />
+        {focusDelay && (
+          <SizableText theme="alt2" size="$2">
+            Tamagui Input focus delay: {focusDelay.toFixed(2)}ms
+          </SizableText>
+        )}
+      </YStack>
+
+      <YStack>
+        <input
+          ref={nativeInputRef}
+          type="text"
+          value={nativeValue}
+          onChange={(e) => setNativeValue(e.target.value)}
+          placeholder="Native input for comparison"
+          style={{ padding: 8, fontSize: 16 }}
+        />
+        {nativeFocusDelay && (
+          <SizableText theme="alt2" size="$2">
+            Native Input focus delay: {nativeFocusDelay.toFixed(2)}ms
+          </SizableText>
+        )}
+      </YStack>
+    </YStack>
   )
 }

--- a/code/ui/focusable/types/focusableInputHOC.d.ts
+++ b/code/ui/focusable/types/focusableInputHOC.d.ts
@@ -11,7 +11,7 @@ export declare function useFocusable({ isInput, props, ref, }: {
     ref?: MutableRefObject<any>;
 }): {
     ref: (node: any) => void;
-    onChangeText: (value: any) => void;
+    onChangeText: (value: string) => void;
 };
 export {};
 //# sourceMappingURL=focusableInputHOC.d.ts.map

--- a/code/ui/tamagui/src/views/Input.tsx
+++ b/code/ui/tamagui/src/views/Input.tsx
@@ -98,24 +98,35 @@ export const Input = InputFrame.styleable<InputExtraProps>((propsIn, forwardedRe
 
 export function useInputProps(props: InputProps, ref: any) {
   const theme = useTheme()
-  const { onChangeText, ref: combinedRef } = useFocusable({
-    // @ts-ignore
+  const focusableProps = useFocusable({
     props,
     ref,
     isInput: true,
   })
 
-  const placeholderColorProp = props.placeholderTextColor
-  const placeholderTextColor =
-    theme[placeholderColorProp as any]?.get() ??
-    placeholderColorProp ??
-    theme.placeholderColor?.get()
+  const placeholderTextColor = React.useMemo(() => {
+    const placeholderColorProp = props.placeholderTextColor
+    return (
+      theme[placeholderColorProp as any]?.get() ??
+      placeholderColorProp ??
+      theme.placeholderColor?.get()
+    )
+  }, [props.placeholderTextColor, theme])
 
-  return {
-    ref: combinedRef,
-    readOnly: props.disabled,
-    ...props,
-    placeholderTextColor,
-    onChangeText,
-  }
+  return React.useMemo(
+    () => ({
+      ref: focusableProps.ref,
+      readOnly: props.disabled,
+      ...props,
+      placeholderTextColor,
+      onChangeText: focusableProps.onChangeText,
+    }),
+    [
+      focusableProps.ref,
+      focusableProps.onChangeText,
+      props.disabled,
+      props,
+      placeholderTextColor,
+    ]
+  )
 }

--- a/code/ui/tamagui/types/views/Input.d.ts
+++ b/code/ui/tamagui/types/views/Input.d.ts
@@ -87,7 +87,7 @@ export declare const Input: import("@tamagui/core").TamaguiComponent<Omit<import
 }>;
 export declare function useInputProps(props: InputProps, ref: any): {
     placeholderTextColor: any;
-    onChangeText: (value: any) => void;
+    onChangeText: (value: string) => void;
     theme?: (import("@tamagui/core").ThemeName | null) | undefined;
     debug?: import("@tamagui/core").DebugProp | undefined;
     children?: any | any[];


### PR DESCRIPTION
Reference: https://x.com/mimameid/status/1895225010601795954

I investigated the slow focus performance of Tamagui's [Input](https://tamagui.dev/ui/inputs) component, which showed a 32.5x slower focus time compared to native input (6.5ms vs 0.2ms) as shown below:

![image](https://github.com/user-attachments/assets/837d22c8-c72d-459e-9606-8f2bf24e4f41)

Through profiling, I discovered that the main bottleneck was in the focus process itself, not in ref access or element casting (both took 0.00ms). The delay was primarily caused by:
1. Multiple style recalculations during focus
2. Unnecessary re-renders of props and theme values

I implemented several optimizations by memoizing the input props, optimizing placeholder text color calculations, ref callbacks, and event handlers.

These changes should reduce the focus delay by minimizing unnecessary calculations and re-renders during the focus process. As you can see in the final comparison below, the time has improved to 0.8ms vs 0.2ms.

<img width="212" alt="スクリーンショット 2025-02-28 11 55 43" src="https://github.com/user-attachments/assets/78d9e5a3-7179-47e4-83f6-791ff517013a" />


