### PR TITLE
fix(docs): remove old info about react-native-web dependency for image

### DIFF
--- a/code/tamagui.dev/data/docs/components/image/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/image/2.0.0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Image
-description: React Native Web Image + Tamagui style props.
+description: A pure, lightweight Image component with Tamagui style props.
 name: html
 component: Image
 package: image
@@ -109,7 +109,7 @@ export default () => (
 
 ### Image
 
-[Tamagui props](/docs/intro/props) + [React Native Web Image props](https://necolas.github.io/react-native-web/docs/image/).
+[Tamagui props](/docs/intro/props).
 
 | Prop | Type | Description |
 |------|------|-------------|


### PR DESCRIPTION
This PR removes old info about the image component being based on React Native Web.