### PR TITLE
fix(helpers-tamagui): simplify useGetThemedIcon and add configureIconProps

### DIFF
--- a/code/core/helpers-tamagui/src/useGetThemedIcon.tsx
+++ b/code/core/helpers-tamagui/src/useGetThemedIcon.tsx
@@ -2,18 +2,58 @@ import React from 'react'
 import type { ColorProp } from './useCurrentColor'
 import { useCurrentColor } from './useCurrentColor'
 
+export type IconProps = {
+  width: number
+  height: number
+  color: string
+}
+
+type IconPropsTransformer = (el: any, props: IconProps) => Record<string, any>
+
+let customIconPropsTransformer: IconPropsTransformer | null = null
+
+/**
+ * Configure how icon props are transformed before being passed to icon components.
+ * This allows customization for different icon libraries that may expect different props.
+ *
+ * @example
+ * // For a library that uses 'size' instead of width/height:
+ * configureIconProps((el, props) => ({
+ *   size: props.width,
+ *   color: props.color,
+ * }))
+ */
+export function configureIconProps(transformer: IconPropsTransformer | null) {
+  customIconPropsTransformer = transformer
+}
+
 export const useGetThemedIcon = (props: { color: ColorProp; size: number }) => {
   const color = useCurrentColor(props.color)
+
   return (el: any) => {
     if (!el) return el
+
+    // Calculate the icon props
+    const iconProps: IconProps = {
+      width: props.size,
+      height: props.size,
+      color,
+    }
+
+    // Allow user customization of props
+    const finalProps = customIconPropsTransformer
+      ? customIconPropsTransformer(el, iconProps)
+      : iconProps
+
+    // Single logic for clone vs create
     if (React.isValidElement(el)) {
       return React.cloneElement(el, {
-        ...props,
-        color,
+        ...finalProps,
         // @ts-expect-error
         ...el.props,
       })
     }
-    return React.createElement(el, props)
+
+    return React.createElement(el, finalProps)
   }
 }

--- a/code/core/helpers-tamagui/types/useGetThemedIcon.d.ts
+++ b/code/core/helpers-tamagui/types/useGetThemedIcon.d.ts
@@ -1,6 +1,25 @@
 import type { ColorProp } from './useCurrentColor';
+export type IconProps = {
+    width: number;
+    height: number;
+    color: string;
+};
+type IconPropsTransformer = (el: any, props: IconProps) => Record<string, any>;
+/**
+ * Configure how icon props are transformed before being passed to icon components.
+ * This allows customization for different icon libraries that may expect different props.
+ *
+ * @example
+ * // For a library that uses 'size' instead of width/height:
+ * configureIconProps((el, props) => ({
+ *   size: props.width,
+ *   color: props.color,
+ * }))
+ */
+export declare function configureIconProps(transformer: IconPropsTransformer | null): void;
 export declare const useGetThemedIcon: (props: {
     color: ColorProp;
     size: number;
 }) => (el: any) => any;
+export {};
 //# sourceMappingURL=useGetThemedIcon.d.ts.map


### PR DESCRIPTION
## Summary

- Simplifies `useGetThemedIcon` to use `width/height/color` for all icons by default (works with external icon libraries like Iconoir)
- Adds `configureIconProps()` function for user customization of icon prop transformation
- Refactors to calculate props at top with single clone/create logic below

## Usage

```tsx
import { configureIconProps } from 'tamagui'

// For a library that uses 'size' instead of width/height:
configureIconProps((el, props) => ({
  size: props.width,
  color: props.color,
}))
```

## Test plan

- [x] Build passes
- [ ] Verify Tamagui icons still work correctly
- [ ] Verify external icons (Iconoir, etc.) respect scaleIcon

Fixes #2961, #2935, #3268

Related to #3570 - implements feedback from that PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)