### PR TITLE
fix: add role=dialog and aria-modal to DialogContent for accessibility

### DIFF
--- a/code/ui/dialog/src/Dialog.tsx
+++ b/code/ui/dialog/src/Dialog.tsx
@@ -593,6 +593,8 @@ const DialogContentImpl = React.forwardRef<TamaguiElement, DialogContentImplProp
       <DialogContentFrame
         ref={composedRefs}
         id={context.contentId}
+        role="dialog"
+        aria-modal={context.modal}
         aria-describedby={context.descriptionId}
         aria-labelledby={context.titleId}
         data-state={getState(context.open)}


### PR DESCRIPTION
## Summary
- Adds `role="dialog"` and `aria-modal` to DialogContentFrame for proper ARIA compliance

Fixes #3314

---

⚠️ **Note:** This fix was automated and needs careful review.

cc @anhquan291

🤖 Generated with [Claude Code](https://claude.com/claude-code)