### PR TITLE
Updated correct-yarn-formatting plugin for Windows compatibility patch

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -15,8 +15,8 @@ logFilters:
 nodeLinker: node-modules
 
 plugins:
-  - checksum: dd1402820c9f1be4f23995511109ef5110d44502498f59e7f637d6771bce032aafffba0042842f4c9cd3ea5fc4faa0cafdad023cfbd554aa2f1f4bb00711b3fb
+  - checksum: 00959c0d2a5826bc669416a83428f711bbd22a02aa6534f07749b3d806ab35b9d66352f0c967fbd2b4e03cdadc31193af7dd403dd359c1a897d97ff60a358adc
     path: .yarn/plugins/correct-yarn-formatting.cjs
-    spec: "https://raw.githubusercontent.com/HanseltimeIndustries/correct-yarn-formatting/v1.0.1/lib/index.js"
+    spec: "https://raw.githubusercontent.com/HanseltimeIndustries/correct-yarn-formatting/v1.0.2/lib/index.js"
 
 yarnPath: .yarn/releases/yarn-4.5.0.cjs


### PR DESCRIPTION
the guide within CONTRIBUTING.md failed within the `yarn install` step because of a path error caused by the `correct-yarn-formatting` plugin (will paste example below). 

A patch was merged and new version was released approximately four months ago addressing this issue (https://github.com/HanseltimeIndustries/correct-yarn-formatting/releases/tag/v1.0.2)

What I did:
  - delete plugin configuration within `.yamlrc.yml`
  - add updated plugin via the command
       - yarn plugin import https://raw.githubusercontent.com/HanseltimeIndustries/correct-yarn-formatting/v1.0.2/lib/index.js
       
Error that lead to this PR:
```
PS C:\Users\Mustafa\Desktop\tamagui-docs\tamagui> cat .\.yarnrc.yml
compressionLevel: mixed

enableTelemetry: false

logFilters:
  - code: YN0002
    level: discard
  - code: YN0060
    level: discard
  - code: YN0006
    level: discard
  - code: YN0076
    level: discard

nodeLinker: node-modules

plugins:
  - checksum: dd1402820c9f1be4f23995511109ef5110d44502498f59e7f637d6771bce032aafffba0042842f4c9cd3ea5fc4faa0cafdad023cfbd554aa2f1f4bb00711b3fb
    path: .yarn/plugins/correct-yarn-formatting.cjs
    spec: "https://raw.githubusercontent.com/HanseltimeIndustries/correct-yarn-formatting/v1.0.1/lib/index.js
                                                                               (!! OLD VERSION ^ !!)
yarnPath: .yarn/releases/yarn-4.5.0.cjs
PS C:\Users\Mustafa\Desktop\tamagui-docs\tamagui> cd ..
PS C:\Users\Mustafa\Desktop\tamagui-docs> code .\tamagui\
PS C:\Users\Mustafa\Desktop\tamagui-docs> cd .\tamagui\
PS C:\Users\Mustafa\Desktop\tamagui-docs\tamagui> yarn install
➤ YN0000: · Yarn 4.5.0
➤ YN0000: ┌ Project validation
➤ YN0057: │ starter-free: Resolutions field will be ignored
➤ YN0001: │ Error: ENOENT: no such file or directory, open 'C:\C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\package.json'
    at Object.openSync (node:fs:562:18)                   (!! ^ PATH ERROR !!)
    at readFileSync (node:fs:446:35)
    at validateProject (C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\plugins\correct-yarn-formatting.cjs:47:21)
    at t.triggerHook (C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\releases\yarn-4.5.0.cjs:149:3724)
    at async C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\releases\yarn-4.5.0.cjs:213:2044
    at async Rt.startSectionPromise (C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\releases\yarn-4.5.0.cjs:176:2828)
    at async t.install (C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\releases\yarn-4.5.0.cjs:213:1794)
    at async C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\releases\yarn-4.5.0.cjs:447:18229
    at async Rt.start (C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\releases\yarn-4.5.0.cjs:176:1995)
    at async lE.execute (C:\Users\Mustafa\Desktop\tamagui-docs\tamagui\.yarn\releases\yarn-4.5.0.cjs:447:18086)
➤ YN0000: └ Completed
➤ YN0000: · Failed with errors in 0s 11ms
```       