### PR TITLE
fix(input): fix the placeholder alignment on iOS

### DIFF
--- a/code/ui/input/src/shared.tsx
+++ b/code/ui/input/src/shared.tsx
@@ -89,6 +89,10 @@ export const textAreaSizeVariant: SizeVariantSpreadFunction<any> = (
   const lines = props.rows ?? props.numberOfLines
   const height =
     typeof lines === 'number' ? lines * getVariableValue(fontStyle.lineHeight) : 'auto'
+  // lineHeight messes up input on native
+  if (!isWeb && fontStyle) {
+    delete fontStyle['lineHeight']
+  }
   const paddingVertical = getSpace(val, {
     shift: -2,
     bounds: [2],


### PR DESCRIPTION
This PR fixes the issue of the placeholder alignment on IOS being broken on bigger text input sizes.

Before(Right: Android, Left:iOS):
<img width="908" height="100" alt="Screenshot 2026-01-07 at 2 40 21 PM" src="https://github.com/user-attachments/assets/a5088666-45bb-4c18-8ae0-cc431cd9bd11" />

After(Right: Android, Left:iOS):
<img width="908" height="100" alt="Screenshot 2026-01-07 at 8 56 50 PM" src="https://github.com/user-attachments/assets/852c0001-2d67-45a1-9569-b7b0b3f2dcf2" />
