### PR TITLE
fix(sheet): use container-relative height for inline mode percentage snap points

### DIFF
--- a/code/ui/sheet/src/SheetImplementationCustom.tsx
+++ b/code/ui/sheet/src/SheetImplementationCustom.tsx
@@ -510,8 +510,8 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
     const forcedContentHeight = hasFit
       ? undefined
       : snapPointsMode === 'percent'
-        // Use dvh for modal (viewport-relative), % for inline (container-relative)
-        ? `${maxSnapPoint}${isWeb ? (modal ? 'dvh' : '%') : '%'}`
+        ? // Use dvh for modal (viewport-relative), % for inline (container-relative)
+          `${maxSnapPoint}${isWeb ? (modal ? 'dvh' : '%') : '%'}`
         : maxSnapPoint
 
     const setHasScrollView = React.useCallback((val: boolean) => {


### PR DESCRIPTION
This PR improves the Sheet Demo component to use container-relative height for inline mode percentage snap points

Before:
![Sheet](https://github.com/user-attachments/assets/26e7c5a2-fdad-4559-b088-2786123cdeaf)

After:

https://github.com/user-attachments/assets/7247d721-ce11-4553-baf1-6e4eb22c0413

