### PR TITLE
fix(menu): menu not show on android

### DIFF
--- a/code/core/native/src/index.ts
+++ b/code/core/native/src/index.ts
@@ -67,6 +67,7 @@ export type { KeyboardControllerState } from './keyboardControllerState'
 // zeego (native menus)
 export { getZeego } from './zeegoState'
 export type { ZeegoAccessor } from './zeegoState'
+export { NativeMenuContext } from './nativeMenuContext'
 
 // burnt (native toasts)
 export { getBurnt } from './burntState'

--- a/code/core/native/src/nativeMenuContext.ts
+++ b/code/core/native/src/nativeMenuContext.ts
@@ -1,0 +1,4 @@
+import type React from 'react'
+import { createContext } from 'react'
+
+export const NativeMenuContext: React.Context<boolean> = createContext(false)

--- a/code/core/native/types/index.d.ts
+++ b/code/core/native/types/index.d.ts
@@ -33,6 +33,7 @@ export { isKeyboardControllerEnabled, getKeyboardControllerState, setKeyboardCon
 export type { KeyboardControllerState } from "./keyboardControllerState";
 export { getZeego } from "./zeegoState";
 export type { ZeegoAccessor } from "./zeegoState";
+export { NativeMenuContext } from "./nativeMenuContext";
 export { getBurnt } from "./burntState";
 export type { BurntAccessor } from "./burntState";
 export { NativePortal, NativePortalHost, NativePortalProvider } from "./components";

--- a/code/core/native/types/nativeMenuContext.d.ts
+++ b/code/core/native/types/nativeMenuContext.d.ts
@@ -1,0 +1,4 @@
+import type React from "react";
+export declare const NativeMenuContext: React.Context<boolean>;
+
+//# sourceMappingURL=nativeMenuContext.d.ts.map

--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -1,5 +1,6 @@
 import { composeRefs } from '@tamagui/compose-refs'
 import { isClient, isServer, isWeb, useIsomorphicLayoutEffect } from '@tamagui/constants'
+import { NativeMenuContext } from '@tamagui/native'
 import { composeEventHandlers } from '@tamagui/helpers'
 import { isEqualShallow } from '@tamagui/is-equal-shallow'
 import React, { ReactElement, ReactNode, useMemo } from 'react'
@@ -279,6 +280,14 @@ export function createComponent<
 
     const componentContext = React.useContext(ComponentContext)
     const hasTextAncestor = !!(isWeb && isText ? componentContext.inText : false)
+
+    // On Android, skip RNGH GestureDetector inside native menus (zeego) and use
+    // direct press events instead — GestureDetector consumes touches before they
+    // reach MenuView's native handler, preventing the menu from opening
+    const isInsideNativeMenu =
+      process.env.TAMAGUI_TARGET === 'native'
+        ? React.useContext(NativeMenuContext)
+        : false
 
     if (
       !process.env.TAMAGUI_IS_CORE_NODE &&
@@ -1377,7 +1386,7 @@ export function createComponent<
     // Skip gesture setup for HOC components - they may return null which crashes GestureDetector
     const pressGesture =
       process.env.TAMAGUI_TARGET === 'native'
-        ? useEvents(events, viewProps, stateRef, staticConfig, isHOC)
+        ? useEvents(events, viewProps, stateRef, staticConfig, isHOC, isInsideNativeMenu)
         : null
 
     if (process.env.NODE_ENV === 'development' && time) time`hooks`

--- a/code/core/web/src/eventHandling.ts
+++ b/code/core/web/src/eventHandling.ts
@@ -37,7 +37,8 @@ export function useEvents(
   _viewProps: any,
   _stateRef: { current: any },
   _staticConfig: any,
-  _isHOC?: boolean
+  _isHOC?: boolean,
+  _isInsideNativeMenu?: boolean
 ) {
   return null
 }

--- a/code/core/web/types/eventHandling.d.ts
+++ b/code/core/web/types/eventHandling.d.ts
@@ -22,6 +22,6 @@ export declare function wrapWithGestureDetector(content: any, _gesture: any, _st
 }, _isHOC?: boolean): any;
 export declare function useEvents(_events: any, _viewProps: any, _stateRef: {
     current: any;
-}, _staticConfig: any, _isHOC?: boolean): null;
+}, _staticConfig: any, _isHOC?: boolean, _isInsideNativeMenu?: boolean): null;
 export {};
 //# sourceMappingURL=eventHandling.d.ts.map

--- a/code/core/web/types/eventHandling.native.d.ts
+++ b/code/core/web/types/eventHandling.native.d.ts
@@ -5,7 +5,7 @@ import type { StaticConfig, TamaguiComponentStateRef } from './types';
 export declare function getWebEvents(): {};
 export declare function useEvents(events: any, viewProps: any, stateRef: {
     current: TamaguiComponentStateRef;
-}, staticConfig: StaticConfig, isHOC?: boolean): any;
+}, staticConfig: StaticConfig, isHOC?: boolean, isInsideNativeMenu?: boolean): any;
 export declare function wrapWithGestureDetector(content: any, gesture: any, stateRef: {
     current: TamaguiComponentStateRef;
 }, isHOC?: boolean): any;

--- a/code/ui/menu/src/Menu.tsx
+++ b/code/ui/menu/src/Menu.tsx
@@ -123,9 +123,11 @@ export function createMenu(params: CreateBaseMenuProps) {
   })
 
   // on native, ScrollView is just a passthrough since native menus handle overflow
-  const ScrollView = isWeb
-    ? NonNativeMenu.ScrollView
-    : ({ children }: { children: React.ReactNode }) => <>{children}</>
+  const NativeScrollView = ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  )
+  NativeScrollView.displayName = 'MenuScrollView'
+  const ScrollView = isWeb ? NonNativeMenu.ScrollView : NativeScrollView
 
   const Menu = withStaticProperties(MenuComp, {
     Trigger,

--- a/code/ui/menu/types/Menu.d.ts
+++ b/code/ui/menu/types/Menu.d.ts
@@ -124,8 +124,11 @@ export declare function createMenu(params: CreateBaseMenuProps): React.FC<import
         accept: {
             readonly contentContainerStyle: "style";
         };
-    } & import("@tamagui/web").StaticConfigPublic> | (({ children }: {
-        children: React.ReactNode;
-    }) => import("react/jsx-runtime").JSX.Element);
+    } & import("@tamagui/web").StaticConfigPublic> | {
+        ({ children }: {
+            children: React.ReactNode;
+        }): import("react/jsx-runtime").JSX.Element;
+        displayName: string;
+    };
 };
 //# sourceMappingURL=Menu.d.ts.map

--- a/code/ui/menu/types/index.d.ts
+++ b/code/ui/menu/types/index.d.ts
@@ -123,8 +123,11 @@ export declare const Menu: import("react").FC<import("./createNonNativeMenu").Me
         accept: {
             readonly contentContainerStyle: "style";
         };
-    } & import("@tamagui/web").StaticConfigPublic> | (({ children }: {
-        children: React.ReactNode;
-    }) => import("react/jsx-runtime").JSX.Element);
+    } & import("@tamagui/web").StaticConfigPublic> | {
+        ({ children }: {
+            children: React.ReactNode;
+        }): import("react/jsx-runtime").JSX.Element;
+        displayName: string;
+    };
 };
 //# sourceMappingURL=index.d.ts.map


### PR DESCRIPTION
Fix native Android dropdown menus not showing when @tamagui/native/setup-gesture-handler is imported.

**Root Cause 1: RNGH gesture blocks MenuView touches**

When RNGH is enabled, Tamagui wraps components with GestureDetector using Gesture.Tap(). On Android, when Tap goes ACTIVE it sends ACTION_CANCEL up the view hierarchy, killing MenuView's native touch recognition so the menu never opens.

Fix: Detect when a component is inside a native menu (via NativeMenuContext on Android) and use Gesture.Manual() with manualActivation(true) instead. This fires press callbacks via onTouchesDown/onTouchesUp but never goes ACTIVE, so MenuView touch handling is preserved.

**Root Cause 2: ScrollView wrapper hides menu items from zeego**

On native, Menu.ScrollView is a passthrough (<>{children}</>) but zeego's flattenChildren only unwraps React.Fragment, not custom wrapper components. Menu items inside the ScrollView wrapper become invisible to zeego.

Fix: Add displayName to the native ScrollView passthrough and flatten it in transformForZeego so zeego sees the menu items directly.