### PR TITLE
fix(input): preserve explicit inputMode on native when type is not set

### DIFF
--- a/code/ui/input/src/Input.native.tsx
+++ b/code/ui/input/src/Input.native.tsx
@@ -50,6 +50,8 @@ export const Input = StyledInput.styleable<InputProps>((inProps, forwardedRef) =
     _enterKeyHint = undefined
   }
 
+  // Map HTML input types to React Native inputMode values.
+  // If inputMode is explicitly provided and type is not set, preserve the passed inputMode.
   let _inputMode = inputMode
   if (type === 'email') {
     _inputMode = 'email'
@@ -64,7 +66,8 @@ export const Input = StyledInput.styleable<InputProps>((inProps, forwardedRef) =
     _inputMode = 'text'
   } else if (type === 'number') {
     _inputMode = 'numeric'
-  } else {
+  } else if (!inputMode) {
+    // Only default to 'text' if inputMode was not explicitly provided
     _inputMode = 'text'
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `inputMode` prop passed to the `Input` component on native platforms (iOS/Android) was being ignored, always defaulting to `'text'`.

## Problem

In `Input.native.tsx`, the logic for mapping `type` to `inputMode` had an unconditional `else` clause:

```typescript
let _inputMode = inputMode
if (type === 'email') {
  _inputMode = 'email'
} else if (type === 'tel') {
  // ...
} else {
  _inputMode = 'text'  // BUG: Always overwrites inputMode!
}
```

This meant that if `type` was not one of the recognized values (which is the common case when only `inputMode` is specified), the explicitly passed `inputMode` would be overwritten with `'text'`.

## Solution

Changed the `else` clause to only apply the default when `inputMode` was not explicitly provided:

```typescript
} else if (!inputMode) {
  // Only default to 'text' if inputMode was not explicitly provided
  _inputMode = 'text'
}
```

## Before (broken)

```tsx
// User expects numeric keyboard, but gets standard text keyboard
<Input inputMode="numeric" placeholder="Enter amount" />
```

## After (fixed)

```tsx
// Now correctly shows numeric keyboard on iOS/Android
<Input inputMode="numeric" placeholder="Enter amount" />
```

## Testing

- Verified on iOS simulator that `inputMode="numeric"` now correctly shows the numeric keypad
- The fix is minimal (3 lines changed) and isolated to the native input mapping logic
- Existing web tests continue to pass

## Related Issues

- Fixes #2926 - `keyboardType`, `inputMode` & `secureTextEntry` props not working
- Fixes #3598 - Input keyboardType not working

Note: These issues were previously closed via #3149 which added web support, but the native-side bug was not addressed in that PR.