### PR TITLE
fix(core): Add key remapping to PropsWithoutMediaStyles type

### DIFF
--- a/code/core/web/src/hooks/useProps.tsx
+++ b/code/core/web/src/hooks/useProps.tsx
@@ -28,7 +28,7 @@ type UsePropsOptions = Pick<
 
 export type PropsWithoutMediaStyles<A> = {
   // remove all media
-  [Key in keyof A extends `$${string}` ? never : keyof A]?: A[Key]
+  [Key in keyof A as Key extends `$${string}` ? never : Key]?: A[Key];
 }
 
 type PropsLikeObject = (ViewProps & Record<string, any>) | Object


### PR DESCRIPTION
## Problem

The `PropsWithoutMediaStyles` type doesn't properly filter out media query keys (properties starting with `$` like `$base`, `$sm`, `$md`, etc.) because it's missing the `as` keyword for key remapping in the mapped type.

## Current Implementation (Broken)

```typescript
type PropsWithoutMediaStyles<A> = {
  [Key in keyof A extends `$${string}` ? never : keyof A]?: A[Key];
};
```

This syntax doesn't actually filter keys - it evaluates keyof A extends '$${string}' (checking if the entire union of keys extends that pattern), which is not the intended behavior.


### Fix
```typescript
type PropsWithoutMediaStyles<A> = {
  [Key in keyof A as Key extends `$${string}` ? never : Key]?: A[Key];
};
```
The as clause (introduced in TypeScript 4.1) enables key remapping, which:
- Evaluates the condition for each individual key
- Maps keys matching $${string} to never, excluding them from the type
- Keeps all other keys unchanged


### Test

I created a [TS playground](https://www.typescriptlang.org/play/?noUncheckedIndexedAccess=true#code/PTACDsHsFVwYwBYFM4GskBMCS4NIB6YCCccSAzuQFA0AuAngA5IAEACgE6SPkDqAlrQQBZTPwCGLALwsA3lRaKWAEgBG48kgBcLcrQ79wAcwDcCperRGuAV1wBhSABtIHHXoPGzAXxogWAEIASgDyANIAogByVAzM7Fw8AkKQNrSiGBIAygxOFAA8RAB80nLm-hxIALaQAG6s4k5OLFVi4uYA2mFI9CyGLOj0kABmLEQsBLRIuOQsAAbKyrIehkbecywA-CzgSPUcLDqDI2MAups6RF09pz5+wCxxrAAqTEjJCKnpbaXy-koqdSaC66fSrFgAHxYdjww0MmDM-ws4istgczlcIJWxkh0NwSDhuwwiIevieLFezA+XwyElKnG4fEEnzStPEOXoeXI+QZSWZbKKNCo-gAYlgABoRAAisTeCUZ1NZbQ5XJF-EIGEKJRk8kUFWqdQaTRabU63V6-WOo3GGhY5om+CmM3mi2WYOM6y2Oz2SAOOnN50u13otyovmFD3JlPezJpbTVGt+EYBllQ1lS6JcHCx7qMuJhBPhxOTZLl0cV30y4gTmHpiSZKSVVZVFBrmt5DZEbUFNCAA) to illustrate the issue and the fix.

