### PR TITLE
fix(use-event): use useInsertionEffect for ref updates in useGet

### DIFF
--- a/code/core/use-event/package.json
+++ b/code/core/use-event/package.json
@@ -31,9 +31,7 @@
     "clean": "tamagui-build clean",
     "clean:build": "tamagui-build clean:build"
   },
-  "dependencies": {
-    "@tamagui/constants": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@tamagui/build": "workspace:*",
     "react": ">=19"

--- a/code/core/use-event/src/useGet.ts
+++ b/code/core/use-event/src/useGet.ts
@@ -1,5 +1,14 @@
-import { useIsomorphicLayoutEffect } from '@tamagui/constants'
 import * as React from 'react'
+
+const isServer = typeof window === 'undefined'
+
+// Use useInsertionEffect on the client to ensure the ref is updated before any
+// useLayoutEffect reads the returned callback. This fixes a React 19 timing
+// issue where a consumer's useLayoutEffect could fire before this ref update,
+// causing stale values. Falls back to useLayoutEffect for React < 18.3.
+const useIsomorphicInsertionEffect = isServer
+  ? React.useEffect
+  : React.useInsertionEffect || React.useLayoutEffect
 
 // keeps a reference to the current value easily
 
@@ -9,7 +18,7 @@ export function useGet<A>(
   forwardToFunction?: boolean
 ): () => A {
   const curRef = React.useRef<any>(initialValue ?? currentValue)
-  useIsomorphicLayoutEffect(() => {
+  useIsomorphicInsertionEffect(() => {
     curRef.current = currentValue
   })
 


### PR DESCRIPTION
## Summary

Replaces `useIsomorphicLayoutEffect` with `useInsertionEffect` in `useGet` to fix a **React 19 timing issue** where stale callback values could be observed.

### The Problem

`useGet` keeps a ref in sync with the latest value and returns a stable callback that reads from it. The ref update was happening inside `useIsomorphicLayoutEffect` (which resolves to `useLayoutEffect` on the client). In React 19, the ordering of `useLayoutEffect` across components is not guaranteed to match the order you might expect — a **consumer's** `useLayoutEffect` can fire **before** `useGet`'s layout effect has updated the ref, causing the returned callback to read a stale value.

This is particularly impactful for `useEvent`, which delegates to `useGet` and is widely used throughout Tamagui for stable event callbacks.

### The Fix

- Use `React.useInsertionEffect` (falling back to `useLayoutEffect` for React < 18.3) instead of `useIsomorphicLayoutEffect`
- `useInsertionEffect` fires **before all** `useLayoutEffect` callbacks, guaranteeing the ref is always current when any consumer reads it
- On the server, `useEffect` is used (same as before) since insertion/layout effects don't run during SSR
- This is safe because `useGet` only **writes** to `ref.current` (a plain property assignment) — it doesn't read DOM refs or do anything the React docs warn against for `useInsertionEffect`

### Side Effect

Removes the `@tamagui/constants` dependency from `@tamagui/use-event` since the isomorphic effect selection is now self-contained (3 lines).

## Test Plan

- [x] Verified this fixes stale callback issues in React 19 applications using `useEvent` / `useGet`
- [ ] Existing tests should continue to pass — the behavioral contract is identical, only the timing is tightened