### PR TITLE
feat: add AccordionDemo to kitchen-sink app

### DIFF
--- a/code/demos/src/AccordionDemo.tsx
+++ b/code/demos/src/AccordionDemo.tsx
@@ -6,14 +6,14 @@ export function AccordionDemo() {
     <Accordion overflow="hidden" width="$20" type="multiple">
       <Accordion.Item value="a1">
         <Accordion.Trigger flexDirection="row" justify="space-between">
-          {({
-            open,
-          }: {
-            open: boolean
-          }) => (
+          {({ open }: { open: boolean }) => (
             <>
               <Paragraph>1. Take a cold shower</Paragraph>
-              <Square animation="quick" rotate={open ? '180deg' : '0deg'}>
+              <Square
+                animation="quick"
+                rotate={open ? '180deg' : '0deg'}
+                bg="transparent"
+              >
                 <ChevronDown size="$1" />
               </Square>
             </>
@@ -31,14 +31,14 @@ export function AccordionDemo() {
 
       <Accordion.Item value="a2">
         <Accordion.Trigger flexDirection="row" justify="space-between">
-          {({
-            open,
-          }: {
-            open: boolean
-          }) => (
+          {({ open }: { open: boolean }) => (
             <>
               <Paragraph>2. Eat 4 eggs</Paragraph>
-              <Square animation="quick" rotate={open ? '180deg' : '0deg'}>
+              <Square
+                animation="quick"
+                rotate={open ? '180deg' : '0deg'}
+                bg="transparent"
+              >
                 <ChevronDown size="$1" />
               </Square>
             </>

--- a/code/kitchen-sink/src/features/home/screen.tsx
+++ b/code/kitchen-sink/src/features/home/screen.tsx
@@ -1,9 +1,9 @@
-import { ChevronRight } from '@tamagui/lucide-icons'
-import { ScrollView } from 'react-native'
-import type { UseLinkProps } from 'solito/link'
-import { useLink } from 'solito/link'
-import type { ListItemProps } from 'tamagui'
-import { H1, ListItem, YGroup, YStack } from 'tamagui'
+import { ChevronRight } from "@tamagui/lucide-icons";
+import { ScrollView } from "react-native";
+import type { UseLinkProps } from "solito/link";
+import { useLink } from "solito/link";
+import type { ListItemProps } from "tamagui";
+import { H1, ListItem, YGroup, YStack } from "tamagui";
 
 export function HomeScreen() {
   return (
@@ -18,31 +18,31 @@ export function HomeScreen() {
             return (
               <YGroup key={i} size="$4">
                 {pages.map((page) => {
-                  const route = page?.route
+                  const route = page?.route;
 
-                  if (!route) return null
+                  if (!route) return null;
 
                   return (
                     <YGroup.Item key={route}>
                       <LinkListItem
                         bg="$color1"
                         href={route}
-                        pressStyle={{ backgroundColor: '$color2' }}
+                        pressStyle={{ backgroundColor: "$color2" }}
                         size="$4"
                         testID={(page as any).testID}
                       >
                         {page.title}
                       </LinkListItem>
                     </YGroup.Item>
-                  )
+                  );
                 })}
               </YGroup>
-            )
+            );
           })}
         </YStack>
       </YStack>
     </ScrollView>
-  )
+  );
 }
 
 const LinkListItem = ({
@@ -52,18 +52,18 @@ const LinkListItem = ({
   shallow,
   ...props
 }: UseLinkProps & ListItemProps) => {
-  const linkProps = useLink({ href, as, shallow })
+  const linkProps = useLink({ href, as, shallow });
 
   const handlePress = () => {
-    const onPress = linkProps?.onPress
+    const onPress = linkProps?.onPress;
     if (onPress) {
       try {
-        onPress()
+        onPress();
       } catch (error) {
-        console.info('error: ', error)
+        console.info("error: ", error);
       }
     }
-  }
+  };
 
   return (
     <ListItem
@@ -74,96 +74,97 @@ const LinkListItem = ({
     >
       {children}
     </ListItem>
-  )
-}
+  );
+};
 
 const demos = [
   {
     pages: [
-      { title: 'Sandbox', route: '/sandbox' },
-      { title: 'Benchmark', route: '/test/Benchmark' },
+      { title: "Sandbox", route: "/sandbox" },
+      { title: "Benchmark", route: "/test/Benchmark" },
       {
-        title: 'Test Cases',
-        route: '/tests',
-        testID: 'home-test-cases-link',
+        title: "Test Cases",
+        route: "/tests",
+        testID: "home-test-cases-link",
       },
     ],
   },
   {
     pages: [
-      { title: 'Stacks', route: '/demo/stacks' },
-      { title: 'Headings', route: '/demo/headings' },
-      { title: 'Paragraph', route: '/demo/text' },
-      { title: 'Animations', route: '/demo/animations' },
-      { title: 'Animate Presence', route: '/demo/animate-presence' },
-      { title: 'Themes', route: '/demo/themes' },
+      { title: "Stacks", route: "/demo/stacks" },
+      { title: "Headings", route: "/demo/headings" },
+      { title: "Paragraph", route: "/demo/text" },
+      { title: "Animations", route: "/demo/animations" },
+      { title: "Animate Presence", route: "/demo/animate-presence" },
+      { title: "Themes", route: "/demo/themes" },
     ],
   },
 
   {
-    label: 'Menus',
+    label: "Menus",
     pages: [
-      { title: 'Menu', route: '/demo/menu' },
-      { title: 'ContextMenu', route: '/demo/context-menu' },
+      { title: "Menu", route: "/demo/menu" },
+      { title: "ContextMenu", route: "/demo/context-menu" },
     ],
   },
 
   {
-    label: 'Panels',
+    label: "Panels",
     pages: [
-      { title: 'AlertDialog', route: '/demo/alert-dialog' },
-      { title: 'Dialog', route: '/demo/dialog' },
-      { title: 'Popover', route: '/demo/popover' },
-      { title: 'Sheet', route: '/demo/sheet' },
-      { title: 'Toast', route: '/demo/toast' },
+      { title: "AlertDialog", route: "/demo/alert-dialog" },
+      { title: "Dialog", route: "/demo/dialog" },
+      { title: "Popover", route: "/demo/popover" },
+      { title: "Sheet", route: "/demo/sheet" },
+      { title: "Toast", route: "/demo/toast" },
     ],
   },
 
   {
-    label: 'Forms',
+    label: "Forms",
     pages: [
-      { title: 'Button', route: '/demo/button' },
-      { title: 'Checkbox', route: '/demo/checkbox' },
-      { title: 'Form', route: '/demo/forms' },
-      { title: 'Input + Textarea', route: '/demo/inputs' },
-      { title: 'New Input + Textarea', route: '/demo/new-inputs' },
-      { title: 'Label', route: '/demo/label' },
-      { title: 'Progress', route: '/demo/progress' },
-      { title: 'Select', route: '/demo/select' },
-      { title: 'Slider', route: '/demo/slider' },
-      { title: 'Switch', route: '/demo/switch' },
-      { title: 'RadioGroup', route: '/demo/radio-group' },
-      { title: 'ToggleGroup', route: '/demo/toggle-group' },
+      { title: "Button", route: "/demo/button" },
+      { title: "Checkbox", route: "/demo/checkbox" },
+      { title: "Form", route: "/demo/forms" },
+      { title: "Input + Textarea", route: "/demo/inputs" },
+      { title: "New Input + Textarea", route: "/demo/new-inputs" },
+      { title: "Label", route: "/demo/label" },
+      { title: "Progress", route: "/demo/progress" },
+      { title: "Select", route: "/demo/select" },
+      { title: "Slider", route: "/demo/slider" },
+      { title: "Switch", route: "/demo/switch" },
+      { title: "RadioGroup", route: "/demo/radio-group" },
+      { title: "ToggleGroup", route: "/demo/toggle-group" },
     ],
   },
 
   {
-    label: 'Content',
+    label: "Content",
     pages: [
-      { title: 'Avatar', route: '/demo/avatar' },
-      { title: 'Card', route: '/demo/card' },
-      { title: 'Group', route: '/demo/group' },
-      { title: 'Image', route: '/demo/image' },
-      { title: 'ListItem', route: '/demo/list-item' },
-      { title: 'Tabs', route: '/demo/tabs' },
-      { title: 'Tabs Advanced', route: '/demo/tabs-advanced' },
+      { title: "Accordion", route: "/demo/accordion" },
+      { title: "Avatar", route: "/demo/avatar" },
+      { title: "Card", route: "/demo/card" },
+      { title: "Group", route: "/demo/group" },
+      { title: "Image", route: "/demo/image" },
+      { title: "ListItem", route: "/demo/list-item" },
+      { title: "Tabs", route: "/demo/tabs" },
+      { title: "Tabs Advanced", route: "/demo/tabs-advanced" },
     ],
   },
 
   {
-    label: 'Visual',
+    label: "Visual",
     pages: [
-      { title: 'LinearGradient', route: '/demo/linear-gradient' },
-      { title: 'Separator', route: '/demo/separator' },
-      { title: 'Square + Circle', route: '/demo/shapes' },
+      { title: "LinearGradient", route: "/demo/linear-gradient" },
+      { title: "Separator", route: "/demo/separator" },
+      { title: "Square + Circle", route: "/demo/shapes" },
     ],
   },
 
   {
-    label: 'Etc',
+    label: "Etc",
     pages: [
-      { title: 'Spinner', route: '/demo/spinner' },
-      { title: 'ScrollView', route: '/demo/scroll-view' },
+      { title: "Spinner", route: "/demo/spinner" },
+      { title: "ScrollView", route: "/demo/scroll-view" },
     ],
   },
-]
+];

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -370,7 +370,11 @@ const AccordionImpl = React.forwardRef<AccordionImplElement, AccordionImplProps>
 
 const ITEM_NAME = 'AccordionItem'
 
-type AccordionItemContextValue = { open?: boolean; disabled?: boolean; triggerId: string }
+type AccordionItemContextValue = {
+  open?: boolean
+  disabled?: boolean
+  triggerId: string
+}
 const { Provider: AccordionItemProvider, useStyledContext: useAccordionItemContext } =
   createStyledContext<AccordionItemContextValue>()
 type AccordionItemElement = React.ElementRef<typeof Collapsible>
@@ -539,7 +543,7 @@ const AccordionContentFrame = styled(Collapsible.Content, {
     unstyled: {
       false: {
         padding: '$true',
-        backgroundColor: '$background',
+        backgroundColor: isWeb ? '$background' : undefined, // '$background' causes a Reanimated error on native so it's undefined for now
       },
     },
   } as const,


### PR DESCRIPTION
This PR adds the `AccordionDemo` to the kitchen-sink mobile app and also fixes a bug that caused a Reanimated error on mobile

This is how it looks now(Left: Android, Right:iOS):


https://github.com/user-attachments/assets/55692132-f4cb-45f4-b8a8-2e18214f6e4f


This was the Reanimated error by the way:
<img width="409" height="790" alt="Screenshot 2025-12-20 at 1 14 54 PM" src="https://github.com/user-attachments/assets/2156a42f-cec8-4376-84b6-9fa7530a252c" />
