### PR TITLE
feat: Improve Parity Deals banner detection and data extraction

### DIFF
--- a/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
+++ b/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
@@ -397,7 +397,7 @@ const PurchaseModalContents = () => {
                           p="$2"
                         >
                           <Paragraph size="$3" color="$color11" textWrap="balance">
-                            {parityDeals.countryFlag} Use code{' '}
+                            You are from {parityDeals.country}.{`\n`} Use code{' '}
                             <Text fontWeight="bold" fontFamily="$mono" color="$color12">
                               {parityDeals.couponCode}
                             </Text>{' '}

--- a/code/tamagui.dev/hooks/__tests__/useParityDiscount.test.ts
+++ b/code/tamagui.dev/hooks/__tests__/useParityDiscount.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, act } from '@testing-library/react'
+import { useParityDiscount } from '../useParityDiscount'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+describe('useParityDiscount', () => {
+  const mockBannerHTML = `
+    <div class="parity-banner">
+      <div class="parity-banner-inner">
+        Looks like you are from <b>Japan</b>. If you need it, use code <b>"pdsiurjf20"</b> to get <b>20%</b> off your subscription at checkout.
+      </div>
+      <button type="button" class="parity-banner-close-btn" aria-label="Close">
+        <svg viewBox="0 0 24 24" focusable="false" aria-hidden="true">
+          <path fill="currentColor" d="M.439,21.44a1.5,1.5,0,0,0,2.122,2.121L11.823,14.3a.25.25,0,0,1,.354,0l9.262,9.263a1.5,1.5,0,1,0,2.122-2.121L14.3,12.177a.25.25,0,0,1,0-.354l9.263-9.262A1.5,1.5,0,0,0,21.439.44L12.177,9.7a.25.25,0,0,1-.354,0L2.561.44A1.5,1.5,0,0,0,.439,2.561L9.7,11.823a.25.25,0,0,1,0,.354Z"></path>
+        </svg>
+      </button>
+    </div>
+  `
+
+  beforeEach(() => {
+    // Clear the body before each test
+    document.body.innerHTML = ''
+  })
+
+  it('should extract parity deals data when banner appears', async () => {
+    const { result } = renderHook(() => useParityDiscount())
+
+    // Initially, parityDeals should be null
+    expect(result.current.parityDeals).toBeNull()
+
+    // Simulate banner injection
+    act(() => {
+      document.body.innerHTML = mockBannerHTML
+    })
+
+    // Wait for MutationObserver to fire
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // Check if the data was extracted correctly
+    expect(result.current.parityDeals).toEqual({
+      country: 'Japan',
+      couponCode: 'pdsiurjf20',
+      discountPercentage: '20',
+    })
+
+    // Check if the banner was removed
+    expect(document.querySelector('.parity-banner')).toBeNull()
+  })
+
+  it('should handle malformed banner content', () => {
+    const { result } = renderHook(() => useParityDiscount())
+
+    // Inject malformed banner
+    act(() => {
+      document.body.innerHTML = `
+        <div class="parity-banner">
+          <div class="parity-banner-inner">
+            Invalid content
+          </div>
+        </div>
+      `
+    })
+
+    // parityDeals should remain null for invalid content
+    expect(result.current.parityDeals).toBeNull()
+  })
+
+  it('should cleanup observer on unmount', () => {
+    const disconnectSpy = vi.spyOn(MutationObserver.prototype, 'disconnect')
+    const { unmount } = renderHook(() => useParityDiscount())
+
+    unmount()
+
+    expect(disconnectSpy).toHaveBeenCalled()
+    disconnectSpy.mockRestore()
+  })
+
+  it('should ignore non-parity-banner elements', () => {
+    const { result } = renderHook(() => useParityDiscount())
+
+    act(() => {
+      document.body.innerHTML = `
+        <div class="some-other-banner">
+          <div class="parity-banner-inner">
+            Looks like you are from <b>Japan</b>. If you need it, use code <b>"pdsiurjf20"</b> to get <b>20%</b> off your subscription at checkout.
+          </div>
+        </div>
+      `
+    })
+
+    expect(result.current.parityDeals).toBeNull()
+  })
+})

--- a/code/tamagui.dev/hooks/useParityDiscount.ts
+++ b/code/tamagui.dev/hooks/useParityDiscount.ts
@@ -1,42 +1,98 @@
-import { useMemo } from 'react'
-import useSWR from 'swr'
+import { useEffect, useRef, useState } from 'react'
 import z from 'zod'
 
-/**
- * Since we moved the Purchase page to a modal, we cannot set path based parity deals.
- * Therefore, we have to manually fetch the parity deals from the API and apply it to the purchase modal manually.
- * This hook is used to fetch the parity deals and apply it to the purchase modal.
- */
-export const useParityDiscount = () => {
-  const { data, error } = useSWR('/api/parity-discount', fetcher)
-
-  const parityDeals = useMemo(() => {
-    if (!data) return null
-    const parsedData = ParityDealsSchema.safeParse(data)
-    if (!parsedData.success) {
-      console.error('Failed to parse parity deals', parsedData.error)
-      return null
-    }
-    return parsedData.data
-  }, [data])
-
-  return { parityDeals, error }
-}
-
-const fetcher = async (url: string) => {
-  const isLocal = process.env.NODE_ENV === 'development'
-  const baseUrl = isLocal
-    ? `${window.location.origin}/api/parity-discount`
-    : `https://api.paritydeals.com/api/v1/deals/discount/?url=${window.location.origin}`
-
-  const response = await fetch(baseUrl)
-  const data = await response.json()
-  return data
-}
-
 const ParityDealsSchema = z.object({
+  country: z.string(),
   couponCode: z.string(),
   discountPercentage: z.string(),
-  countryFlag: z.string(),
-  countryFlagSvg: z.string(),
 })
+
+type ParityDeals = z.infer<typeof ParityDealsSchema>
+
+/**
+ * A hook that detects and extracts data from Parity Deals banner.
+ * When the banner is detected, it extracts the country, coupon code, and discount information,
+ * then removes the original banner from the DOM.
+ *
+ * @returns An object containing the extracted parity deals data
+ * @example
+ * ```tsx
+ * const { parityDeals } = useParityDiscount()
+ * if (parityDeals) {
+ *   console.log(parityDeals.country, parityDeals.couponCode, parityDeals.discountPercentage)
+ * }
+ * ```
+ */
+export const useParityDiscount = () => {
+  const observerRef = useRef<MutationObserver | null>(null)
+  const [parityDeals, setParityDeals] = useState<ParityDeals | null>(null)
+
+  /**
+   * If the banner is present, the text is like this:
+   * `Looks like you are from <b>Japan</b>. If you need it, use code <b>"pdsiurjf20"</b> to get <b>20%</b> off your subscription at checkout.`
+   * This function extracts the country, coupon code, and discount percentage from the banner.
+   */
+  const extractParityData = (element: Element): ParityDeals | null => {
+    const bannerInner = element.querySelector('.parity-banner-inner')
+    if (!bannerInner) return null
+
+    const boldElements = bannerInner.querySelectorAll('b')
+    if (boldElements.length < 3) return null
+
+    const [country, code, discount] = Array.from(boldElements).map((el) => el.textContent)
+
+    if (!country || !code || !discount) return null
+
+    const result = ParityDealsSchema.safeParse({
+      country: country.trim(),
+      couponCode: code.replace(/"/g, '').trim(),
+      discountPercentage: discount.replace('%', '').trim(),
+    })
+
+    return result.success ? result.data : null
+  }
+
+  useEffect(() => {
+    // Check for existing banner first
+    const existingBanner = document.querySelector('.parity-banner')
+    if (existingBanner instanceof HTMLElement) {
+      const data = extractParityData(existingBanner)
+      if (data) {
+        setParityDeals(data)
+        existingBanner.remove()
+        return // No need to observe if we already found the banner
+      }
+    }
+
+    // If no existing banner, observe for dynamically added ones
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        mutation.addedNodes.forEach((node) => {
+          if (node instanceof HTMLElement && node.classList.contains('parity-banner')) {
+            const data = extractParityData(node)
+            if (data) {
+              setParityDeals(data)
+              node.remove()
+              observer.disconnect()
+            }
+          }
+        })
+      }
+    })
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    })
+
+    observerRef.current = observer
+
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect()
+      }
+    }
+  }, [])
+
+  return { parityDeals }
+}


### PR DESCRIPTION
Add a new hook to handle Parity Deals banner detection and data extraction.
The hook detects the banner on mount or dynamic injection, extracts country and discount information, and removes the original banner.