### PR TITLE
fix: import of TextAncestorModule

### DIFF
--- a/code/core/core/src/getBaseViews.native.ts
+++ b/code/core/core/src/getBaseViews.native.ts
@@ -7,7 +7,7 @@ export function getBaseViews() {
   if (process.env.NODE_ENV !== 'test') {
     View = require('react-native/Libraries/Components/View/ViewNativeComponent').default
     const TextAncestorModule = require('react-native/Libraries/Text/TextAncestor')
-    TextAncestor = TextAncestorModule.default ?? TextAncestor
+    TextAncestor = TextAncestorModule.default ?? TextAncestorModule
   }
 
   if (!View) {


### PR DESCRIPTION
Will close [3347](https://github.com/tamagui/tamagui/issues/3347)

### What was done

- fix issue where TextAncestor is not properly imported


### Notes

It looks like an error is coming from this potentially now:
```
console.js:614 Warning: Rendering <Context.Consumer.Consumer> is not supported and will be removed in a future major release. Did you mean to render <Context.Consumer> instead?
```
This may need more investigation