### PR TITLE
Add missing 'r' in "Compiler"

### DIFF
--- a/code/tamagui.dev/features/site/header/Header.tsx
+++ b/code/tamagui.dev/features/site/header/Header.tsx
@@ -763,7 +763,7 @@ const HeaderMenuMoreContents = () => {
 
         <Link asChild href="/docs/intro/compiler-install" onPress={handlePress}>
           <HeadAnchor grid half>
-            Compile
+            Compiler
           </HeadAnchor>
         </Link>
 


### PR DESCRIPTION
Super tiny typo. (Mainly just wanted an excuse to go spelunking through the codebase 🤓)

This is buried in the hamburger menu.

I considered pulling this out into a variable or switching on the types, but felt that was potentially overkill and a wider blast radius for something so small.
<img width="384" alt="image" src="https://github.com/user-attachments/assets/119398a2-b457-417c-a3f1-0da0e8fbd7b5" />
