### PR TITLE
fix(site): redirect handling after logout

### DIFF
--- a/code/tamagui.dev/app/api/logout+api.tsx
+++ b/code/tamagui.dev/app/api/logout+api.tsx
@@ -3,20 +3,33 @@ import { apiRoute } from '~/features/api/apiRoute'
 import { ensureAuth } from '~/features/api/ensureAuth'
 
 export default apiRoute(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 })
+  }
+
   const { supabase, user } = await ensureAuth({ req })
 
   if (!user) {
     console.warn(`No user found during logout`)
-    return redirect('/')
+    return new Response(JSON.stringify({ success: false }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
   }
 
   console.warn(`Logging out`)
 
   try {
     await supabase.auth.signOut()
-    return redirect('/')
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
   } catch (error) {
     console.error('Error signing out:', error)
-    return redirect('/')
+    return new Response(JSON.stringify({ success: false }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
   }
 })

--- a/code/tamagui.dev/features/site/purchase/NewAccountModal.tsx
+++ b/code/tamagui.dev/features/site/purchase/NewAccountModal.tsx
@@ -271,6 +271,22 @@ const AccountHeader = () => {
   }
   const { userDetails, user } = data
 
+  const handleLogout = async () => {
+    try {
+      const response = await fetch('/api/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      if (response.ok) {
+        window.location.href = '/'
+      }
+    } catch (error) {
+      console.error('Logout failed:', error)
+    }
+  }
+
   return (
     <XStack gap="$4" p="$5" pb="$8">
       <Avatar circular size="$5">
@@ -302,9 +318,7 @@ const AccountHeader = () => {
       </YStack>
 
       <Button
-        onPress={() => {
-          location.href = '/api/logout'
-        }}
+        onPress={handleLogout}
         icon={<LogOut />}
         size="$2"
         alignSelf="flex-end"


### PR DESCRIPTION
fix(site): improve logout flow and redirect handling

- Replace direct location.href navigation with fetch API call
- Change logout endpoint to use POST method for better security
- Fix redirect issues in both development and production

This fixes the issue where:
- Production: Redirected to blank page at /api/logout
- Development: Changed host to 0.0.0.0 after logout