### PR TITLE
fix: handle custom Trigger components in Accordion that don't forward refs

### DIFF
--- a/code/ui/collection/src/Collection.tsx
+++ b/code/ui/collection/src/Collection.tsx
@@ -103,6 +103,26 @@ function createCollection<ItemElement extends TamaguiElement, ItemData = {}>(
       return () => void context.itemMap.delete(ref)
     })
 
+    // Check if children is a valid element that can receive refs
+    // This prevents errors when custom components are passed that don't forward refs
+    const child = React.Children.only(children)
+    const canReceiveRef =
+      React.isValidElement(child) &&
+      (typeof child.type === 'string' || // DOM element
+        (typeof child.type === 'object' && 'render' in (child.type as any)) || // forwardRef
+        (typeof child.type === 'function' &&
+          child.type.prototype &&
+          child.type.prototype.isReactComponent)) // Class component
+
+    if (!canReceiveRef && React.isValidElement(child)) {
+      // Wrap in a span to receive the ref when the child can't
+      return (
+        <span {...{ [ITEM_DATA_ATTR]: '' }} ref={composedRefs as any} style={{ display: 'contents' }}>
+          {children}
+        </span>
+      )
+    }
+
     return (
       <Slot {...{ [ITEM_DATA_ATTR]: '' }} ref={composedRefs}>
         {children}


### PR DESCRIPTION
## Summary
- Updates `CollectionItemSlot` to detect when children can't receive refs
- When a custom component that doesn't support ref forwarding is passed, it's wrapped in a span with `display: contents`
- This prevents React errors when using custom components as Accordion triggers

Fixes #2729

---

⚠️ **Note:** This fix was automated and needs careful review.

cc @anhquan291

🤖 Generated with [Claude Code](https://claude.com/claude-code)