### PR TITLE
Update package.json instructions for Tamagui Expo Guide

### DIFF
--- a/code/tamagui.dev/data/docs/guides/expo.mdx
+++ b/code/tamagui.dev/data/docs/guides/expo.mdx
@@ -79,7 +79,7 @@ module.exports = function (api) {
 
 - First, follow the [Metro configuration guide](/docs/guides/metro#web-support) to enable web support.
 
-Add `@tamagui/config/v4` and `tamagui` to your package.json and install them. Then add a `tamagui.config.ts`:
+Add `@tamagui/config` and `tamagui` to your package.json and install them. Then add a `tamagui.config.ts`:
 
 ```tsx fileName="tamagui.config.ts"
 import { defaultConfig } from '@tamagui/config/v4'


### PR DESCRIPTION
The package is `@tamagui/config` although the import is from `@tamagui/config/v4`. The v4 is a export from the main package.