### PR TITLE
fix: add missing IS_REACT_19 for native

### DIFF
--- a/code/core/constants/src/constants.native.ts
+++ b/code/core/constants/src/constants.native.ts
@@ -1,5 +1,9 @@
 import { useLayoutEffect, type useEffect } from 'react'
+// @ts-ignore
+import { use } from 'react'
 import { Platform } from 'react-native'
+
+export const IS_REACT_19: boolean = !!use
 
 export const isWeb: boolean = false
 export const isWindowDefined: boolean = false


### PR DESCRIPTION
Error

```
"IS_REACT_19" is not exported by "../../node_modules/@tamagui/constants/dist/esm/index.native.js", imported by "../../node_modules/@tamagui/web/dist/esm/helpers/wrapStyleTags.native.js"
```