### PR TITLE
fix(variant): variant props priority

### DIFF
--- a/code/core/core-test/getSplitStyles.native.test.tsx
+++ b/code/core/core-test/getSplitStyles.native.test.tsx
@@ -1,4 +1,4 @@
-import { Stack, createTamagui, getSplitStyles } from '@tamagui/core'
+import { Stack, createTamagui, getSplitStyles, styled } from '@tamagui/core'
 import { beforeAll, describe, expect, test } from 'vitest'
 
 import config from '../config-default'
@@ -173,6 +173,52 @@ describe('getSplitStyles', () => {
     }
   })
 
+})
+
+describe('getSplitStyles - pseudo prop merging', () => {
+  const StyledButton = styled(Stack, {
+    name: 'StyledButton',
+    pressStyle: { backgroundColor: 'green' },
+    variants: {
+      variant: {
+        prim: {
+          pressStyle: { backgroundColor: 'blue' },
+        },
+      },
+    },
+  })
+
+  function getPressStyle(props: any) {
+    const { style } = getSplitStyles(
+      props,
+      StyledButton.staticConfig,
+      {} as any,
+      '',
+      {
+        hover: false,
+        press: true, // simulate press state
+        pressIn: true,
+        focus: false,
+        unmounted: false,
+        disabled: false,
+        focusVisible: false,
+      },
+      {
+        isAnimated: false,
+      }
+    )
+    return style?.backgroundColor
+  }
+
+  test('inline pressStyle should override variant pressStyle', () => {
+    const bg = getPressStyle({ variant: 'prim', pressStyle: { backgroundColor: 'red' } })
+    expect(bg).toBe('red')
+  })
+
+  test('variant pressStyle should be used if no inline pressStyle', () => {
+    const bg = getPressStyle({ variant: 'prim' })
+    expect(bg).toBe('blue')
+  })
 })
 
 function getSplitStylesStack(props: Record<string, any>, tag?: string) {

--- a/code/core/core-test/getSplitStyles.web.test.tsx
+++ b/code/core/core-test/getSplitStyles.web.test.tsx
@@ -404,3 +404,47 @@ describe('getSplitStyles', () => {
   //   ).toEqual('-1')
   // })
 })
+
+describe('getSplitStyles - pseudo prop merging', () => {
+  const StyledButton = styled(Stack, {
+    name: 'StyledButton',
+    pressStyle: { backgroundColor: 'green' },
+    variants: {
+      variant: {
+        prim: {
+          pressStyle: { backgroundColor: 'blue' },
+        },
+      },
+    },
+  })
+
+  test('inline pressStyle should override variant pressStyle', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      StyledButton,
+      {
+        variant: 'prim',
+        pressStyle: { backgroundColor: 'red' },
+      }
+    )
+    expect(viewProps.className).toContain('_bg-0active-red')
+  })
+
+  test('variant pressStyle should be used if no inline pressStyle', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      StyledButton,
+      {
+        variant: 'prim',
+      }
+    )
+    expect(viewProps.className).toContain('_bg-0active-blue')
+  })
+
+  test('default pressStyle should not generate a class if not used', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      StyledButton,
+      {}
+    )
+    // No press state simulated, so no class is generated
+    expect(viewProps.className).not.toContain('_bg-0active-green')
+  })
+})

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -250,7 +250,6 @@ export const getSplitStyles: StyleSplitter = (
   const { noSkip, disableExpandShorthands, noExpand } = styleProps
   const { webContainerType } = conf.settings
   const parentVariants = parentStaticConfig?.variants
-
   for (const keyOg in props) {
     let keyInit = keyOg
     let valInit = props[keyInit]

--- a/code/core/web/src/helpers/mergeProps.ts
+++ b/code/core/web/src/helpers/mergeProps.ts
@@ -39,6 +39,11 @@ function mergeProp(
 ) {
   const longhand = inverseShorthands?.[key] || null
   const val = a[key]
+
+  if (b && (key in b || (longhand && longhand in b))) {
+    return
+  }
+
   if (key in pseudoDescriptors || mediaKeys.has(key)) {
     out[key] = {
       ...out[key],
@@ -46,8 +51,6 @@ function mergeProp(
     }
     return
   }
-  if (b && (key in b || (longhand && longhand in b))) {
-    return
-  }
+
   out[longhand || key] = val
 }


### PR DESCRIPTION
- Fix the `mergeProps` to keep the props order correctly:
- Example: 
```
const StyledButton = styled(Button, {
  pressStyle: {
    bg: '$blue10',
  },
  variants: {
    disabled: {
      true: {
        bg: '$gray10',
      },
    },
    variant: {
      default: {
        pressStyle: {
          bg: 'red',
          scale: 1.05,
        },
      },
    },
  },
})

// case 1
<StyledButton variant='default' pressStyle={{ bg: 'orange' }} ... />

// case 2
<StyledButton pressStyle={{ bg: 'orange' )) variant='default' ... />
```

- Before: 
```
output props:  
case 1: {pressStyle: {bg: 'orange'}, variant: 'default'}
case 2: {pressStyle: {bg: 'orange'}, variant: 'default'}
```

- After: 
```
output props:  
case 1: {variant: 'default', {pressStyle: {bg: 'orange'}}
case 2: {pressStyle: {bg: 'orange'}, variant: 'default'}
```

