### PR TITLE
fix(stacks): prevent overriding stack direction

### DIFF
--- a/code/ui/stacks/src/Stacks.tsx
+++ b/code/ui/stacks/src/Stacks.tsx
@@ -3,9 +3,12 @@ import { View, styled } from '@tamagui/core'
 
 import { getElevation } from './getElevation'
 
-export type YStackProps = GetProps<typeof YStack>
+// Base type for stacks
+type BaseStackProps = GetProps<typeof View>
 
-export type XStackProps = YStackProps
+// Remove flexDirection from allowed props
+export type YStackProps = Omit<BaseStackProps, 'flexDirection'>
+export type XStackProps = Omit<BaseStackProps, 'flexDirection'>
 export type ZStackProps = YStackProps
 
 export const fullscreenStyle = {
@@ -51,7 +54,8 @@ const variants = {
  * @see — Docs https://tamagui.dev/ui/stacks#xstack-ystack-zstack
  */
 export const YStack = styled(View, {
-  flexDirection: 'column',
+  // Set flexDirection in the style object
+  flexDirection: 'column' as const,
   variants,
 })
 
@@ -62,7 +66,8 @@ YStack['displayName'] = 'YStack'
  * @see — Docs https://tamagui.dev/ui/stacks#xstack-ystack-zstack
  */
 export const XStack = styled(View, {
-  flexDirection: 'row',
+  // Set flexDirection in the style object
+  flexDirection: 'row' as const,
   variants,
 })
 


### PR DESCRIPTION
## Description
This PR prevents overriding the flexDirection prop for XStack and YStack components, ensuring their intended layouts remain consistent.

Specifically:

- XStack is always horizontal (flexDirection: 'row')
- YStack is always vertical (flexDirection: 'column')

This change enforces semantic correctness:

- Use XStack exclusively for horizontal layouts
- Use YStack exclusively for vertical layouts

## Motivation: Why am I making this change ? 
I am using Tamagui for a product I am building and came across this piece of code. This was an innocent mistake and made me wonder  why is it even allowed and whether I should add an ESLint rule to prevent flexDirection on YStack and XStack, or simply fix it at the source. I decided to go with the latter, and here I am.
 
![WhatsApp Image Mar 17 2025](https://github.com/user-attachments/assets/e7fdf3f3-f5dc-4c14-9d0b-b06842ef9391)


Changes made:
1. Created a BaseStackProps type from View props
2. Removed flexDirection from allowed props using TypeScript's Omit
3. Kept the flexDirection style definitions with 'as const' to ensure type safety
4. Updated types to avoid circular references

This enforces the semantic meaning of the components:
- If you need horizontal layout, use XStack
- If you need vertical layout, use YStack

## Type of change
- [x] Bug fix (prevents misuse of components)
- [x] Enhancement (improves type safety)

## Testing
Existing tests should pass as the core functionality remains the same. The change only prevents a prop that shouldn't be used anyway. 

## Breaking Change
While this technically could be considered breaking if someone was (incorrectly) relying on changing stack directions, it's actually fixing behavior to match the intended design of these components. That said, this change could be part of the next release version.