### PR TITLE
fix: allow direct Bento whitelist access for zip download

### DIFF
--- a/code/tamagui.dev/app/api/bento/zip-download+api.ts
+++ b/code/tamagui.dev/app/api/bento/zip-download+api.ts
@@ -2,6 +2,7 @@ import type { Endpoint } from 'one'
 import { ensureAuth } from '~/features/api/ensureAuth'
 import { hasBentoAccess } from '~/features/bento/hasBentoAccess'
 import { getBentoBundleZip } from '~/features/auth/supabaseAdmin'
+import { whitelistBentoUsernames } from '~/features/github/helpers'
 
 export const GET: Endpoint = async (req) => {
   // Extract the token from the Authorization header
@@ -11,11 +12,25 @@ export const GET: Endpoint = async (req) => {
     return Response.json({ error: 'not_authenticated' }, { status: 401 })
   }
 
-  // Check Bento access
-  const resultHasBentoAccess = await hasBentoAccess(user.id)
-  if (!resultHasBentoAccess) {
-    return Response.json({ error: 'not_authorized' }, { status: 401 })
+  // Check if user is directly whitelisted for Bento
+  let isUserDirectlyBentoWhitelisted = false
+  const githubUsername = user.user_metadata?.user_name
+  const userEmail = user.email
+
+  if (githubUsername && whitelistBentoUsernames.has(githubUsername)) {
+    isUserDirectlyBentoWhitelisted = true
+  } else if (userEmail && whitelistBentoUsernames.has(userEmail)) {
+    isUserDirectlyBentoWhitelisted = true
   }
+
+  if (!isUserDirectlyBentoWhitelisted) {
+    // If not directly whitelisted, perform the standard Bento access check
+    const resultHasBentoAccess = await hasBentoAccess(user.id)
+    if (!resultHasBentoAccess) {
+      return Response.json({ error: 'not_authorized' }, { status: 401 })
+    }
+  }
+  // If directly whitelisted or passes hasBentoAccess check, proceed to download
 
   try {
     const zipFile = await getBentoBundleZip()


### PR DESCRIPTION
- Updated zip-download+api.ts to allow users in whitelistBentoUsernames (by GitHub username or email) to download the Bento zip, bypassing the subscription check.
- Updated getUserAccessInfo in helpers.ts to use the same direct whitelist logic for Bento access.