### PR TITLE
fix: allow string[] for fontVariant in TextStylePropsBase for variant typing

### DIFF
--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -2176,7 +2176,7 @@ export interface StackStyleBase
     ExtendedBaseProps {}
 
 export interface TextStylePropsBase
-  extends Omit<RNTextStyle, keyof ExtendedBaseProps>,
+  extends Omit<RNTextStyle, keyof ExtendedBaseProps | 'fontVariant'>,
     ExtendedBaseProps {
   ellipse?: boolean
   textDecorationDistance?: number
@@ -2185,6 +2185,10 @@ export interface TextStylePropsBase
   wordWrap?: Properties['wordWrap']
   /** @deprecated use verticalAlign instead */
   textAlignVertical?: RNTextStyle['textAlignVertical']
+  /**
+   * Font variant - accepts RN FontVariant[] or string[] for easier typing in variants
+   */
+  fontVariant?: RNTextStyle['fontVariant'] | string[]
 }
 
 //


### PR DESCRIPTION
## Summary
- Adds `string[]` to the `fontVariant` type in `TextStylePropsBase`
- Fixes TypeScript errors when specifying fontVariant in boolean variants
- TypeScript infers literal arrays as `string[]` rather than `FontVariant[]`

Fixes #2787

---

⚠️ **Note:** This fix was automated and needs careful review.

cc @anhquan291

🤖 Generated with [Claude Code](https://claude.com/claude-code)