### PR TITLE
fix:add return keyword to if statement

### DIFF
--- a/code/ui/toast/src/createNativeToast.tsx
+++ b/code/ui/toast/src/createNativeToast.tsx
@@ -9,7 +9,7 @@ export const createNativeToast: CreateNativeToastsFn = (
     return false
   }
 
-  if (Notification.permission === 'denied') false
+  if (Notification.permission === 'denied') return false
   const showNotification = () => {
     const notification = new Notification(title, {
       body: message,


### PR DESCRIPTION
This PR adds `return` keyword to the if-statement in `createNativeToast.tsx` because without it, the if-statment does nothing useful - it just evaluates to false but doesn't stop the function from continuing.