### PR TITLE
fix(menu): change demo transition from quickest -> 100ms

### DIFF
--- a/code/demos/src/ContextMenuDemo.tsx
+++ b/code/demos/src/ContextMenuDemo.tsx
@@ -33,7 +33,7 @@ export function ContextMenuDemo() {
           enterStyle={{ scale: 0.9, opacity: 0, y: -5 }}
           exitStyle={{ scale: 0.95, opacity: 0, y: -3 }}
           elevation="$3"
-          transition="quickest"
+          transition="200ms"
         >
           <ContextMenu.Arrow size="$4" borderWidth={1} borderColor="$borderColor" />
 
@@ -105,7 +105,7 @@ export function ContextMenuDemo() {
               <ContextMenu.SubContent
                 enterStyle={{ scale: 0.9, opacity: 0, x: -5 }}
                 exitStyle={{ scale: 0.95, opacity: 0, x: -3 }}
-                transition="quickest"
+                transition="200ms"
                 transformOrigin="left top"
                 elevation="$3"
                 minW={160}

--- a/code/demos/src/MenuDemo.tsx
+++ b/code/demos/src/MenuDemo.tsx
@@ -43,7 +43,7 @@ export function MenuDemo() {
 
         <Menu.Portal zIndex={100}>
           <Menu.Content
-            transition="quickest"
+            transition="200ms"
             borderRadius="$4"
             enterStyle={{ scale: 0.9, opacity: 0, y: -5 }}
             exitStyle={{ scale: 0.95, opacity: 0, y: -3 }}
@@ -109,7 +109,7 @@ export function MenuDemo() {
                 <Menu.SubContent
                   enterStyle={{ scale: 0.9, opacity: 0, x: -5 }}
                   exitStyle={{ scale: 0.95, opacity: 0, x: -3 }}
-                  transition="quickest"
+                  transition="200ms"
                   transformOrigin="left top"
                   elevation="$3"
                   minW={160}


### PR DESCRIPTION
This PR changes the demo transition from quickest -> 100ms to fix the menu closing lag bug in Safari