### PR TITLE
fix: improve the version select component

### DIFF
--- a/code/tamagui.dev/features/docs/SourceVersionSwitcher.tsx
+++ b/code/tamagui.dev/features/docs/SourceVersionSwitcher.tsx
@@ -79,8 +79,13 @@ export function SourceVersionSwitcher({
           />
         </Select.ScrollUpButton>
 
-        <Select.Viewport minW={200} borderWidth={1} borderColor="$borderColor" elevation="$3" br="$4">
-          <Select.Indicator transition="quicker" />
+        <Select.Viewport
+          minW={200}
+          borderWidth={1}
+          borderColor="$borderColor"
+          elevation="$3"
+          br="$4"
+        >
           <Select.Group>
             <Select.Label>Source Version</Select.Label>
             {React.useMemo(


### PR DESCRIPTION
This PR improves the version select component in the docs

Before:
![Source](https://github.com/user-attachments/assets/e98f06e9-4ae3-4750-8844-4ce3c1d48be4)


After:
<img width="217" height="356" alt="Screenshot 2026-01-13 at 8 54 36 PM" src="https://github.com/user-attachments/assets/b3f70c90-a782-4530-994a-1a41c06e5cdb" />
