### PR TITLE
fix(website): copy/paste hint from theme configuration

### DIFF
--- a/code/tamagui.dev/features/studio/theme/steps/5-export/StepExportCode.tsx
+++ b/code/tamagui.dev/features/studio/theme/steps/5-export/StepExportCode.tsx
@@ -119,8 +119,8 @@ export class StepExportStore {
 import { defaultConfig } from '@tamagui/config/v4'
 
 export const config = createTamagui({
-  themes,
   ...defaultConfig,
+  themes,
 })
 `,
                   },


### PR DESCRIPTION
as a tamagui new user,
I can quickly copy/paste generated theme from the website,
so that i can and app ship with my custom theme.

**before**
```
'themes' is specified more than once, so this usage will be overwritten.
```
<img width="1986" height="966" alt="CleanShot 2025-07-29 at 12 29 27@2x" src="https://github.com/user-attachments/assets/4a9d1b28-7083-4c76-8dfc-c36066a3ed6c" />


**after**
no error

<img width="1544" height="1002" alt="CleanShot 2025-07-29 at 12 29 54@2x" src="https://github.com/user-attachments/assets/3fe80120-1356-4649-bb18-fa20e3774cc4" />
