### PR TITLE
package.json fixes

### DIFF
--- a/code/ui/context-menu/package.json
+++ b/code/ui/context-menu/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0-rc.6-1770450745210",
   "gitHead": "a49cc7ea6b93ba384e77a4880ae48ac4a5635c14",
   "source": "src/index.ts",
+  "type": "module",
   "files": [
     "src",
     "types",

--- a/code/ui/focus-guard/package.json
+++ b/code/ui/focus-guard/package.json
@@ -2,6 +2,7 @@
   "name": "@tamagui/focus-guard",
   "version": "2.0.0-rc.6-1770450745210",
   "source": "src/index.ts",
+  "type": "module",
   "files": [
     "src",
     "types",
@@ -11,6 +12,19 @@
   "main": "dist/cjs",
   "module": "dist/esm",
   "types": "./types/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./types/index.d.ts",
+      "react-native": {
+        "import": "./dist/esm/index.native.js",
+        "require": "./dist/cjs/index.native.js"
+      },
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.cjs",
+      "default": "./dist/cjs/index.native.js"
+    }
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Was running into some build issues where the `create-menu` package was seeing the import from `focus-guard` as CJS. This seemed to resolve. Also checked to make sure all other package.json's are consistent and identified `context-menu` was missing `type`. Should resolve both issues.