### PR TITLE
fix: remove arbitrary -1 border radius adjustment in Group component

### DIFF
--- a/code/ui/group/src/Group.tsx
+++ b/code/ui/group/src/Group.tsx
@@ -105,10 +105,8 @@ function createGroup(verticalDefault: boolean) {
 
       const isUsingItems = itemChildrenCount > 0
 
-      // 1 off given border to adjust for border radius? This should be user controllable
       const radius =
-        borderRadius ??
-        (size ? getVariableValue(getTokens().radius[size]) - 1 : undefined)
+        borderRadius ?? (size ? getVariableValue(getTokens().radius[size]) : undefined)
 
       const hasRadius = radius !== undefined
       const disablePassBorderRadius = disablePassBorderRadiusProp ?? !hasRadius


### PR DESCRIPTION
## Summary
- Removes the `-1` adjustment from border radius calculation in Group component
- This adjustment caused visual discontinuity on HiDPI displays due to sub-pixel rendering issues
- The border radius now matches exactly between the Group frame and its items

Fixes #3049

---

⚠️ **Note:** This fix was automated and needs careful review.

cc @anhquan291

🤖 Generated with [Claude Code](https://claude.com/claude-code)