### PR TITLE
feat(kitchen-sink): add AccordionDemo

### DIFF
--- a/code/kitchen-sink/src/features/home/screen.tsx
+++ b/code/kitchen-sink/src/features/home/screen.tsx
@@ -168,6 +168,7 @@ const demos = [
   {
     label: 'Content',
     pages: [
+      { title: 'Accordion', route: '/demo/accordion' },
       { title: 'Avatar', route: '/demo/avatar' },
       { title: 'Card', route: '/demo/card' },
       { title: 'Group', route: '/demo/group' },


### PR DESCRIPTION
## Summary
- Adds Accordion demo to kitchen-sink home screen

Cleaned up version of #3732 by @DaveyEke - removed unrelated formatting changes to keep the diff minimal.