### PR TITLE
fix(animations): allow enterStyle animations to work on disabled component

### DIFF
--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -719,10 +719,8 @@ export function createComponent<
     }
 
     useIsomorphicLayoutEffect(() => {
-      if (disabled) {
-        return
-      }
-
+      // Note: We removed the early return on disabled to allow animations to work
+      // This fixes the issue where animations wouldn't work on disabled components
       if (state.unmounted === true && hasEnterStyle) {
         setStateShallow({ unmounted: 'should-enter' })
         return
@@ -746,8 +744,9 @@ export function createComponent<
         return
       }
 
+      // Only subscribe to context group if not disabled
       const dispose =
-        pseudoGroups || mediaGroups
+        !disabled && (pseudoGroups || mediaGroups)
           ? subscribeToContextGroup({
               componentContext,
               setStateShallow,

--- a/code/core/web/src/hooks/useComponentState.ts
+++ b/code/core/web/src/hooks/useComponentState.ts
@@ -137,7 +137,7 @@ export const useComponentState = (
 
   let setStateShallow = createShallowSetState(
     setState,
-    disabled ? ['disabled'] : undefined,
+    undefined, // note: allows all state updates even when disabled for the enterStyle animation to work
     false,
     props.debug
   )


### PR DESCRIPTION
- Remove early return on disabled state to allow animations to work
- Allow state updates for animations when component is disabled
- Skip context group subscription for disabled components to prevent interactive states
- Maintain existing behavior for non-disabled components


https://github.com/user-attachments/assets/54d243ce-9468-4ce7-bd53-5023af464b55

