### PR TITLE
feat: fix SelectDemo component

### DIFF
--- a/code/demos/src/SelectDemo.tsx
+++ b/code/demos/src/SelectDemo.tsx
@@ -114,6 +114,22 @@ export function SelectDemoContents(props: SelectProps & { trigger?: React.ReactN
               [items]
             )}
           </Select.Group>
+           {/* Native gets an extra icon */}
+          {props.native && (
+            <YStack
+              position="absolute"
+              r={0}
+              t={16}
+              items="center"
+              justify="center"
+              width={'$4'}
+              pointerEvents="none"
+            >
+              <ChevronDown
+                size={getFontSize((props.size as FontSizeTokens) ?? '$true')}
+              />
+            </YStack>
+          )}
         </Select.Viewport>
 
         <Select.ScrollDownButton


### PR DESCRIPTION
This PR removes the unnecessary second arrow that was present in  `SelectDemo.tsx` for v2 that wasn't even present in v1 as seen on `tamagui.dev`