### PR TITLE
types: add autocomplete for default colors in createV5Theme

### DIFF
--- a/code/core/themes/src/v5-themes.ts
+++ b/code/core/themes/src/v5-themes.ts
@@ -273,7 +273,8 @@ export type CreateV5ThemeOptions = {
   /** Override the light base palette (12 colors from lightest to darkest) */
   lightPalette?: ColorPalette
   /** Add or override color themes (e.g., { brand: { dark: [...], light: [...] } }) */
-  colors?: Partial<Record<DefaultColorName, ColorDefinition>> & Record<string, ColorDefinition>
+  colors?: Partial<Record<DefaultColorName, ColorDefinition>> &
+    Record<string, ColorDefinition>
   /** Whether to include default color themes (blue, red, green, etc.). Defaults to true */
   includeDefaultColors?: boolean
   /** Add or override grandChildrenThemes (e.g., { alt1: { template: 'alt1' } }) */


### PR DESCRIPTION
This PR adds some autocomplete types for default colors in the createV5Theme helper function