### PR TITLE
fix: correct config.tokens.size type mapping to properly strip $ prefix

### DIFF
--- a/code/core/themes/src/v3-tokens.ts
+++ b/code/core/themes/src/v3-tokens.ts
@@ -48,9 +48,9 @@ export const size = {
 
 type SizeKeysIn = keyof typeof size
 type Sizes = {
-  [Key in SizeKeysIn extends `$${infer Key}` ? Key : SizeKeysIn]: number
+  [Key in SizeKeysIn as Key extends `$${infer K}` ? K : Key]: number
 }
-type SizeKeys = `${keyof Sizes extends `${infer K}` ? K : never}`
+type SizeKeys = keyof Sizes
 
 export const spaces = Object.entries(size).map(([k, v]) => {
   return [k, sizeToSpace(v)] as const


### PR DESCRIPTION
## Summary
- Fixes the `Sizes` type mapping to properly use distributive conditional types
- Changes from `SizeKeysIn extends ...` to `Key in SizeKeysIn as Key extends ...`

Fixes #2973

---

⚠️ **Note:** This fix was automated and needs careful review.

cc @anhquan291

🤖 Generated with [Claude Code](https://claude.com/claude-code)