### PR TITLE
WIP: Output individual CSS transform properties for CSS-compatible drivers

### DIFF
--- a/code/core/animations-css/src/createAnimations.tsx
+++ b/code/core/animations-css/src/createAnimations.tsx
@@ -135,7 +135,11 @@ export function createAnimations<A extends Object>(animations: A): AnimationDriv
       let keys: string[]
       if (props.animateOnly) {
         // animateOnly is explicit filter
-        keys = props.animateOnly
+        // expand 'transform' to include individual CSS transform properties
+        // since we now output translate, scale, rotate instead of a combined transform
+        keys = props.animateOnly.flatMap((key) =>
+          key === 'transform' ? ['translate', 'scale', 'rotate'] : key
+        )
       } else if (hasPerPropertyConfigs && !hasDefault) {
         // object format without default: { opacity: '200ms' } = only animate opacity
         keys = animatedProperties

--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -2529,6 +2529,8 @@ export type GetStyleState = {
   fontFamily?: string
   debug?: DebugProp
   flatTransforms?: Record<string, any>
+  // when true, use individual CSS transform props (scale, translateX, etc.) instead of transform array
+  useIndividualTransforms?: boolean
   // Track style values that override context props (for issues #3670, #3676)
   overriddenContextProps?: Record<string, any>
   // Track original token values (like '$8') before they get resolved to CSS vars

--- a/code/core/web/types/types.d.ts
+++ b/code/core/web/types/types.d.ts
@@ -1448,6 +1448,7 @@ export type GetStyleState = {
     fontFamily?: string;
     debug?: DebugProp;
     flatTransforms?: Record<string, any>;
+    useIndividualTransforms?: boolean;
     overriddenContextProps?: Record<string, any>;
     originalContextPropValues?: Record<string, any>;
 };

--- a/code/kitchen-sink/tests/StyledButtonVariantPseudoMerge.animated.test.tsx
+++ b/code/kitchen-sink/tests/StyledButtonVariantPseudoMerge.animated.test.tsx
@@ -15,19 +15,22 @@ test(`pseudo + variant with pseudo should merge`, async ({ page }) => {
   const button = page.locator('button#test')
   const pressStyles = await getPressStyle(button, { delay: 3000 })
   expect(pressStyles.backgroundColor).toBe(`rgb(255, 0, 0)`)
-  expect(pressStyles.transform).toBe(`matrix(0.5, 0, 0, 0.5, 0, 0)`)
+  // CSS driver uses individual scale property instead of transform matrix
+  expect(pressStyles.scale).toBe(`0.5`)
 })
 
 test(`animation + pseudo + variant with pseudo should merge`, async ({ page }) => {
   const button = page.locator('#animated')
   const pressStyles = await getPressStyle(button, { delay: 3000 })
   expect(pressStyles.backgroundColor).toBe(`rgb(255, 0, 0)`)
-  expect(pressStyles.transform).toBe(`matrix(0.5, 0, 0, 0.5, 0, 0)`)
+  // CSS driver uses individual scale property instead of transform matrix
+  expect(pressStyles.scale).toBe(`0.5`)
 })
 
 test(`styled without variants HOC of HOC + pseudo`, async ({ page }) => {
   const button = page.locator('#double-styled')
   const pressStyles = await getPressStyle(button, { delay: 3000 })
   expect(pressStyles.backgroundColor).toBe(`rgb(255, 0, 0)`)
-  expect(pressStyles.transform).toBe(`matrix(0.5, 0, 0, 0.5, 0, 0)`)
+  // CSS driver uses individual scale property instead of transform matrix
+  expect(pressStyles.scale).toBe(`0.5`)
 })

--- a/code/kitchen-sink/tests/TooltipAnimation.animated.test.tsx
+++ b/code/kitchen-sink/tests/TooltipAnimation.animated.test.tsx
@@ -31,7 +31,21 @@ async function getTranslateY(page: Page, testId: string): Promise<number> {
     (id) => {
       const el = document.querySelector(`[data-testid="${id}"]`)
       if (!el) return -9999
-      const transform = getComputedStyle(el).transform
+      const styles = getComputedStyle(el)
+      // check individual CSS translate property first
+      const translate = styles.translate
+      if (translate && translate !== 'none') {
+        // translate can be "100px" or "100px 50px" or "100px 50px 0px"
+        // Y is the second value
+        const parts = translate.split(/\s+/)
+        if (parts.length >= 2) {
+          const yMatch = parts[1].match(/^(-?[\d.]+)px/)
+          return yMatch ? Number.parseFloat(yMatch[1]) : 0
+        }
+        return 0 // only X value, Y is 0
+      }
+      // fall back to parsing transform matrix
+      const transform = styles.transform
       if (transform === 'none') return 0
       // matrix(a, b, c, d, tx, ty) - translateY is in the 'ty' position (6th value)
       const match = transform.match(/matrix\([^,]+,[^,]+,[^,]+,[^,]+,[^,]+,\s*([^)]+)\)/)

--- a/code/kitchen-sink/tests/TransitionEnterExit.animated.test.tsx
+++ b/code/kitchen-sink/tests/TransitionEnterExit.animated.test.tsx
@@ -28,10 +28,25 @@ async function getScale(page: Page, testId: string): Promise<number> {
     (id) => {
       const el = document.querySelector(`[data-testid="${id}"]`)
       if (!el) return -1
-      const transform = getComputedStyle(el).transform
-      if (transform === 'none') return 1
-      const match = transform.match(/matrix\(([^,]+),/)
-      return match ? Number.parseFloat(match[1]) : 1
+      const styles = getComputedStyle(el)
+
+      // check transform matrix first - motion uses transform: scale()
+      // which shows up in the computed transform matrix
+      const transform = styles.transform
+      if (transform && transform !== 'none') {
+        const match = transform.match(/matrix\(([^,]+),/)
+        if (match) {
+          return Number.parseFloat(match[1])
+        }
+      }
+
+      // fall back to individual CSS scale property
+      const scale = styles.scale
+      if (scale && scale !== 'none') {
+        return Number.parseFloat(scale)
+      }
+
+      return 1
     },
     testId
   )


### PR DESCRIPTION
## Summary

This PR changes Tamagui to output individual CSS transform properties (`translate`, `scale`, `rotate`) instead of combined transform strings when the animation driver has `supportsCSS: true`.

## Problem

The motion driver was using a complex matrix parsing hack to extract individual transform values from the combined `transform` CSS property. This was fragile and caused issues.

## Solution

Output individual CSS transform properties directly:
- `x`/`y`/`translateX`/`translateY` → combined into CSS `translate` property
- `scale` → CSS `scale` property  
- `rotate` → CSS `rotate` property

## ⚠️ Important Discovery

**Motion does NOT use WAAPI for individual transform props.** From [Motion's docs](https://motion.dev/guides/waapi-improvements):

> "Motion supports individual transform properties including: x, y, scale, rotate etc... **Under the hood, it is animating CSS variables, and currently these are not accelerated**, even though they're being applied to transform."

This means when we pass individual props like `x`, `scale`, `rotate` to motion's `animate()`, it uses **requestAnimationFrame + CSS variables** instead of hardware-accelerated WAAPI.

For WAAPI acceleration, motion requires the full `transform` string:
```js
animate(".box", { transform: "translateX(100px) scale(2)" })
```

## Status

- ✅ All tests pass
- ⚠️ Implementation needs cleanup
- ⚠️ Need to decide: keep individual props (simpler code, no matrix parsing) vs. build transform strings for motion (WAAPI acceleration)

## Files Changed

- `code/core/web/src/helpers/getSplitStyles.tsx` - Output `translate` instead of `translateX`/`translateY`
- `code/core/animations-motion/src/createAnimations.tsx` - Clear CSS transform props before animating
- `code/core/animations-css/src/createAnimations.tsx` - Expand `transform` in animateOnly to individual props
- Test helpers updated to check new CSS properties