### PR TITLE
chore(Slider): use new styledContext and make it easier to customize

### DIFF
--- a/code/ui/slider/src/Slider.tsx
+++ b/code/ui/slider/src/Slider.tsx
@@ -315,7 +315,7 @@ export const SliderTrackFrame = styled(SliderFrame, {
 const SliderTrack = React.forwardRef<SliderTrackElement, SliderTrackProps>(
   (props: ScopedProps<SliderTrackProps>, forwardedRef) => {
     const { __scopeSlider, ...trackProps } = props
-    const context = useSliderContext(TRACK_NAME, __scopeSlider)
+    const context = useSliderContext(__scopeSlider)
     return (
       <SliderTrackFrame
         data-disabled={context.disabled ? '' : undefined}
@@ -349,8 +349,8 @@ type SliderTrackActiveProps = GetProps<typeof SliderTrackActiveFrame>
 const SliderTrackActive = React.forwardRef<View, SliderTrackActiveProps>(
   (props: ScopedProps<SliderTrackActiveProps>, forwardedRef) => {
     const { __scopeSlider, ...rangeProps } = props
-    const context = useSliderContext(RANGE_NAME, __scopeSlider)
-    const orientation = useSliderOrientationContext(RANGE_NAME, __scopeSlider)
+    const context = useSliderContext(__scopeSlider)
+    const orientation = useSliderOrientationContext(__scopeSlider)
     const ref = React.useRef<View>(null)
     const composedRefs = useComposedRefs(forwardedRef, ref)
     const valuesCount = context.values.length
@@ -446,9 +446,9 @@ export interface SliderThumbProps extends SizableStackProps, SliderThumbExtraPro
 
 const SliderThumb = SliderThumbFrame.styleable<SliderThumbExtraProps>(
   function SliderThumb(props: ScopedProps<SliderThumbProps>, forwardedRef) {
-    const { __scopeSlider, index, size: sizeProp, ...thumbProps } = props
-    const context = useSliderContext(THUMB_NAME, __scopeSlider)
-    const orientation = useSliderOrientationContext(THUMB_NAME, __scopeSlider)
+    const { __scopeSlider, index, circular, size: sizeProp, ...thumbProps } = props
+    const context = useSliderContext(__scopeSlider)
+    const orientation = useSliderOrientationContext(__scopeSlider)
     const [thumb, setThumb] = React.useState<TamaguiElement | null>(null)
     const composedRefs = useComposedRefs(forwardedRef, setThumb as any)
 
@@ -516,6 +516,7 @@ const SliderThumb = SliderThumbFrame.styleable<SliderThumbExtraProps>(
           [orientation.startEdge]: `${percent}%`,
         }}
         size={sizeIn}
+        circular={circular}
         {...thumbProps}
         onLayout={(e) => {
           setSize(e.nativeEvent.layout[orientation.sizeProp])

--- a/code/ui/slider/src/SliderImpl.tsx
+++ b/code/ui/slider/src/SliderImpl.tsx
@@ -81,7 +81,7 @@ export const SliderImpl = React.forwardRef<View, SliderImplProps>(
       onStepKeyDown,
       ...sliderProps
     } = props
-    const context = useSliderContext(SLIDER_NAME, __scopeSlider)
+    const context = useSliderContext(__scopeSlider)
     return (
       <SliderFrame
         size="$4"

--- a/code/ui/slider/src/constants.tsx
+++ b/code/ui/slider/src/constants.tsx
@@ -1,29 +1,35 @@
-import type { SizeTokens } from '@tamagui/core'
-import { createContextScope } from '@tamagui/create-context'
+import { createStyledContext, type SizeTokens } from '@tamagui/core'
 
 import type { Direction, SliderContextValue } from './types'
 
 export const SLIDER_NAME = 'Slider'
 
-export const [createSliderContext, createSliderScope] = createContextScope(SLIDER_NAME)
+export const SliderContext = createStyledContext<SliderContextValue>({
+  size: '$true',
+  min: 0,
+  max: 100,
+  orientation: 'horizontal',
+} as SliderContextValue)
 
-export const [SliderProvider, useSliderContext] =
-  createSliderContext<SliderContextValue>(SLIDER_NAME)
+export const { Provider: SliderProvider, useStyledContext: useSliderContext } =
+  SliderContext
 
-export const [SliderOrientationProvider, useSliderOrientationContext] =
-  createSliderContext<{
-    startEdge: 'bottom' | 'left' | 'right'
-    endEdge: 'top' | 'right' | 'left'
-    sizeProp: 'width' | 'height'
-    size: number | SizeTokens
-    direction: number
-  }>(SLIDER_NAME, {
-    startEdge: 'left',
-    endEdge: 'right',
-    sizeProp: 'width',
-    size: 0,
-    direction: 1,
-  })
+export const {
+  Provider: SliderOrientationProvider,
+  useStyledContext: useSliderOrientationContext,
+} = createStyledContext<{
+  startEdge: 'bottom' | 'left' | 'right'
+  endEdge: 'top' | 'right' | 'left'
+  sizeProp: 'width' | 'height'
+  size: number | SizeTokens
+  direction: number
+}>({
+  startEdge: 'left',
+  endEdge: 'right',
+  sizeProp: 'width',
+  size: 0,
+  direction: 1,
+})
 
 export const PAGE_KEYS = ['PageUp', 'PageDown']
 export const ARROW_KEYS = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight']

--- a/code/ui/slider/src/index.ts
+++ b/code/ui/slider/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Slider'
+export { SliderContext } from './constants'
 // for static extract to find, must export
 export { SliderFrame } from './SliderImpl'
 export type {

--- a/code/ui/slider/src/types.ts
+++ b/code/ui/slider/src/types.ts
@@ -2,7 +2,7 @@ import type { GestureReponderEvent, SizeTokens, TamaguiElement } from '@tamagui/
 import type { Scope } from '@tamagui/create-context'
 import type { SizableStackProps } from '@tamagui/stacks'
 
-export type ScopedProps<P> = P & { __scopeSlider?: Scope }
+export type ScopedProps<P> = P & { __scopeSlider?: string }
 
 export type Direction = 'ltr' | 'rtl'
 

--- a/code/ui/slider/types/Slider.d.ts
+++ b/code/ui/slider/types/Slider.d.ts
@@ -190,7 +190,7 @@ declare const SliderThumb: import("@tamagui/core").TamaguiComponent<Omit<import(
     chromeless?: boolean | "all" | undefined;
 }, import("@tamagui/core").StaticConfigPublic>;
 declare const Slider: React.ForwardRefExoticComponent<SliderProps & {
-    __scopeSlider?: import("@tamagui/create-context").Scope;
+    __scopeSlider?: string;
 } & React.RefAttributes<unknown>> & {
     Track: React.ForwardRefExoticComponent<Omit<import("@tamagui/core").RNTamaguiViewNonStyleProps, "elevation" | keyof import("@tamagui/core").StackStyleBase | "size" | "fullscreen" | "circular" | "hoverTheme" | "pressTheme" | "focusTheme" | "elevate" | "bordered" | "unstyled"> & import("@tamagui/core").WithThemeValues<import("@tamagui/core").StackStyleBase> & {
         size?: import("@tamagui/core").SizeTokens | undefined;

--- a/code/ui/slider/types/constants.d.ts
+++ b/code/ui/slider/types/constants.d.ts
@@ -1,51 +1,21 @@
-import type { SizeTokens } from '@tamagui/core';
+import { type SizeTokens } from '@tamagui/core';
 import type { Direction, SliderContextValue } from './types';
 export declare const SLIDER_NAME = "Slider";
-export declare const createSliderContext: <ContextValueType extends object | null>(rootComponentName: string, defaultContext?: ContextValueType) => readonly [(props: ContextValueType & {
-    scope: import("@tamagui/create-context").Scope<ContextValueType>;
-    children: React.ReactNode;
-}) => import("react/jsx-runtime").JSX.Element, (consumerName: string, scope: import("@tamagui/create-context").Scope<ContextValueType | undefined>, options?: {
-    warn?: boolean;
-    fallback?: Partial<ContextValueType>;
-}) => ContextValueType], createSliderScope: import("@tamagui/create-context").CreateScope;
-export declare const SliderProvider: (props: SliderContextValue & {
-    scope: import("@tamagui/create-context").Scope<SliderContextValue>;
-    children: React.ReactNode;
-}) => import("react/jsx-runtime").JSX.Element, useSliderContext: (consumerName: string, scope: import("@tamagui/create-context").Scope<SliderContextValue | undefined>, options?: {
-    warn?: boolean;
-    fallback?: Partial<SliderContextValue> | undefined;
-} | undefined) => SliderContextValue;
-export declare const SliderOrientationProvider: (props: {
+export declare const SliderContext: import("@tamagui/core").StyledContext<SliderContextValue>;
+export declare const SliderProvider: import("react").ProviderExoticComponent<Partial<SliderContextValue> & {
+    children?: import("react").ReactNode;
+    scope?: string;
+}>, useSliderContext: (scope?: string) => SliderContextValue;
+export declare const SliderOrientationProvider: import("react").ProviderExoticComponent<Partial<{
     startEdge: "bottom" | "left" | "right";
     endEdge: "top" | "right" | "left";
     sizeProp: "width" | "height";
     size: number | SizeTokens;
     direction: number;
-} & {
-    scope: import("@tamagui/create-context").Scope<{
-        startEdge: "bottom" | "left" | "right";
-        endEdge: "top" | "right" | "left";
-        sizeProp: "width" | "height";
-        size: number | SizeTokens;
-        direction: number;
-    }>;
-    children: React.ReactNode;
-}) => import("react/jsx-runtime").JSX.Element, useSliderOrientationContext: (consumerName: string, scope: import("@tamagui/create-context").Scope<{
-    startEdge: "bottom" | "left" | "right";
-    endEdge: "top" | "right" | "left";
-    sizeProp: "width" | "height";
-    size: number | SizeTokens;
-    direction: number;
-} | undefined>, options?: {
-    warn?: boolean;
-    fallback?: Partial<{
-        startEdge: "bottom" | "left" | "right";
-        endEdge: "top" | "right" | "left";
-        sizeProp: "width" | "height";
-        size: number | SizeTokens;
-        direction: number;
-    }> | undefined;
-} | undefined) => {
+}> & {
+    children?: import("react").ReactNode;
+    scope?: string;
+}>, useSliderOrientationContext: (scope?: string) => {
     startEdge: "bottom" | "left" | "right";
     endEdge: "top" | "right" | "left";
     sizeProp: "width" | "height";

--- a/code/ui/slider/types/index.d.ts
+++ b/code/ui/slider/types/index.d.ts
@@ -1,4 +1,5 @@
 export * from './Slider';
+export { SliderContext } from './constants';
 export { SliderFrame } from './SliderImpl';
 export type { SliderProps, SliderHorizontalProps, SliderVerticalProps, SliderTrackProps, } from './types';
 //# sourceMappingURL=index.d.ts.map

--- a/code/ui/slider/types/types.d.ts
+++ b/code/ui/slider/types/types.d.ts
@@ -1,8 +1,7 @@
 import type { GestureReponderEvent, SizeTokens, TamaguiElement } from '@tamagui/core';
-import type { Scope } from '@tamagui/create-context';
 import type { SizableStackProps } from '@tamagui/stacks';
 export type ScopedProps<P> = P & {
-    __scopeSlider?: Scope;
+    __scopeSlider?: string;
 };
 export type Direction = 'ltr' | 'rtl';
 type SliderEventProps = {


### PR DESCRIPTION
### Patch notes
- Use new createStyledContext instead of old createScopeContext
- Make the slider easier to customize, especially the slider Thumb sizes