### PR TITLE
fix(takeout.tsx): removed stray slash on the homepage

### DIFF
--- a/code/tamagui.dev/app/(site)/takeout.tsx
+++ b/code/tamagui.dev/app/(site)/takeout.tsx
@@ -965,7 +965,6 @@ const StarterCard = memo(() => {
           {seasons[name]}
         </SizableText>
       )}
-      \
       <TakeoutCardFrame
         bg="$color1"
         className="blur-medium"


### PR DESCRIPTION
This PR removes stray slash on the takeout homepage

Before:
<img width="387" height="319" alt="Screenshot 2026-01-04 at 7 20 00 AM" src="https://github.com/user-attachments/assets/2282e3da-3618-4440-8e9b-5f4e55d9ec8d" />

After: 
<img width="439" height="466" alt="Screenshot 2026-01-04 at 7 47 01 AM" src="https://github.com/user-attachments/assets/f07ef5d1-9537-4b53-af76-d1ef791072b9" />
