### PR TITLE
fix(site): fix docs code blocks, tint toggle, and vertical tabs

### DIFF
--- a/code/demos/src/TabsDemo.tsx
+++ b/code/demos/src/TabsDemo.tsx
@@ -126,13 +126,13 @@ const VerticalTabs = () => {
       borderColor="$borderColor"
     >
       <Tabs.List disablePassBorderRadius="end" aria-label="Manage your account">
-        <Tabs.Tab value="tab1">
+        <Tabs.Tab focusStyle={{ backgroundColor: '$color3' }} value="tab1">
           <SizableText>Profile</SizableText>
         </Tabs.Tab>
-        <Tabs.Tab value="tab2">
+        <Tabs.Tab focusStyle={{ backgroundColor: '$color3' }} value="tab2">
           <SizableText>Connections</SizableText>
         </Tabs.Tab>
-        <Tabs.Tab value="tab3">
+        <Tabs.Tab focusStyle={{ backgroundColor: '$color3' }} value="tab3">
           <SizableText>Notifications</SizableText>
         </Tabs.Tab>
       </Tabs.List>

--- a/code/tamagui.dev/features/docs/DocsCodeBlock.tsx
+++ b/code/tamagui.dev/features/docs/DocsCodeBlock.tsx
@@ -7,7 +7,7 @@ import {
   TerminalSquare,
 } from '@tamagui/lucide-icons'
 import { useStore } from '@tamagui/use-store'
-import { forwardRef, useEffect, useRef, useState } from 'react'
+import { forwardRef, useEffect, useId, useRef, useState } from 'react'
 import {
   AnimatePresence,
   Button,
@@ -29,8 +29,8 @@ import { toggleDocsTinted } from './docsTint'
 class CollapseStore {
   isCollapsed: boolean
 
-  constructor(initialState: { isCollapsed: boolean } = { isCollapsed: true }) {
-    this.isCollapsed = initialState.isCollapsed
+  constructor(props: { id: string; isCollapsed: boolean }) {
+    this.isCollapsed = props.isCollapsed
   }
 
   setIsCollapsed(val: boolean) {
@@ -58,7 +58,8 @@ export const DocCodeBlock = forwardRef((props: any, ref) => {
 
   const lines = Array.isArray(children) ? children.length : 0
   const isCollapsible = isHero || props.isCollapsible
-  const store = useStore(CollapseStore, { isCollapsed: showMore })
+  const storeId = useId()
+  const store = useStore(CollapseStore, { id: storeId, isCollapsed: showMore })
   const { isCollapsed, setIsCollapsed } = store
   const isLong = lines > 22
   const [isCutoff, setIsCutoff] = useState(isLong && !showMore)

--- a/code/tamagui.dev/features/docs/HeroContainer.tsx
+++ b/code/tamagui.dev/features/docs/HeroContainer.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from 'react'
 import { ThemeTint } from '@tamagui/logo'
+import { useIsDocsTinted } from './docsTint'
 import { Timer, Waves } from '@tamagui/lucide-icons'
 import {
   Configuration,
@@ -101,10 +103,18 @@ export function HeroContainer({
   )
 
   if (tinted) {
-    return <ThemeTint>{contents}</ThemeTint>
+    return <ThemeTintWithToggle>{contents}</ThemeTintWithToggle>
   }
 
   return contents
+}
+
+const ThemeTintWithToggle = ({ children }: { children: ReactNode }) => {
+  const isTinted = useIsDocsTinted()
+  if (!isTinted) {
+    return <Theme name="gray">{children}</Theme>
+  }
+  return <ThemeTint>{children}</ThemeTint>
 }
 
 const Card = styled(YStack, {

--- a/code/tamagui.dev/features/docs/docsTint.tsx
+++ b/code/tamagui.dev/features/docs/docsTint.tsx
@@ -19,8 +19,8 @@ export const useIsDocsTinted = () => {
   const [isTinted, setIsTinted] = useState(true)
 
   useEffect(() => {
-    const fn = () => {
-      setIsTinted((x) => !x)
+    const fn = (next: boolean) => {
+      setIsTinted(next)
     }
     listeners.add(fn)
     return () => {


### PR DESCRIPTION
## Summary

Clean re-implementation of fixes from #3757:

- Fix multiple code blocks opening together when clicking "Show Code" (uses unique store IDs per code block)
- Fix tint toggle not syncing state properly across components
- Add tint toggle support to HeroContainer for docs/blog demos
- Add focusStyle to vertical tabs for visual selection feedback

Fixes the issues described in #3757 with a clean diff against v2.