### PR TITLE
fix(popover): added shadows to the popover demo

### DIFF
--- a/code/demos/src/PopoverDemo.tsx
+++ b/code/demos/src/PopoverDemo.tsx
@@ -90,7 +90,7 @@ export function Demo({
         height={200}
         enterStyle={{ y: -10, opacity: 0 }}
         exitStyle={{ y: -10, opacity: 0 }}
-        elevate
+        boxShadow="0px 4px 8px rgba(0,0,0,0.1), 0px 12px 32px rgba(0,0,0,0.08)"
         transition={[
           'quick',
           {


### PR DESCRIPTION
This PR adds some shadows to the popover demo

Before:

![Popover](https://github.com/user-attachments/assets/dde82345-5126-4f1f-a207-1756cc81ba94)

After:

<img width="532" height="503" alt="Screenshot 2026-01-13 at 9 46 02 PM" src="https://github.com/user-attachments/assets/23dad613-4cf7-48b8-a6bf-b6bd1e4905cb" />
