### PR TITLE
fix: fixed mangled menu on the homepage

### DIFF
--- a/code/tamagui.dev/features/site/header/Header.tsx
+++ b/code/tamagui.dev/features/site/header/Header.tsx
@@ -818,7 +818,7 @@ const HeaderMenuMoreContents = () => {
         <Separator bg="$color02" opacity={0.25} my="$2" />
       </YStack>
 
-      <XStack flexWrap="wrap" flex={1} gap="$2" width="100%">
+      <XStack flexWrap="wrap" flexBasis="auto" gap="$2" width="100%">
         <Link asChild href="/docs/intro/introduction">
           <HeadAnchor grid half>
             Core
@@ -875,7 +875,7 @@ const HeaderMenuMoreContents = () => {
 
       <Separator bg="$color02" opacity={0.25} my="$2" />
 
-      <XStack flexWrap="wrap" flex={1} gap="$2" width="100%">
+      <XStack flexWrap="wrap" flexBasis="auto" gap="$2" width="100%">
         <Link asChild href="/takeout">
           <HeadAnchor grid half tag="a">
             <XStack items="center">
@@ -984,7 +984,9 @@ const HeadAnchor = styled(Paragraph, {
         letterSpacing: 1,
         textTransform: 'unset',
         width: '100%',
-        flex: 1,
+        flexGrow: 1,
+        flexShrink: 0,
+        flexBasis: 'auto',
         p: '$2',
         px: '$4',
 


### PR DESCRIPTION
This PR fixes the mangled menu on the homepage.

Before:
<img width="421" height="618" alt="Screenshot 2026-01-12 at 8 38 53 PM" src="https://github.com/user-attachments/assets/2c86303a-0905-451b-8591-61384b9fb6b5" />

After
<img width="421" height="618" alt="Screenshot 2026-01-12 at 8 47 45 PM" src="https://github.com/user-attachments/assets/2ab84ed0-57f2-44a0-bc79-44aa2c79944f" />
