### PR TITLE
fix(alert-dialog): wrong scope context for custom alert dialog on native

### DIFF
--- a/code/ui/alert-dialog/src/AlertDialog.tsx
+++ b/code/ui/alert-dialog/src/AlertDialog.tsx
@@ -39,9 +39,7 @@ import { useControllableState } from '@tamagui/use-controllable-state'
 import * as React from 'react'
 import { Alert } from 'react-native'
 
-const AlertScopePrefix = 'Alert__'
-
-const getAlertDialogScope = (scope?: string) => AlertScopePrefix + scope
+const getAlertDialogScope = (scope?: string) =>  scope
 
 /* -------------------------------------------------------------------------------------------------
  * AlertDialog


### PR DESCRIPTION
The root cause was because we have the scope prefix `Alert__` so it messed of the context from the `Dialog` since `Dialog` already had it's own context also.

https://github.com/user-attachments/assets/6584edb2-2532-4b59-8f10-bbadc51a3a6c

