### PR TITLE
 fix(button, list-item): resolve icon color from theme when not explicitly set

### DIFF
--- a/code/kitchen-sink/src/usecases/ButtonIconColor.tsx
+++ b/code/kitchen-sink/src/usecases/ButtonIconColor.tsx
@@ -1,18 +1,82 @@
 import { Moon } from '@tamagui/lucide-icons'
-import { Button, ListItem, Theme, YStack } from 'tamagui'
+import { Button, ListItem, Text } from 'tamagui'
 
 export function ButtonIconColor() {
   return (
-    <YStack gap="$4" padding="$4">
-      {/* button icon should get theme color */}
-      <Theme name="red">
-        <Button testID="button-themed" icon={Moon} />
-      </Theme>
+    <>
+      {/* Button with theme - icon should get the theme's color */}
+      <Button
+        testID="button-themed"
+        theme="red"
+        size="$3"
+        icon={({ color, size }) => {
+          return (
+            <>
+              <Text testID="icon-color-themed" opacity={0}>
+                {String(color ?? 'undefined')}
+              </Text>
+              <Moon color={color} size={size} />
+            </>
+          )
+        }}
+      >
+        Themed
+      </Button>
 
-      {/* listitem icon should get theme color */}
-      <Theme name="red">
-        <ListItem testID="listitem-themed" icon={Moon} />
-      </Theme>
-    </YStack>
+      {/* Button with no theme or color - icon color should still resolve */}
+      <Button
+        testID="button-default"
+        size="$3"
+        icon={({ color, size }) => {
+          return (
+            <>
+              <Text testID="icon-color-default" opacity={0}>
+                {String(color ?? 'undefined')}
+              </Text>
+              <Moon color={color} size={size} />
+            </>
+          )
+        }}
+      >
+        Default
+      </Button>
+
+      {/* ListItem with theme - icon should get the theme's color */}
+      <ListItem
+        testID="listitem-themed"
+        theme="red"
+        size="$3"
+        icon={({ color, size }) => {
+          return (
+            <>
+              <Text testID="listitem-icon-color-themed" opacity={0}>
+                {String(color ?? 'undefined')}
+              </Text>
+              <Moon color={color} size={size} />
+            </>
+          )
+        }}
+      >
+        ListItem Themed
+      </ListItem>
+
+      {/* ListItem with no theme - icon color should still resolve */}
+      <ListItem
+        testID="listitem-default"
+        size="$3"
+        icon={({ color, size }) => {
+          return (
+            <>
+              <Text testID="listitem-icon-color-default" opacity={0}>
+                {String(color ?? 'undefined')}
+              </Text>
+              <Moon color={color} size={size} />
+            </>
+          )
+        }}
+      >
+        ListItem Default
+      </ListItem>
+    </>
   )
 }

--- a/code/kitchen-sink/tests/ButtonIconColor.test.tsx
+++ b/code/kitchen-sink/tests/ButtonIconColor.test.tsx
@@ -6,18 +6,26 @@ test.beforeEach(async ({ page }) => {
   await setupPage(page, { name: 'ButtonIconColor', type: 'useCase' })
 })
 
-test(`button icon receives color from theme`, async ({ page }) => {
-  const button = page.getByTestId('button-themed')
-  const path = button.locator('svg path').first()
-  const stroke = await path.evaluate((el) => getComputedStyle(el).stroke)
-  expect(stroke).toBeTruthy()
-  expect(stroke).not.toBe('none')
+test(`Button icon receives color from theme`, async ({ page }) => {
+  const colorText = await page.getByTestId('icon-color-themed').textContent()
+  expect(colorText).not.toBe('undefined')
+  expect(colorText).toBeTruthy()
 })
 
-test(`listitem icon receives color from theme`, async ({ page }) => {
-  const listitem = page.getByTestId('listitem-themed')
-  const path = listitem.locator('svg path').first()
-  const stroke = await path.evaluate((el) => getComputedStyle(el).stroke)
-  expect(stroke).toBeTruthy()
-  expect(stroke).not.toBe('none')
+test(`Button icon receives color with default theme`, async ({ page }) => {
+  const colorText = await page.getByTestId('icon-color-default').textContent()
+  expect(colorText).not.toBe('undefined')
+  expect(colorText).toBeTruthy()
+})
+
+test(`ListItem icon receives color from theme`, async ({ page }) => {
+  const colorText = await page.getByTestId('listitem-icon-color-themed').textContent()
+  expect(colorText).not.toBe('undefined')
+  expect(colorText).toBeTruthy()
+})
+
+test(`ListItem icon receives color with default theme`, async ({ page }) => {
+  const colorText = await page.getByTestId('listitem-icon-color-default').textContent()
+  expect(colorText).not.toBe('undefined')
+  expect(colorText).toBeTruthy()
 })


### PR DESCRIPTION
 ## Summary
  - Button and ListItem `icon` prop received `undefined` for `color` unless explicitly set — the v2 rewrite
  dropped `useCurrentColor` theme resolution that v1 had
  - Restores theme-aware color fallback using `useCurrentColor(styledContext?.color)` so icons get `theme.color`
  (e.g. `var(--color)`) automatically
  - Adds kitchen-sink playwright tests covering Button and ListItem icon color resolution
  - fixes this discord [issue](https://discord.com/channels/909986013848412191/1471206756481892504)