### PR TITLE
fix: add aria-modal attribute to AlertDialog content for accessibility

### DIFF
--- a/code/ui/alert-dialog/src/AlertDialog.tsx
+++ b/code/ui/alert-dialog/src/AlertDialog.tsx
@@ -169,6 +169,7 @@ const AlertDialogContent = React.forwardRef<TamaguiElement, AlertDialogContentPr
           <DialogContent
             // @ts-ignore
             role="alertdialog"
+            aria-modal={true}
             scope={dialogScope}
             {...contentProps}
             ref={composedRefs}


### PR DESCRIPTION
## Summary
- Adds `aria-modal={true}` to AlertDialog content for proper ARIA compliance

Fixes #3316

---

⚠️ **Note:** This fix was automated and needs careful review.

cc @anhquan291

🤖 Generated with [Claude Code](https://claude.com/claude-code)