### PR TITLE
fix(useDisableScroll): implement ref counting to manage multiple instances

### DIFF
--- a/code/ui/remove-scroll/src/useDisableScroll.ts
+++ b/code/ui/remove-scroll/src/useDisableScroll.ts
@@ -3,6 +3,9 @@ import { useEffect } from 'react'
 const canUseDOM = () =>
   typeof window !== 'undefined' && !!window.document && !!window.document.createElement
 
+let refCount = 0
+let previousBodyStyle: { scrollbarGutter: string; overflow: string } | null = null
+
 export const useDisableBodyScroll = (enabled: boolean): void => {
   useEffect(() => {
     if (!enabled || !canUseDOM()) {
@@ -11,15 +14,21 @@ export const useDisableBodyScroll = (enabled: boolean): void => {
 
     // for 99% browsers this can replace all the events
     const bodyEl = document.documentElement
-    const previousBodyStyle = {
-      scrollbarGutter: bodyEl.style.scrollbarGutter,
-      overflow: bodyEl.style.overflow,
+
+    if (++refCount === 1) {
+      previousBodyStyle = {
+        scrollbarGutter: bodyEl.style.scrollbarGutter,
+        overflow: bodyEl.style.overflow,
+      }
+      bodyEl.style.scrollbarGutter = 'stable'
+      bodyEl.style.overflow = 'hidden'
     }
-    bodyEl.style.scrollbarGutter = 'stable'
-    bodyEl.style.overflow = 'hidden'
 
     return () => {
-      Object.assign(bodyEl.style, previousBodyStyle)
+      if (--refCount === 0 && previousBodyStyle) {
+        Object.assign(bodyEl.style, previousBodyStyle)
+        previousBodyStyle = null
+      }
     }
   }, [enabled])
 }


### PR DESCRIPTION
## Fix scroll lock bug when Dialog closes

### Problem
After closing a Dialog with Adapt Sheet, page scroll remains disabled even though the dialog is closed.

### Root Cause
When multiple `RemoveScroll` instances exist (nested dialogs), each instance independently saves and restores `document.documentElement.style.overflow`:

1. First instance: saves `overflow: ''` (original), sets to `'hidden'` ✅
2. Second instance: saves `overflow: 'hidden'` (wrong!), sets to `'hidden'`
3. First cleanup: restores to `''` ✅
4. Second cleanup: restores to `'hidden'` ❌ - **scroll stays locked**

### Context
This is a regression from commit `1787cf7f6e` which simplified RemoveScroll to use `overflow: hidden` instead of event listeners. The old implementation didn't need reference counting because each instance managed independent event listeners.


https://github.com/user-attachments/assets/6983d0a6-6b29-4e79-95b1-13b826a465d1

