### PR TITLE
Update react-native deep imports for 0.79 compatibility

### DIFF
--- a/code/core/core/src/getBaseViews.native.ts
+++ b/code/core/core/src/getBaseViews.native.ts
@@ -6,7 +6,8 @@ export function getBaseViews() {
 
   if (process.env.NODE_ENV !== 'test') {
     View = require('react-native/Libraries/Components/View/ViewNativeComponent').default
-    TextAncestor = require('react-native/Libraries/Text/TextAncestor')
+    const TextAncestorModule = require('react-native/Libraries/Text/TextAncestor')
+    TextAncestor = TextAncestorModule.default ?? TextAncestor
   }
 
   if (!View) {

--- a/code/ui/portal/src/Portal.native.tsx
+++ b/code/ui/portal/src/Portal.native.tsx
@@ -10,14 +10,18 @@ import type { PortalProps } from './PortalProps'
 const createPortal = (() => {
   if (IS_FABRIC) {
     try {
-      return require('react-native/Libraries/Renderer/shims/ReactFabric').createPortal
+      const ReactFabricShimModule = require('react-native/Libraries/Renderer/shims/ReactFabric');
+
+      return ReactFabricShimModule.default?.createPortal ?? ReactFabricShimModule.createPortal;
     } catch (err) {
       console.info(`Note: error importing portal, defaulting to non-native portals`, err)
       return null
     }
   }
   try {
-    return require('react-native/Libraries/Renderer/shims/ReactNative').createPortal
+    const ReactNativeShimModule = require('react-native/Libraries/Renderer/shims/ReactNative').createPortal
+
+    return ReactNativeShimModule.default?.createPortal ?? ReactNativeShimModule.createPortal;
   } catch (err) {
     console.info(`Note: error importing portal, defaulting to non-native portals`, err)
     return null


### PR DESCRIPTION
## Summary

In the incoming React Native 0.79 release, we've converted a number of internal modules to `export` syntax — affecting usages with `require()`. This PR attempts to update these imports ahead of time, to work with both versions.

💡 Secondary note: In a future release, we are intending to omit each of these deep-imported modules from the public API of React Native. There will be a consultation period on opening up new APIs via the root `'react-native'` exports. Some of the uses in this library may need `@ts-ignores` in future.

## Test plan

**Needs testing**. CI should pass for integration with current RN versions.