### PR TITLE
fix(popper): forward direction prop to floating wrapper for RTL detection

### DIFF
--- a/code/ui/popper/src/Popper.tsx
+++ b/code/ui/popper/src/Popper.tsx
@@ -662,6 +662,7 @@ export const PopperContent = React.forwardRef<PopperContentElement, PopperConten
       <TamaguiView
         passThrough={passThrough}
         ref={contentRefs}
+        direction={(rest as any).direction}
         {...(passThrough ? null : floatingProps)}
         {...(!passThrough &&
           animatePos && {


### PR DESCRIPTION
When using Popover/Tooltip in an RTL layout, `start`/`end` alignment placements like `top-start` or `bottom-end` don't flip - the popover always behaves as if it's LTR.


The issue is that `@floating-ui/dom` checks `getComputedStyle(element).direction` on the floating element to determine RTL, but the `direction` prop passed to `PopperContent` only ends up on the inner content frame, not on the outer wrapper element that floating-ui actually inspects. So `platform.isRTL()` always returns `false`.

Whatever is accepted, could it also be cherry-picked to v1