### PR TITLE
fix(docs): nav item button alignment

### DIFF
--- a/code/tamagui.dev/features/docs/DocsRouteNavItem.tsx
+++ b/code/tamagui.dev/features/docs/DocsRouteNavItem.tsx
@@ -69,7 +69,7 @@ export const DocsRouteNavItem = function DocsRouteNavItem({
           cursor="pointer"
           select="none"
           opacity={active ? 1 : 0.65}
-          text={inMenu ? 'left' : 'right'}
+          style={{ textAlign: inMenu ? 'left' : 'right' }}
           width="100%"
           hoverStyle={{
             opacity: 0.85,


### PR DESCRIPTION
This PR fixes the issue of the nav item button staying right-aligned when the menu is opened.

Before fix:
<img width="1440" height="900" alt="Screenshot 2025-12-23 at 8 51 05 AM" src="https://github.com/user-attachments/assets/0e45b0f3-21a9-41cd-8409-760224c607df" />

After fix:
<img width="1440" height="900" alt="Screenshot 2025-12-23 at 10 11 02 AM" src="https://github.com/user-attachments/assets/4945beea-ec04-46b7-8c3a-1700cc50d3bc" />
