### PR TITLE
fix(accordion-demo): added negative margin to remove double horizontal line

### DIFF
--- a/code/demos/src/AccordionDemo.tsx
+++ b/code/demos/src/AccordionDemo.tsx
@@ -4,7 +4,8 @@ import { Accordion, Paragraph, Square } from 'tamagui'
 export function AccordionDemo() {
   return (
     <Accordion overflow="hidden" width="$20" type="multiple">
-      <Accordion.Item value="a1">
+      {/* negative margin prevents double border between items */}
+      <Accordion.Item value="a1" mb={-1}>
         <Accordion.Trigger flexDirection="row" justify="space-between">
           {({
             open,


### PR DESCRIPTION
This PR adds a negative margin to remove the double horizontal line in the accordion demo

Before:
![Accordion](https://github.com/user-attachments/assets/20d7dbe6-1757-475b-9ed7-2ae31e49c9ab)

After:
<img width="923" height="470" alt="Screenshot 2026-01-13 at 7 24 51 PM" src="https://github.com/user-attachments/assets/b0bdf5ff-cf7f-4014-9552-293ab3eb44fc" />
