### PR TITLE
fix(focus-scope, dialogdemo): don't select text when refocusing for focus trap and add border radius to select.trigger

### DIFF
--- a/code/demos/src/DialogDemo.tsx
+++ b/code/demos/src/DialogDemo.tsx
@@ -117,7 +117,7 @@ function DialogInstance({ disableAdapt }: { disableAdapt?: boolean }) {
               <XStack flex={1}>
                 <SelectDemoContents
                   trigger={
-                    <Select.Trigger flex={1} iconAfter={ChevronDown}>
+                    <Select.Trigger flex={1} iconAfter={ChevronDown} borderRadius="$4">
                       <Select.Value placeholder="Something" />
                     </Select.Trigger>
                   }

--- a/code/ui/focus-scope/src/FocusScope.tsx
+++ b/code/ui/focus-scope/src/FocusScope.tsx
@@ -115,7 +115,8 @@ export function useFocusScope(
         target?.addEventListener('blur', handleBlur, { signal: controller.signal })
         lastFocusedElementRef.current = target
       } else {
-        focus(lastFocusedElementRef.current, { select: true })
+        // Don't select text when refocusing for focus trap - only refocus
+        focus(lastFocusedElementRef.current)
       }
     }
 
@@ -123,7 +124,8 @@ export function useFocusScope(
       controller.abort()
       if (focusScope.paused || !container) return
       if (!container.contains(event.relatedTarget as HTMLElement | null)) {
-        focus(lastFocusedElementRef.current, { select: true })
+        // Don't select text when refocusing for focus trap - only refocus
+        focus(lastFocusedElementRef.current)
       }
     }
 


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/tamagui/tamagui/issues/3813) on the v2 branch. 