### PR TITLE
fix: spread parent ComponentContext props

### DIFF
--- a/code/core/web/src/views/FontLanguage.native.tsx
+++ b/code/core/web/src/views/FontLanguage.native.tsx
@@ -4,9 +4,10 @@ import { ComponentContext } from '../contexts/ComponentContext'
 import type { FontLanguageProps } from './FontLanguage.types'
 
 export const FontLanguage = ({ children, ...props }: FontLanguageProps) => {
+  const parentProps = React.useContext(ComponentContext);
   const language = React.useMemo(() => props, [JSON.stringify(props)])
   return (
-    <ComponentContext.Provider language={language}>{children}</ComponentContext.Provider>
+    <ComponentContext.Provider {...parentProps} language={language}>{children}</ComponentContext.Provider>
   )
 }
 


### PR DESCRIPTION
Found a bug in the `FontLanguage` component on native:

When using `FontLanguage` inside the `TamaguiProvider` the `animationProvider` and all other props from the `ComponentContext` are not being forwarded - which means they are unset.