### PR TITLE
chore: upgrade to react-native-web 0.21

### DIFF
--- a/code/bento/package.json
+++ b/code/bento/package.json
@@ -92,7 +92,7 @@
     "react-native-reanimated": "^3.18.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-svg": "15.11.2",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "swr": "^2.2.5",
     "tamagui": "workspace:*",
     "zod": "^3.25.67"

--- a/code/compiler/static-tests/package.json
+++ b/code/compiler/static-tests/package.json
@@ -44,7 +44,7 @@
     "esbuild-loader": "^4.2.2",
     "null-loader": "^4.0.1",
     "react": "*",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "react-test-renderer": "^19.0.0",
     "style-loader": "^3.3.3",
     "typescript": "^5.8.2",

--- a/code/compiler/static/package.json
+++ b/code/compiler/static/package.json
@@ -69,7 +69,7 @@
     "fs-extra": "^11.2.0",
     "invariant": "^2.2.4",
     "js-yaml": "^4.1.0",
-    "react-native-web": "^0.20.0"
+    "react-native-web": "^0.21.0"
   },
   "devDependencies": {
     "@babel/plugin-syntax-typescript": "^7.25.4",

--- a/code/compiler/vite-plugin/package.json
+++ b/code/compiler/vite-plugin/package.json
@@ -44,7 +44,7 @@
     "esm-resolve": "^1.0.8",
     "fs-extra": "^11.2.0",
     "outdent": "^0.8.0",
-    "react-native-web": "^0.20.0"
+    "react-native-web": "^0.21.0"
   },
   "devDependencies": {
     "@tamagui/build": "workspace:*",

--- a/code/kitchen-sink/package.json
+++ b/code/kitchen-sink/package.json
@@ -73,7 +73,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-svg": "15.11.2",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "solito": "^4.3.0",
     "tamagui": "workspace:*",
     "vitest": "^3.2.4",

--- a/code/sandbox/package.json
+++ b/code/sandbox/package.json
@@ -37,7 +37,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-svg": "15.11.2",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "tamagui": "workspace:*"
   },
   "devDependencies": {

--- a/code/starters/expo-router/package.json
+++ b/code/starters/expo-router/package.json
@@ -40,7 +40,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-svg": "15.11.2",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "tamagui": "^1.132.23"
   },
   "devDependencies": {

--- a/code/starters/simple-web/package.json
+++ b/code/starters/simple-web/package.json
@@ -20,7 +20,7 @@
     "expo-linear-gradient": "^12.7.2",
     "react": "*",
     "react-dom": "*",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "tamagui": "^1.132.23"
   },
   "devDependencies": {

--- a/code/tests/integration/package.json
+++ b/code/tests/integration/package.json
@@ -19,7 +19,7 @@
     "@tamagui/linear-gradient": "workspace:*",
     "@tamagui/react-native-svg": "workspace:*",
     "@tamagui/shorthands": "workspace:*",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "tamagui": "workspace:*"
   },
   "devDependencies": {

--- a/code/tests/nextjs15-app-router-theme/apps/next/package.json
+++ b/code/tests/nextjs15-app-router-theme/apps/next/package.json
@@ -17,7 +17,7 @@
     "react": "*",
     "react-dom": "*",
     "react-native": "^0.79.2",
-    "react-native-web": "^0.20.0",
+    "react-native-web": "^0.21.0",
     "tamagui": "workspace:*"
   },
   "devDependencies": {

--- a/code/tests/nextjs15-app-router-theme/package.json
+++ b/code/tests/nextjs15-app-router-theme/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^18.3.1",
     "react-refresh": "^0.14.0",
     "react-native-svg": "15.11.2",
-    "react-native-web": "~0.19.12"
+    "react-native-web": "~0.21.1"
   },
   "dependencies": {
     "@tamagui/cli": "workspace:*"

--- a/code/ui/tamagui/package.json
+++ b/code/ui/tamagui/package.json
@@ -142,7 +142,7 @@
     "@tamagui/build": "workspace:*",
     "react": "*",
     "react-native": "^0.79.2",
-    "react-native-web": "^0.20.0"
+    "react-native-web": "^0.21.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6587,7 +6587,7 @@ __metadata:
     react-native-reanimated: "npm:^3.18.0"
     react-native-safe-area-context: "npm:5.4.0"
     react-native-svg: "npm:15.11.2"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     swr: "npm:^2.2.5"
     tamagui: "workspace:*"
     tilg: "npm:0.1.1"
@@ -7592,7 +7592,7 @@ __metadata:
     react-native-safe-area-context: "npm:5.4.0"
     react-native-screens: "npm:~4.10.0"
     react-native-svg: "npm:15.11.2"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     solito: "npm:^4.3.0"
     tamagui: "workspace:*"
     tilg: "npm:0.1.1"
@@ -8331,7 +8331,7 @@ __metadata:
     esbuild-loader: "npm:^4.2.2"
     null-loader: "npm:^4.0.1"
     react: "npm:*"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     react-test-renderer: "npm:^19.0.0"
     style-loader: "npm:^3.3.3"
     typescript: "npm:^5.8.2"
@@ -8392,7 +8392,7 @@ __metadata:
     null-loader: "npm:^4.0.1"
     react: "npm:*"
     react-native: "npm:^0.79.2"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     typescript: "npm:^5.8.2"
   peerDependencies:
     react: "*"
@@ -8907,7 +8907,7 @@ __metadata:
     esm-resolve: "npm:^1.0.8"
     fs-extra: "npm:^11.2.0"
     outdent: "npm:^0.8.0"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     vite: "npm:^7.0.2"
   peerDependencies:
     vite: "*"
@@ -17963,7 +17963,7 @@ __metadata:
     "@vitejs/plugin-react-swc": "npm:^3.7.2"
     async-retry: "npm:1.3.1"
     react-dom: "npm:*"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     tamagui: "workspace:*"
     vite: "npm:^7.0.2"
     wait-port: "npm:^0.3.0"
@@ -21457,7 +21457,7 @@ __metadata:
     react: "npm:*"
     react-dom: "npm:*"
     react-native: "npm:^0.79.2"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     tamagui: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -23828,9 +23828,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-web@npm:^0.20.0":
-  version: 0.20.0
-  resolution: "react-native-web@npm:0.20.0"
+"react-native-web@npm:^0.21.0":
+  version: 0.21.1
+  resolution: "react-native-web@npm:0.21.1"
   dependencies:
     "@babel/runtime": "npm:^7.18.6"
     "@react-native/normalize-colors": "npm:^0.74.1"
@@ -23843,7 +23843,7 @@ __metadata:
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
-  checksum: 10/2a2e84ca647b1b1422941f5d8e0a4f513ad61a34c5e47fb6888fc8ca3aca5cc105bc0c6207a3db4727a8333dfd9c7b27eb8d2acdab3bd4ca1abc6fe32459da92
+  checksum: 10/62cc21b514fd4abe3f9705bd9c835a7f6b910b41869f3c52d136e7ce758bbfa03f04e5df08ad430834faae236c575611430d69b4ca9cb87fb086c1a90392a784
   languageName: node
   linkType: hard
 
@@ -25026,7 +25026,7 @@ __metadata:
     react-native-safe-area-context: "npm:5.4.0"
     react-native-screens: "npm:~4.10.0"
     react-native-svg: "npm:15.11.2"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
     tamagui: "workspace:*"
     vite: "npm:^7.0.2"
     wait-port: "npm:^0.3.0"
@@ -26720,7 +26720,7 @@ __metadata:
     "@tamagui/z-index-stack": "workspace:*"
     react: "npm:*"
     react-native: "npm:^0.79.2"
-    react-native-web: "npm:^0.20.0"
+    react-native-web: "npm:^0.21.0"
   peerDependencies:
     react: "*"
     react-native: ^0.79.2


### PR DESCRIPTION
similar to https://github.com/tamagui/tamagui/commit/ab834cd3b6e9944f0799a361020c7730c4aec148
update to latest react-native-web which is recommended with expo 54