### PR TITLE
fix(popper): backport RTL direction prop forwarding to v1

### DIFF
--- a/code/ui/popper/src/Popper.tsx
+++ b/code/ui/popper/src/Popper.tsx
@@ -538,6 +538,7 @@ export const PopperContent = React.forwardRef<PopperContentElement, PopperConten
         passThrough={passThrough}
         ref={contentRefs}
         contain="layout style"
+        direction={rest.direction}
         {...(passThrough ? null : floatingProps)}
       >
         <PopperContentFrame


### PR DESCRIPTION
## Summary
- Backports c469209d01 to v1 (based on v1.144.3)
- Forwards the `direction` prop to the floating wrapper `TamaguiView` in `PopperContent` so that floating-ui can correctly detect RTL layouts

Fixes #3921