### PR TITLE
fix: fix overlapping components on tamagui's welcome page

### DIFF
--- a/code/tamagui.dev/features/site/home/HomeAnimations.tsx
+++ b/code/tamagui.dev/features/site/home/HomeAnimations.tsx
@@ -64,12 +64,11 @@ export function HomeAnimations({ animationCode }: { animationCode: string }) {
           </HomeH3>
         </YStack>
 
-        <XStack>
+        <XStack gap="$4">
           <YStack
             flex={2}
             minW="55%"
             self="center"
-            mr="$-2"
             z={100}
             elevation="$4"
             rounded="$4"
@@ -81,7 +80,6 @@ export function HomeAnimations({ animationCode }: { animationCode: string }) {
           <YStack
             perspective={1000}
             rotateY="-5deg"
-            x={-10}
             $sm={{ display: 'none' }}
             position="relative"
             rounded="$8"


### PR DESCRIPTION
This PR fixes the issue of components overlapping on tamagui's homepage.

Before fix:
<img width="1001" height="790" alt="Screenshot 2025-12-27 at 6 51 25 PM" src="https://github.com/user-attachments/assets/62ff9ee5-95a0-49ec-bf3e-2d0dbe6b5f03" />


After fix:
<img width="1175" height="727" alt="Screenshot 2025-12-27 at 6 59 51 PM" src="https://github.com/user-attachments/assets/fb4689a8-ffd5-41a8-8dcb-132f0fc7f672" />
