### PR TITLE
fix(web): default flex: N to flexShrink 0 matching React Native behavior

### DIFF
--- a/code/compiler/static-tests/tests/__snapshots__/babel.web.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/babel.web.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`className + conditional styles get full base styles merged onto + short
 exports[`conditional classname keeps base and concats properly 1`] = `
 "import { View } from '@tamagui/core';
 export function Test(props) {
-  return <div className={(isEnabled ? '' : 'disable-all-pointer-events') + " " + "is_View _fg-1 _fs-1 _fb-0px"}>
+  return <div className={(isEnabled ? '' : 'disable-all-pointer-events') + " " + "is_View _fg-1 _fs-0 _fb-0px"}>
           {props.child}
         </div>;
 }"
@@ -139,11 +139,11 @@ exports[`conditional styles get full base styles merged onto + shorthand 2`] = `
 
 exports[`double ternary + spread 1`] = `
 "const _cn7 = "is_View _ai-center ";
-const _cn6 = "is_View _ai-center _fg-unset _fs-1 _fb-0px ";
-const _cn5 = "is_View _ai-center _fg-5 _fs-1 _fb-0px ";
-const _cn4 = "is_View _fg-unset _fs-1 _fb-0px _ai-flex-start _fd-column ";
+const _cn6 = "is_View _ai-center _fg-unset _fs-0 _fb-0px ";
+const _cn5 = "is_View _ai-center _fg-5 _fs-0 _fb-0px ";
+const _cn4 = "is_View _fg-unset _fs-0 _fb-0px _ai-flex-start _fd-column ";
 const _cn3 = "is_View _ai-flex-start _fd-column ";
-const _cn2 = "is_View _fg-5 _fs-1 _fb-0px _ai-flex-start _fd-column ";
+const _cn2 = "is_View _fg-5 _fs-0 _fb-0px _ai-flex-start _fd-column ";
 const _cn = "is_View _ai-flex-start _fd-column ";
 import { View } from '@tamagui/core';
 export function Test({

--- a/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`webpack-tests > 1. extracts to a div for simple views, flat transforms 
         class="_dsp_contents  font_body"
       >
         <div
-          class="is_View _tr-0hover-scale21281 _fd-column _fg-1 _fs-1 _fb-0px _bg-red _bxsh-0px0px10px0946673987 test1"
+          class="is_View _tr-0hover-scale21281 _fd-column _fg-1 _fs-0 _fb-0px _bg-red _bxsh-0px0px10px0946673987 test1"
           rounded="100"
         >
           <span
@@ -370,7 +370,7 @@ exports[`webpack-tests > 15. extracts spacer (complex expansion) 1`] = `
           class="is_Spacer is_View _pe-none _w-t-space-tru101 _h-t-space-tru101 _miw-t-space-tru101 _mih-t-space-tru101 "
         />
         <span
-          class="is_Spacer is_View _pe-none _fg-1 _fs-1 _fb-0px _w-10px _h-10px _miw-10px _mih-10px "
+          class="is_Spacer is_View _pe-none _fg-1 _fs-0 _fb-0px _w-10px _h-10px _miw-10px _mih-10px "
         />
         <div
           style="display: contents;"
@@ -394,7 +394,7 @@ exports[`webpack-tests > 16. deopt when spreading multiple 1`] = `
         class="_dsp_contents  font_body"
       >
         <div
-          class="is_View _fd-column _fg-1 _fs-1 _fb-0px _bg-red"
+          class="is_View _fd-column _fg-1 _fs-0 _fb-0px _bg-red"
         />
         <div
           style="display: contents;"

--- a/code/core/core-test/getStylesAtomic.web.test.tsx
+++ b/code/core/core-test/getStylesAtomic.web.test.tsx
@@ -1,4 +1,4 @@
-import { beforeAll, expect, test } from 'vitest'
+import { beforeAll, describe, expect, test } from 'vitest'
 
 import config from '../config-default'
 import {
@@ -7,6 +7,7 @@ import {
   createTamagui,
   getCSSStylesAtomic,
 } from '../core/src'
+import { expandStyle } from '../web/src/helpers/expandStyle'
 
 beforeAll(() => {
   createTamagui(config.getDefaultTamaguiConfig())
@@ -76,6 +77,60 @@ test(`outline longhands get doubled selector`, () => {
   })
   const rule = out[0][StyleObjectRules][0]
   expect(rule).toMatch(/\._[^\s]+\._[^\s]+\{/)
+})
+
+describe('flex expansion', () => {
+  const toMap = (result: ReturnType<typeof expandStyle>) =>
+    Object.fromEntries(result as [string, any][])
+
+  describe('default config (no styleCompat)', () => {
+    beforeAll(() => {
+      createTamagui(config.getDefaultTamaguiConfig())
+    })
+
+    test('flex: 1 expands with flexShrink: 0, flexGrow: 1, flexBasis: 0', () => {
+      const map = toMap(expandStyle('flex', 1))
+      expect(map.flexShrink).toBe(0)
+      expect(map.flexGrow).toBe(1)
+      expect(map.flexBasis).toBe(0)
+    })
+  })
+
+  describe('styleCompat: react-native', () => {
+    beforeAll(() => {
+      createTamagui({ ...config.getDefaultTamaguiConfig(), settings: { styleCompat: 'react-native' } })
+    })
+
+    test('flex: 1 expands with flexShrink: 0', () => {
+      const map = toMap(expandStyle('flex', 1))
+      expect(map.flexShrink).toBe(0)
+    })
+  })
+
+  describe('styleCompat: legacy', () => {
+    beforeAll(() => {
+      createTamagui({ ...config.getDefaultTamaguiConfig(), settings: { styleCompat: 'legacy' } })
+    })
+
+    test('flex: 1 expands with flexShrink: 1 and flexBasis: auto', () => {
+      const map = toMap(expandStyle('flex', 1))
+      expect(map.flexShrink).toBe(1)
+      expect(map.flexBasis).toBe('auto')
+    })
+  })
+
+  describe('flex: -1 special case', () => {
+    beforeAll(() => {
+      createTamagui(config.getDefaultTamaguiConfig())
+    })
+
+    test('flex: -1 always expands to flexShrink: 1, flexGrow: 0, flexBasis: auto', () => {
+      const map = toMap(expandStyle('flex', -1))
+      expect(map.flexShrink).toBe(1)
+      expect(map.flexGrow).toBe(0)
+      expect(map.flexBasis).toBe('auto')
+    })
+  })
 })
 
 // test(`should be fast`, () => {

--- a/code/core/core-test/getStylesAtomic.web.test.tsx
+++ b/code/core/core-test/getStylesAtomic.web.test.tsx
@@ -98,7 +98,10 @@ describe('flex expansion', () => {
 
   describe('styleCompat: react-native', () => {
     beforeAll(() => {
-      createTamagui({ ...config.getDefaultTamaguiConfig(), settings: { styleCompat: 'react-native' } })
+      createTamagui({
+        ...config.getDefaultTamaguiConfig(),
+        settings: { styleCompat: 'react-native' },
+      })
     })
 
     test('flex: 1 expands with flexShrink: 0', () => {
@@ -109,7 +112,10 @@ describe('flex expansion', () => {
 
   describe('styleCompat: legacy', () => {
     beforeAll(() => {
-      createTamagui({ ...config.getDefaultTamaguiConfig(), settings: { styleCompat: 'legacy' } })
+      createTamagui({
+        ...config.getDefaultTamaguiConfig(),
+        settings: { styleCompat: 'legacy' },
+      })
     })
 
     test('flex: 1 expands with flexShrink: 1 and flexBasis: auto', () => {

--- a/code/core/web/src/helpers/expandStyle.ts
+++ b/code/core/web/src/helpers/expandStyle.ts
@@ -24,7 +24,7 @@ export function expandStyle(key: string, value: any): PropMappedValue {
       }
       return [
         ['flexGrow', value],
-        ['flexShrink', 1],
+        ['flexShrink', getSetting('styleCompat') === 'legacy' ? 1 : 0],
         ['flexBasis', getSetting('styleCompat') === 'legacy' ? 'auto' : 0],
       ]
     }

--- a/code/kitchen-sink/src/usecases/FlexShrinkCase.tsx
+++ b/code/kitchen-sink/src/usecases/FlexShrinkCase.tsx
@@ -1,0 +1,21 @@
+import { YStack, Text } from 'tamagui'
+
+/**
+ * Test case for flex: N expansion with flexShrink: 0 (RN-compatible default)
+ *
+ * Two YStack children with flex={1} inside a fixed-height column container.
+ * With correct behavior (flexShrink: 0), each child takes ~200px.
+ * With the bug (flexShrink: 1), children collapse to 0 height.
+ */
+export function FlexShrinkCase() {
+  return (
+    <YStack height={400} backgroundColor="$color3" testID="flex-container">
+      <YStack flex={1} backgroundColor="$blue5" testID="flex-child">
+        <Text>Child 1 (flex=1)</Text>
+      </YStack>
+      <YStack flex={1} backgroundColor="$green5" testID="flex-child">
+        <Text>Child 2 (flex=1)</Text>
+      </YStack>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/FlexShrinkCase.tsx
+++ b/code/kitchen-sink/src/usecases/FlexShrinkCase.tsx
@@ -9,11 +9,11 @@ import { YStack, Text } from 'tamagui'
  */
 export function FlexShrinkCase() {
   return (
-    <YStack height={400} backgroundColor="$color3" testID="flex-container">
-      <YStack flex={1} backgroundColor="$blue5" testID="flex-child">
+    <YStack height={400} backgroundColor="$color3" testID="flex-container" data-testid="flex-container">
+      <YStack flex={1} backgroundColor="$blue5" testID="flex-child" data-testid="flex-child">
         <Text>Child 1 (flex=1)</Text>
       </YStack>
-      <YStack flex={1} backgroundColor="$green5" testID="flex-child">
+      <YStack flex={1} backgroundColor="$green5" testID="flex-child" data-testid="flex-child">
         <Text>Child 2 (flex=1)</Text>
       </YStack>
     </YStack>

--- a/code/kitchen-sink/tests/FlexShrink.test.tsx
+++ b/code/kitchen-sink/tests/FlexShrink.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+import { getStyles } from './utils'
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page, { name: 'FlexShrink', type: 'useCase' })
+})
+
+test('flex: 1 in column layout does not collapse children', async ({ page }) => {
+  const child = page.getByTestId('flex-child').first()
+  const box = await child.boundingBox()
+  // each child should take ~200px (400px container / 2 children), at minimum 100px
+  expect(box!.height).toBeGreaterThan(100)
+})
+
+test('flex: 1 has computed flex-shrink: 0', async ({ page }) => {
+  const child = page.getByTestId('flex-child').first()
+  const styles = await getStyles(child)
+  expect(styles.flexShrink).toBe('0')
+})

--- a/code/kitchen-sink/tests/FlexShrink.test.tsx
+++ b/code/kitchen-sink/tests/FlexShrink.test.tsx
@@ -4,7 +4,7 @@ import { setupPage } from './test-utils'
 import { getStyles } from './utils'
 
 test.beforeEach(async ({ page }) => {
-  await setupPage(page, { name: 'FlexShrink', type: 'useCase' })
+  await setupPage(page, { name: 'FlexShrinkCase', type: 'useCase' })
 })
 
 test('flex: 1 in column layout does not collapse children', async ({ page }) => {


### PR DESCRIPTION
## Summary

- `expandStyle.ts` was always expanding `flex: N` to `flexShrink: 1`, contradicting React Native's default of `flexShrink: 0`
- In v2, components render as plain `<div>` elements (not via react-native-web), so this explicit `flexShrink: 1` caused flex children to collapse below their content height in column layouts — a regression from v1
- Fix mirrors the existing `flexBasis` pattern: `flexShrink` is now `0` by default and `1` only when `styleCompat: 'legacy'` (preserving CSS shorthand semantics for explicit opt-ins)
- The `flex: -1` special case is unchanged (always `flexShrink: 1, flexGrow: 0, flexBasis: auto`)

## Files changed

| File | Change |
|---|---|
| `code/core/web/src/helpers/expandStyle.ts` | 1-line fix: `flexShrink` conditional on `styleCompat` |
| `code/core/core-test/getStylesAtomic.web.test.tsx` | Unit tests for all three `styleCompat` variants + `flex: -1` |
| `code/kitchen-sink/src/usecases/FlexShrinkCase.tsx` | New integration test usecase |
| `code/kitchen-sink/tests/FlexShrink.test.tsx` | Playwright test verifying height > 100px and `flex-shrink: 0` |

## Test plan

- [ ] `cd code/core/core-test && TAMAGUI_TARGET=web npx vitest --run ... getStylesAtomic.web.test.tsx` — all 10 tests pass
- [ ] `cd code/kitchen-sink && npx playwright test tests/FlexShrink.test.tsx`
- [ ] Open `http://localhost:9000/?test=FlexShrink` — both children fill the container (~200px each)
- [ ] Run full `bun run test:web` — no regressions