### PR TITLE
fix(Select): conditionally render overlay to prevent scroll issues

### DIFF
--- a/code/ui/select/src/SelectContent.tsx
+++ b/code/ui/select/src/SelectContent.tsx
@@ -48,16 +48,23 @@ export const SelectContent = ({
     return <>{contents}</>
   }
 
+  const shouldUseOverlay = !context.disablePreventBodyScroll && !!context.open && !touch
+
+  const focusWrappedContents = (
+    <FocusScope loop enabled={!!context.open} trapped {...focusScopeProps}>
+      {contents}
+    </FocusScope>
+  )
+
   return (
     <FloatingPortal>
-      <FloatingOverlay
-        style={overlayStyle}
-        lockScroll={!context.disablePreventBodyScroll && !!context.open && !touch}
-      >
-        <FocusScope loop enabled={!!context.open} trapped {...focusScopeProps}>
-          {contents}
-        </FocusScope>
-      </FloatingOverlay>
+      {shouldUseOverlay ? (
+        <FloatingOverlay style={overlayStyle} lockScroll>
+          {focusWrappedContents}
+        </FloatingOverlay>
+      ) : (
+        focusWrappedContents
+      )}
     </FloatingPortal>
   )
 }


### PR DESCRIPTION
closes #3200 

## Current behavior

The select dropdown remains fixed while scrolling when `disablePreventBodyScroll` is set to `true`.


https://github.com/user-attachments/assets/d493b544-ff99-4cd7-ae2d-f31383dd12a2


## New behavior 

When `disablePreventBodyScroll` is set to `true`, the select dropdown does not remain fixed while scrolling. However, when set to `false`, it locks the screen.

https://github.com/user-attachments/assets/b90b807f-c17c-4694-97cb-8ccf438da34b
