### PR TITLE
fix(themes): preserve color context in nested theme resolution

### DIFF
--- a/code/core/web/src/hooks/useThemeState.ts
+++ b/code/core/web/src/hooks/useThemeState.ts
@@ -397,24 +397,29 @@ function getNewThemeName(
       const parentScheme = getScheme(parentName)
 
       if (parentScheme) {
-        // Get the parent theme name without component part (already done in parentParts)
-        const parentBase = parentParts.join('_')
+        // Try progressively shorter parent bases to preserve color context
+        // For parent "light_blue_surface1" + name "surface3":
+        //   Try: light_blue_surface1_surface3, light_blue_surface3, light_surface3
+        // This ensures color context (blue) is preserved before falling back to scheme-only
 
-        // Try combining with full parent context first, then just scheme
-        // Prioritize component themes: try with componentName first, then without
-        // For parent "light" + name "green" + componentName "Button":
-        //   Try: light_green_Button, light_green (in that order)
-        const withScheme = [
-          componentName ? `${parentBase}_${name}_${componentName}` : undefined,
-          `${parentBase}_${name}`,
-          componentName ? `${parentScheme}_${name}_${componentName}` : undefined,
-          `${parentScheme}_${name}`,
-        ].filter(Boolean) as string[]
+        // Build list of potential bases from most specific to least specific
+        const potentialBases: string[] = []
+        for (let i = parentParts.length; i >= 1; i--) {
+          potentialBases.push(parentParts.slice(0, i).join('_'))
+        }
 
-        for (const potential of withScheme) {
-          if (potential in themes) {
-            found = potential
-            break
+        outer: for (const base of potentialBases) {
+          // Try with componentName first, then without
+          const candidates = [
+            componentName ? `${base}_${name}_${componentName}` : undefined,
+            `${base}_${name}`,
+          ].filter(Boolean) as string[]
+
+          for (const potential of candidates) {
+            if (potential in themes) {
+              found = potential
+              break outer
+            }
           }
         }
       }

--- a/code/kitchen-sink/src/constants/test-ids.ts
+++ b/code/kitchen-sink/src/constants/test-ids.ts
@@ -16,6 +16,9 @@ export const TEST_IDS = {
   nestedThemeRedDirect: 'nested-theme-red-direct',
   nestedThemeRedNested: 'nested-theme-red-nested',
   nestedThemeNoColor: 'nested-theme-no-color',
+  // Surface-to-surface nesting (exact reproduction from issue #3673)
+  nestedSurface1To3Direct: 'nested-surface-1-to-3-direct',
+  nestedSurface1To3Nested: 'nested-surface-1-to-3-nested',
   // Color Token Fallback test IDs (Issue #3620)
   colorTokenFallbackThemeValue: 'color-token-fallback-theme-value',
   colorTokenFallbackTokenValue: 'color-token-fallback-token-value',

--- a/code/kitchen-sink/src/usecases/ThemeNested.tsx
+++ b/code/kitchen-sink/src/usecases/ThemeNested.tsx
@@ -75,6 +75,29 @@ export function ThemeNested() {
           <Square id={TEST_IDS.nestedThemeNoColor} bg="$background" size={100} />
         </Theme>
       </YStack>
+
+      {/* Test Case 5: Exact reproduction from issue #3673 - surface1 → surface3 */}
+      <YStack gap="$2">
+        <Text fontWeight="bold">
+          Case 7: Direct light_blue_surface3 (expected result)
+        </Text>
+        <Theme name="light_blue_surface3">
+          <Square id={TEST_IDS.nestedSurface1To3Direct} bg="$background" size={100} />
+        </Theme>
+      </YStack>
+
+      <YStack gap="$2">
+        <Text fontWeight="bold">
+          Case 8: Nested blue → surface1 → surface3 (should match Case 7)
+        </Text>
+        <Theme name="blue">
+          <Theme name="surface1">
+            <Theme name="surface3">
+              <Square id={TEST_IDS.nestedSurface1To3Nested} bg="$background" size={100} />
+            </Theme>
+          </Theme>
+        </Theme>
+      </YStack>
     </YStack>
   )
 }


### PR DESCRIPTION
## Summary
- Fixes nested theme resolution to preserve color context when using surface themes
- When nesting themes like `blue → surface1 → surface3`, the inner theme now correctly resolves to `light_blue_surface3` instead of losing the blue context and falling back to `light_surface3`

Fixes #3673

## Changes
The theme resolution algorithm in `useThemeState.ts` was updated to iterate through progressively shorter parent bases instead of jumping from the full parent path directly to the scheme:

**Before:** Try `light_blue_surface1_surface3` → `light_surface3` (skips intermediate)
**After:** Try `light_blue_surface1_surface3` → `light_blue_surface3` → `light_surface3`

## Test plan
- [x] Added test case for exact reproduction from issue (blue → surface1 → surface3)
- [x] All theme-related tests pass (12 tests)
- [x] TypeScript type check passes
- [x] Lint passes