### PR TITLE
fix(pro-dialog): increased the height of the pro dialog

### DIFF
--- a/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
+++ b/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
@@ -335,9 +335,9 @@ export function PurchaseModalContents() {
                       value={currentTab}
                       forceMount
                       flex={1}
-                      minH={400}
+                      minH={550}
                       $gtMd={{
-                        height: 'calc(min(100vh - 280px, 620px))',
+                        height: 'calc(min(100vh - 200px, 900px))',
                       }}
                     >
                       <YStack


### PR DESCRIPTION
This PR increases the size of the pro dialog. 

Before:
![DialogImage](https://github.com/user-attachments/assets/f2d3a022-c967-4d18-af0f-90391ee7f4cd)


After:
<img width="1440" height="900" alt="Screenshot 2026-01-13 at 12 00 29 PM" src="https://github.com/user-attachments/assets/68d0084a-cce4-4e23-ba04-7e2a2991a1fd" />
