### PR TITLE
docs: migrate legacy `space` for `gap` on Inputs

### DIFF
--- a/code/tamagui.dev/data/docs/components/new-inputs/1.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/new-inputs/1.0.0.mdx
@@ -32,7 +32,7 @@ import { Input } from 'tamagui'
 
 export const App = () => (
   // Accepts size and style properties directly
-  <Input size="$4" borderWidth={2} />
+  <Input gap="$4" borderWidth={2} />
 )
 ```
 
@@ -45,6 +45,6 @@ import { TextArea } from 'tamagui'
 
 export const App = () => (
   // Accepts size and style properties directly
-  <TextArea size="$4" borderWidth={2} />
+  <TextArea gap="$4" borderWidth={2} />
 )
 ```


### PR DESCRIPTION
`space` is deprecated

![CleanShot 2025-03-18 at 16 38 20](https://github.com/user-attachments/assets/cc569238-38f7-4773-a638-89ff2c8f57c1)
