### PR TITLE
fix(theme-builder): preserve hsla alpha values - Fixes #3601

### DIFF
--- a/code/core/theme-builder/src/createThemes.ts
+++ b/code/core/theme-builder/src/createThemes.ts
@@ -312,13 +312,15 @@ function getAnchors(palette: SchemePalette) {
 
   const anchors = palette.light.map((lcolor, index) => {
     const dcolor = palette.dark[index]
-    const [lhue, lsat, llum] = parseToHsla(lcolor)
-    const [dhue, dsat, dlum] = parseToHsla(dcolor)
+    const [lhue, lsat, llum, lalpha] = parseToHsla(lcolor)
+    const [dhue, dsat, dlum, dalpha] = parseToHsla(dcolor)
+
     return {
       index: spreadIndex(maxIndex, numItems, index),
       hue: { light: lhue, dark: dhue },
       sat: { light: lsat, dark: dsat },
       lum: { light: llum, dark: dlum },
+      alpha: { light: lalpha, dark: dalpha },
     } as const
   })
 

--- a/code/core/theme-builder/src/getThemeSuitePalettes.ts
+++ b/code/core/theme-builder/src/getThemeSuitePalettes.ts
@@ -28,14 +28,19 @@ const generateColorPalette = ({
 
   let palette: string[] = []
 
-  const add = (h: number, s: number, l: number) => {
-    palette.push(hsla(h, s, l, 1))
+  const add = (h: number, s: number, l: number, a?: number) => {
+    palette.push(hsla(h, s, l, a ?? 1))
   }
 
   const numAnchors = Object.keys(anchors).length
 
   for (const [anchorIndex, anchor] of anchors.entries()) {
-    const [h, s, l] = [anchor.hue[scheme], anchor.sat[scheme], anchor.lum[scheme]]
+    const [h, s, l, a] = [
+      anchor.hue[scheme],
+      anchor.sat[scheme],
+      anchor.lum[scheme],
+      anchor.alpha[scheme],
+    ]
 
     if (anchorIndex !== 0) {
       const lastAnchor = anchors[anchorIndex - 1]
@@ -56,7 +61,7 @@ const generateColorPalette = ({
       }
     }
 
-    add(h, s, l)
+    add(h, s, l, a)
 
     const isLastAnchor = anchorIndex === numAnchors - 1
     if (isLastAnchor && palette.length < paletteSize) {

--- a/code/core/theme-builder/src/types.ts
+++ b/code/core/theme-builder/src/types.ts
@@ -83,6 +83,10 @@ export type BuildThemeAnchor = {
     light: number
     dark: number
   }
+  alpha: {
+    light: number
+    dark: number
+  }
 }
 
 export type BuildTheme = BuildThemeBase & {


### PR DESCRIPTION
## Summary
- Preserves alpha values when parsing HSLA colors in theme builder
- Previously alpha was being ignored and defaulted to 1

Fixes #3601

Based on work from #3667 by @oktaysenkan, cleaned up and rebased.