### PR TITLE
fix: add insets to the tamaguu provider for kitchen-sink

### DIFF
--- a/code/kitchen-sink/src/provider/index.tsx
+++ b/code/kitchen-sink/src/provider/index.tsx
@@ -1,6 +1,8 @@
 import { ToastProvider } from '@tamagui/toast'
+import { isWeb } from '@tamagui/constants'
 import type { TamaguiProviderProps } from 'tamagui'
 import { TamaguiProvider } from 'tamagui'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import config from '../tamagui.config'
 
@@ -8,8 +10,9 @@ export function Provider({
   children,
   ...rest
 }: Omit<Partial<TamaguiProviderProps>, 'config'>) {
+  const insets = isWeb ? undefined : useSafeAreaInsets()
   return (
-    <TamaguiProvider config={config} defaultTheme="light" {...rest}>
+    <TamaguiProvider config={config} defaultTheme="light" insets={insets} {...rest}>
       <ToastProvider swipeDirection="horizontal">{children}</ToastProvider>
     </TamaguiProvider>
   )


### PR DESCRIPTION
This PR adds insets to the tamagui provider in kitchen-sink so the slider component works properly on iOS