### PR TITLE
ci: skip integration tests for unrelated package changes

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -52,7 +52,31 @@ jobs:
       - name: Run unit tests
         run: bun turbo run test:web --filter='!@tamagui/kitchen-sink' --concurrency=1
 
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      integration-relevant: ${{ steps.filter.outputs.integration-relevant }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            integration-relevant:
+              - 'code/core/**'
+              - 'code/ui/**'
+              - 'code/packages/**'
+              - 'code/kitchen-sink/**'
+              - 'code/compiler/babel-plugin/**'
+              - 'code/compiler/loader/**'
+              - 'code/compiler/metro-plugin/**'
+              - 'code/demos/**'
+              - 'package.json'
+              - 'bun.lock'
+
   integration-tests:
+    needs: changes
+    if: needs.changes.outputs.integration-relevant == 'true'
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: '--max-old-space-size=6144'


### PR DESCRIPTION
## Summary

- Add a `changes` detection job using `dorny/paths-filter` to skip the ~15min kitchen-sink Playwright integration tests when a PR only touches unrelated packages (e.g., `vite-plugin`, `next-plugin`, `.github/`)
- Uses a positive allowlist of paths kitchen-sink actually depends on, so new unrelated packages are excluded by default
- `checks` and `unit-tests` jobs are unchanged and still run unconditionally

## Detail

Kitchen-sink uses webpack with `tamagui-loader` and `@tamagui/babel-plugin` — it has no dependency on the vite or next plugins. The allowlist includes:

`code/core/`, `code/ui/`, `code/packages/`, `code/kitchen-sink/`, `code/compiler/babel-plugin/`, `code/compiler/loader/`, `code/compiler/metro-plugin/`, `code/demos/`, `package.json`, `bun.lock`

## Test plan

- [ ] PR touching only `code/compiler/vite-plugin/` — `integration-tests` should skip
- [ ] PR touching `code/core/web/` — `integration-tests` should run
- [ ] `checks` and `unit-tests` still run unconditionally on both