### PR TITLE
fix: preserve function props when using styled() on components with matching prop names

### DIFF
--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -2349,13 +2349,24 @@ export type Styleable<
   ParentStaticProperties
 >
 
+// Preserves function-typed props from the original component that would otherwise be
+// overwritten by style props with the same name (e.g., a `color` callback prop)
+type PreserveFunctionProps<NonStyleProps, StylePropsBase> = {
+  [K in keyof NonStyleProps as K extends keyof StylePropsBase
+    ? NonStyleProps[K] extends (...args: any[]) => any
+      ? K
+      : never
+    : never]: NonStyleProps[K]
+}
+
 export type GetFinalProps<NonStyleProps, StylePropsBase, Variants> = Omit<
   NonStyleProps,
   keyof StylePropsBase | keyof Variants
 > &
   (StylePropsBase extends Object
     ? WithThemeShorthandsPseudosMedia<StylePropsBase, Variants>
-    : {})
+    : {}) &
+  PreserveFunctionProps<NonStyleProps, StylePropsBase>
 
 export type TamaguiComponent<
   Props = any,


### PR DESCRIPTION
## Summary
- Adds `PreserveFunctionProps` type utility to `GetFinalProps`
- When a component has a prop with a name matching a style prop (e.g., `color`) but with a function type, the original type is now preserved
- Previously, function-typed props would be overwritten by style prop types

Fixes #2784

---

⚠️ **Note:** This fix was automated and needs careful review.

cc @anhquan291

🤖 Generated with [Claude Code](https://claude.com/claude-code)