### PR TITLE
fix(core): deleted color from tokenCats array because it is not existed in config v3 and v4.

### DIFF
--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -330,7 +330,7 @@ function getVariantDefinition(variant: any, value: any, conf: TamaguiInternalCon
   if (value != null) {
     const { tokensParsed } = conf
     for (const { name, spreadName } of tokenCats) {
-      if (spreadName in variant && value in tokensParsed[name]) {
+      if (spreadName in variant && name in tokensParsed && value in tokensParsed[name]) {
         return variant[spreadName]
       }
     }


### PR DESCRIPTION
Closes #3177

## current behavior 

if you add the following context and variant to any component.
```

export const context = createStyledContext({
  color: '',
})


const StyledView = styled(View, {
  context,

  variants: {
       color: {
        '...color': () => {
          return {}
        },
      },
    }
})

```

it will give you this error 

TypeError: Cannot use 'in' operator to search for '' in undefined. 

This issue happens because config V3 and V4 tokens don't include color, and this snippet code tries to check the color

```
 const { tokensParsed } = conf
    for (const { name, spreadName } of tokenCats) {
      if (spreadName in variant && value in tokensParsed[name]) {
        return variant[spreadName]
      }
    }
```
so `tokensParsed[name]` is undefined  and  `value in tokensParsed[name]` crash the app.

## New behavior 

I removed the color from the tokenCats array, which will no longer check for the color, and it works nicely.


@natew Let me know if there's anything you'd like me to adjust!
