### PR TITLE
fix: add toggledStyle prop to ToggleGroup for custom active styling

### DIFF
--- a/code/core/web/src/helpers/getVariantExtras.tsx
+++ b/code/core/web/src/helpers/getVariantExtras.tsx
@@ -1,3 +1,4 @@
+import { getSetting } from '../config'
 import { getVariableValue } from '../createVariable'
 import type { GenericFonts, GetStyleState, LanguageContextType } from '../types'
 
@@ -8,7 +9,7 @@ export const getVariantExtras = (styleState: GetStyleState) => {
     return cache.get(styleState)
   }
 
-  const { props, conf, context, theme } = styleState
+  const { props, conf, context, theme, styleProps } = styleState
   let fonts = conf.fontsParsed
   if (context?.language) {
     fonts = getFontsForLanguage(conf.fontsParsed, context.language)
@@ -18,18 +19,19 @@ export const getVariantExtras = (styleState: GetStyleState) => {
     fonts,
     tokens: conf.tokensParsed,
     theme,
+    context: styleProps?.styledContext,
     get fontFamily() {
       return (
         getVariableValue(styleState.fontFamily || styleState.props.fontFamily) ||
         props.fontFamily ||
-        getVariableValue(styleState.conf.defaultFont)
+        getVariableValue(getSetting('defaultFont'))
       )
     },
     get font() {
       return (
         fonts[this.fontFamily] ||
         (!props.fontFamily || props.fontFamily[0] === '$'
-          ? fonts[styleState.conf.defaultFont!]
+          ? fonts[getSetting('defaultFont') || '']
           : undefined)
       )
     },

--- a/code/tamagui.dev/data/docs/components/toggle-group/1.142.0.mdx
+++ b/code/tamagui.dev/data/docs/components/toggle-group/1.142.0.mdx
@@ -1,0 +1,218 @@
+---
+title: ToggleGroup
+description: Two-state buttons that can be toggled on or off.
+name: toggleGroup
+component: ToggleGroup
+package: toggle-group
+demoName: ToggleGroup
+---
+
+<HeroContainer>
+  <ToggleGroupDemo />
+</HeroContainer>
+
+```tsx hero template=ToggleGroup
+
+```
+
+<Highlights
+  features={[
+    `Full keyboard navigation.`,
+    `Supports horizontal/vertical orientation.`,
+    `Support single and multiple pressed buttons.`,
+    `Can be controlled or uncontrolled.`,
+  ]}
+/>
+
+## Installation
+
+ToggleGroup is already installed in `tamagui`, or you can install it independently:
+
+```bash
+npm install @tamagui/toggle-group
+```
+
+## Usage
+
+```tsx
+import { ToggleGroup } from 'tamagui'
+
+export default () => {
+  return (
+    <ToggleGroup type="single">
+      <ToggleGroup.Item value="foo"></ToggleGroup.Item>
+      <ToggleGroup.Item value="bar"></ToggleGroup.Item>
+    </ToggleGroup>
+  )
+}
+```
+
+## API Reference
+
+### ToggleGroup
+
+`ToggleGroup` extends the [Group](/docs/components/group) component. You can disable passing border radius to children by passing `disablePassBorderRadius`. plus:
+
+<PropsTable
+  data={[
+    {
+      name: 'asChild',
+      type: 'boolean',
+      description: `When true, Tamagui expects a single child element. Instead of rendering its own element, it will pass all props to that child, merging together any event handling props.`,
+      default: `false`,
+    },
+    {
+      name: 'type',
+      type: 'enum',
+      description: `Determines whether a single or multiple items can be pressed at a time.`,
+    },
+    {
+      name: 'value',
+      type: 'string',
+      description: `The controlled value of the pressed item when type is "single". Must be used in conjunction with onValueChange.`,
+    },
+    {
+      name: 'defaultValue',
+      description: 'The values of the items to show as pressed when initially rendered.',
+      type: 'string',
+      default: ``,
+    },
+    {
+      name: 'orientation',
+      type: 'enum',
+      description: `The orientation of the component, which determines how focus moves: horizontal for left/right arrows and vertical for up/down arrows.`,
+      default: `horizontal`,
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      description: `When true, prevents the user from interacting with the toggle group and all its items.`,
+      default: `false`,
+    },
+    {
+      name: 'onValueChange',
+      type: '(value: string[]) => void',
+      description: `Event handler called when the pressed state of an item changes and type is "multiple".`,
+    },
+    {
+      name: 'loop',
+      type: 'boolean',
+      description: `Whether or not to loop over after reaching the end or start of the items. Used mainly for managing keyboard navigation.`,
+      default: `true`,
+    },
+    {
+      name: 'disableDeactivation',
+      type: 'boolean',
+      description: `Won't let the user turn the active item off. Only applied to single toggle group.`,
+      default: 'false',
+    },
+    {
+      name: 'unstyled',
+      type: 'boolean',
+      default: 'false',
+      description: `When true, remove all default tamagui styling.`,
+    },
+    {
+      name: 'sizeAdjust',
+      type: 'number',
+      description: `Adjust the component's size scaling by this number.`,
+    },
+    {
+      name: 'toggledStyle',
+      type: 'object',
+      description: `Styles to apply to all items when they are in the pressed/active state. This is passed down via context to all ToggleGroup.Item children.`,
+    },
+  ]}
+/>
+
+### ToggleGroup.Item
+
+`ToggleGroup.Item` extend Stack views inheriting all the [Tamagui standard props](notion://www.notion.so/docs/intro/props), plus:
+
+<PropsTable
+  data={[
+    {
+      name: 'asChild',
+      type: 'boolean',
+      description: `When true, Tamagui expects a single child element. Instead of rendering its own element, it will pass all props to that child, merging together any event handling props.`,
+      default: `false`,
+    },
+    {
+      name: 'value',
+      type: 'string',
+      description: `The controlled value of the pressed item when type is "single".`,
+    },
+    {
+      name: 'disabled',
+      type: 'boolean',
+      description: `When true, prevents the user from interacting with the toggle group item.`,
+      default: `false`,
+    },
+    {
+      name: 'unstyled',
+      type: 'boolean',
+      default: 'false',
+      description: `When true, remove all default tamagui styling.`,
+    },
+    {
+      name: 'toggledStyle',
+      type: 'object',
+      description: `Styles to apply when the item is in the pressed/active state. Overrides any toggledStyle set on the parent ToggleGroup.`,
+    },
+  ]}
+/>
+
+When it is active, it will receive an `active` prop set to true. You can customize active styles in two ways:
+
+### Using toggledStyle prop
+
+The simplest way to customize the active state is with the `toggledStyle` prop:
+
+```tsx
+import { ToggleGroup } from '@tamagui/toggle-group'
+
+// Apply to all items via the parent
+<ToggleGroup type="single" toggledStyle={{ backgroundColor: '$green9', color: '$white' }}>
+  <ToggleGroup.Item value="a">A</ToggleGroup.Item>
+  <ToggleGroup.Item value="b">B</ToggleGroup.Item>
+</ToggleGroup>
+
+// Or apply to individual items
+<ToggleGroup type="single">
+  <ToggleGroup.Item value="a" toggledStyle={{ backgroundColor: '$red9' }}>A</ToggleGroup.Item>
+  <ToggleGroup.Item value="b" toggledStyle={{ backgroundColor: '$blue9' }}>B</ToggleGroup.Item>
+</ToggleGroup>
+```
+
+You can also use `toggledStyle` when creating styled components:
+
+```tsx
+import { ToggleGroup } from '@tamagui/toggle-group'
+import { styled } from 'tamagui'
+
+const MyToggleGroupItem = styled(ToggleGroup.Item, {
+  toggledStyle: {
+    backgroundColor: '$green9',
+    color: '$yellow9',
+  },
+})
+```
+
+### Using the active variant
+
+For more complex styling needs, you can use the `active` variant:
+
+```tsx
+import { ToggleGroup } from '@tamagui/toggle-group'
+import { styled } from 'tamagui'
+
+const MyToggleGroupItem = styled(ToggleGroup.Item, {
+  variants: {
+    active: {
+      true: {
+        backgroundColor: 'red'
+      },
+    },
+  },
+})
+```

--- a/code/ui/toggle-group/src/Toggle.tsx
+++ b/code/ui/toggle-group/src/Toggle.tsx
@@ -1,12 +1,13 @@
 import { composeEventHandlers } from '@tamagui/helpers'
 import { ThemeableStack } from '@tamagui/stacks'
 import { useControllableState } from '@tamagui/use-controllable-state'
-import type { GetProps } from '@tamagui/web'
+import type { GetProps, TamaguiElement } from '@tamagui/web'
 import { createStyledContext, styled, Text } from '@tamagui/web'
 import * as React from 'react'
 
 export const context = createStyledContext({
   color: '',
+  toggledStyle: null as null | Record<string, any>,
 })
 
 /* -------------------------------------------------------------------------------------------------
@@ -14,10 +15,6 @@ export const context = createStyledContext({
  * -----------------------------------------------------------------------------------------------*/
 
 const NAME = 'Toggle'
-
-type TamaguiButtonElement = HTMLButtonElement
-
-export type ToggleElement = TamaguiButtonElement
 
 export const ToggleFrame = styled(ThemeableStack, {
   name: NAME,
@@ -52,24 +49,24 @@ export const ToggleFrame = styled(ThemeableStack, {
       },
     },
 
-    color: {
-      '...color': () => {
-        return {}
-      },
-    },
-
     active: {
-      true: {
-        zIndex: 1,
-
-        hoverStyle: {
-          backgroundColor: '$background',
-        },
-
-        focusStyle: {
-          borderColor: '$borderColor',
-          backgroundColor: '$background',
-        },
+      true: (_, { props, context }: any) => {
+        const toggledStyle = context?.toggledStyle
+        return {
+          zIndex: 1,
+          ...(!props.unstyled &&
+            !toggledStyle && {
+              backgroundColor: '$background',
+              hoverStyle: {
+                backgroundColor: '$background',
+              },
+              focusStyle: {
+                backgroundColor: '$background',
+                borderColor: '$borderColor',
+              },
+            }),
+          ...toggledStyle,
+        }
       },
     },
 
@@ -98,11 +95,12 @@ type ToggleItemExtraProps = {
   pressed?: boolean
   defaultPressed?: boolean
   onPressedChange?(pressed: boolean): void
+  toggledStyle?: Record<string, any>
 }
 
 export type ToggleProps = ToggleFrameProps & ToggleItemExtraProps
 
-export const Toggle = React.forwardRef<ToggleElement, ToggleProps>(
+export const Toggle = React.forwardRef<TamaguiElement, ToggleProps>(
   function Toggle(props, forwardedRef) {
     const {
       pressed: pressedProp,
@@ -123,7 +121,7 @@ export const Toggle = React.forwardRef<ToggleElement, ToggleProps>(
           theme: pressed ? 'active' : null,
           themeShallow: true,
         })}
-        active={!props.unstyled ? pressed : undefined}
+        active={pressed}
         aria-pressed={pressed}
         data-state={pressed ? 'on' : 'off'}
         data-disabled={props.disabled ? '' : undefined}
@@ -131,7 +129,7 @@ export const Toggle = React.forwardRef<ToggleElement, ToggleProps>(
         ref={forwardedRef}
         onPress={composeEventHandlers(props.onPress ?? undefined, () => {
           if (!props.disabled) {
-            setPressed(!pressed)
+            setPressed((prev) => !prev)
           }
         })}
       />


### PR DESCRIPTION
## Summary

- Add `toggledStyle` prop to `ToggleGroup` and `ToggleGroup.Item` for easy active state customization
- Pass `toggledStyle` via styled context so it works with `styled()` components
- Add context access in `getVariantExtras` for variant functions to access styled context
- Add documentation for version 1.142.0

Based on #3733 by @DaveyEke, cleaned up to:
- Remove generated files (routes.d.ts, type declarations)
- Start fresh from main (original PR was very out of date)
- Add proper documentation

## Usage

```tsx
// Apply to all items via parent
<ToggleGroup type="single" toggledStyle={{ backgroundColor: '$green9' }}>
  <ToggleGroup.Item value="a">A</ToggleGroup.Item>
</ToggleGroup>

// Or per-item
<ToggleGroup.Item value="a" toggledStyle={{ backgroundColor: '$red9' }} />

// Or via styled()
const MyItem = styled(ToggleGroup.Item, {
  toggledStyle: { backgroundColor: '$green9', color: '$yellow9' },
})
```

Fixes #3706

Co-Authored-By: DaveyEke <daveyeke@users.noreply.github.com>