### PR TITLE
fix(progress): round decimal values to prevent native crash

### DIFF
--- a/code/tamagui.dev/data/docs/components/progress/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/progress/2.0.0.mdx
@@ -67,7 +67,7 @@ Progress extends [ThemeableStack](/docs/components/stacks#themeablestack), getti
       name: 'value',
       required: false,
       type: 'number | null',
-      description: `Control the percent progress.`,
+      description: `Control the percent progress. Decimal values are rounded to the nearest integer.`,
     },
     {
       name: 'max',

--- a/code/ui/progress/src/Progress.tsx
+++ b/code/ui/progress/src/Progress.tsx
@@ -13,7 +13,11 @@ import * as React from 'react'
 const PROGRESS_NAME = 'Progress'
 
 const [createProgressContext, createProgressScope] = createContextScope(PROGRESS_NAME)
-type ProgressContextValue = { value: number | null; max: number; width: number }
+type ProgressContextValue = {
+  value: number | null
+  max: number
+  width: number
+}
 const [ProgressProvider, useProgressContext] =
   createProgressContext<ProgressContextValue>(PROGRESS_NAME)
 
@@ -157,7 +161,7 @@ const Progress = withStaticProperties(
     } = props
 
     const max = isValidMaxNumber(maxProp) ? maxProp : DEFAULT_MAX
-    const value = isValidValueNumber(valueProp, max) ? valueProp : null
+    const value = isValidValueNumber(valueProp, max) ? Math.round(valueProp) : null // Math.round() so the component doesn't crash with decimal values such as 16.666
     const valueLabel = isNumber(value) ? getValueLabel(value, max) : undefined
     const [width, setWidth] = React.useState(0)
 


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/tamagui/tamagui/issues/3749), by rounding the value internally. I have also updated docs.