### PR TITLE
fix(blog): fix blog title position

### DIFF
--- a/code/tamagui.dev/app/(site)/(blog)/blog/index.tsx
+++ b/code/tamagui.dev/app/(site)/(blog)/blog/index.tsx
@@ -25,10 +25,11 @@ export default function Blog() {
     <>
       <HeadInfo title="Blog — Tamagui" description="What's up with Tamagui." />
       <Spacer size="$7" />
-      <H2 als="center" size="$8" theme="alt2" fontFamily="$silkscreen">
-        Blog
-      </H2>
-      <ContainerLarge mt="$6" mb="$7">
+      <ContainerLarge mb="$7">
+        <H2 size="$8" theme="alt2" fontFamily="$silkscreen">
+          Blog
+        </H2>
+        <Spacer size="$6" />
         <XStack flexWrap="wrap" jc="space-between">
           {frontmatters.map((frontmatter) => (
             <Link asChild key={frontmatter.title} href={`/blog/${frontmatter.slug}`}>


### PR DESCRIPTION
This PR fixes the blog title not being currently positioned.

Before:
<img width="1003" height="758" alt="Screenshot 2026-01-03 at 11 53 51 AM" src="https://github.com/user-attachments/assets/45d7b964-8e20-49dc-a7a4-55c65cc34e34" />


After:

<img width="1003" height="758" alt="Screenshot 2026-01-03 at 12 01 39 PM" src="https://github.com/user-attachments/assets/cb276932-ba88-445d-95d6-fbc1c8d0ef1c" />
