### PR TITLE
fix: gave the docs menu a little padding

### DIFF
--- a/code/tamagui.dev/features/docs/DocsMenuContents.tsx
+++ b/code/tamagui.dev/features/docs/DocsMenuContents.tsx
@@ -64,7 +64,10 @@ export const DocsMenuContents = React.memo(function DocsMenuContents({
 
   return (
     <>
-      <div style={{ width: '100%', paddingBottom: inMenu ? 0 : 80 }} aria-label="Docs Menu">
+      <div
+        style={{ width: '100%', paddingBottom: inMenu ? 0 : 80 }}
+        aria-label="Docs Menu"
+      >
         {React.useMemo(() => {
           return (
             <>


### PR DESCRIPTION
This PR adds a little padding to the docs menu. 

Before
![Padding](https://github.com/user-attachments/assets/08335daf-1fc6-44b0-bce2-94c39b4f7531)

After:
<img width="401" height="181" alt="Screenshot 2026-01-13 at 7 13 04 PM" src="https://github.com/user-attachments/assets/89d365cd-ec68-40e9-8aee-0186d9a51ada" />
