### PR TITLE
fix: Android Input placeholder clipping at small sizes

### DIFF
--- a/code/ui/input/src/shared.tsx
+++ b/code/ui/input/src/shared.tsx
@@ -63,6 +63,13 @@ export const inputSizeVariant: SizeVariantSpreadFunction<any> = (
     ...fontStyle,
     ...buttonStyles,
     paddingHorizontal,
+    // Android fixes: reset padding and center text vertically
+    ...(!isWeb && {
+      textAlignVertical: 'center',
+      paddingVertical: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+    }),
   }
 }
 

--- a/code/ui/tamagui/src/helpers/inputHelpers.tsx
+++ b/code/ui/tamagui/src/helpers/inputHelpers.tsx
@@ -25,6 +25,13 @@ export const inputSizeVariant: SizeVariantSpreadFunction<any> = (
     ...fontStyle,
     ...buttonStyles,
     paddingHorizontal,
+    // Android fixes: reset padding and center text vertically
+    ...(!isWeb && {
+      textAlignVertical: 'center',
+      paddingVertical: 0,
+      paddingTop: 0,
+      paddingBottom: 0,
+    }),
   }
 }
 


### PR DESCRIPTION
This PR fixes the issue of the placeholder/text clipping in the input component when set to `size="$2"` on Android.

Before(Left: Android, Right: iOS)

<img width="736" height="213" alt="Screenshot 2025-12-18 at 9 15 58 AM" src="https://github.com/user-attachments/assets/1e981aa9-87af-4fc5-8a75-1ab9d9ac6ef4" />

After(Left: Android, Right: iOS)

<img width="736" height="213" alt="Screenshot 2025-12-18 at 10 39 54 AM" src="https://github.com/user-attachments/assets/4b200bd0-1267-4528-87e4-66de39b71b34" />
