### PR TITLE
Fix DynamicColorIOS objects breaking backgroundImage/boxShadow CSS strings on iOS

### DIFF
--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -70,10 +70,16 @@ export const propMapper: PropMapper = (key, value, styleState, disabled, map) =>
     ) {
       // boxShadow/filter/backgroundImage/border with embedded $tokens - resolve each token
       // Try size first (for dimensions), then color (for the color value)
+      // On native, force 'value' resolution — DynamicColorIOS objects can't be
+      // embedded in CSS strings (String() produces '[object Object]')
+      const embeddedStyleProps =
+        process.env.TAMAGUI_TARGET === 'native'
+          ? { ...styleProps, resolveValues: 'value' as ResolveVariableAs }
+          : styleProps
       value = value.replace(/(\$[\w.-]+)/g, (t) => {
-        let r = getTokenForKey('size', t, styleProps, styleState)
+        let r = getTokenForKey('size', t, embeddedStyleProps, styleState)
         if (r == null) {
-          r = getTokenForKey('color', t, styleProps, styleState)
+          r = getTokenForKey('color', t, embeddedStyleProps, styleState)
         }
         return r != null ? String(r) : t
       })


### PR DESCRIPTION
## Problem

`backgroundImage` with `linear-gradient()` and embedded theme tokens (like `$color3`) renders nothing on iOS when `fastSchemeChange` is enabled (the default in `@tamagui/config/v5`).

On iOS with `fastSchemeChange`, theme variable `.get()` returns DynamicColorIOS objects:
```js
{ dynamic: { light: '#F6DDE6', dark: '#3D1F2B' } }
```

In `propMapper.ts`, the regex replacement for embedded `$tokens` in CSS strings calls `getTokenForKey` → `resolveVariableValue` → `.get(undefined)`, then wraps the result with `String(r)`. On a DynamicColorIOS object this produces `'[object Object]'`, so the final gradient becomes:
```
linear-gradient([object Object] 0%, [object Object] 100%)
```
RN's `processBackgroundImage` then fails silently.

Same issue affects `boxShadow`, `textShadow`, `filter`, and `border` with embedded theme tokens.

## Fix

For the CSS string token interpolation path on native, force `resolveValues: 'value'` so `resolveVariableValue` returns `.val` (plain hex string) instead of calling `.get()` (which returns DynamicColorIOS).

This follows the same principle as the existing `shadowColor` guard in `resolveVariableValue` — both bypass DynamicColorIOS for style properties that don't support it. Theme reactivity is preserved because the `.val` getter still triggers `track(key, false)`, ensuring re-renders on scheme changes.

On web, behavior is unchanged (the `TAMAGUI_TARGET` check is dead-code eliminated).

## Tests

Added two regression tests in `getSplitStyles.ios.test.tsx` that:
- Create a properly proxied theme with `getThemeProxied` (so `.get()` returns DynamicColorIOS)
- Mock `doesRootSchemeMatchSystem` → `true`, `isIos` → `true`, `fastSchemeChange` → `true`
- Use `resolveValues: 'auto'` (matching real rendering)
- Verify `backgroundImage` and `boxShadow` resolve to hex strings, not `[object Object]`

All existing tests (native, web, iOS) continue to pass.