### PR TITLE
fix: add tween type to quickest animation

### DIFF
--- a/code/packages/tamagui-dev-config/src/animations.motion.ts
+++ b/code/packages/tamagui-dev-config/src/animations.motion.ts
@@ -73,6 +73,7 @@ export const animationsMotion = createAnimations({
     stiffness: 250,
   },
   quickest: {
+    type: 'tween',
     damping: 14,
     mass: 0.1,
     stiffness: 380,


### PR DESCRIPTION
This PR sets the tween animation type for the quick animation to enable menu close properly on safari