### PR TITLE
fix(web): add lineHeight to unitless CSS properties

### DIFF
--- a/code/core/core-test/getStylesAtomic.web.test.tsx
+++ b/code/core/core-test/getStylesAtomic.web.test.tsx
@@ -78,6 +78,49 @@ test(`outline longhands get doubled selector`, () => {
   expect(rule).toMatch(/\._[^\s]+\._[^\s]+\{/)
 })
 
+test(`numeric lineHeight should not get px appended`, () => {
+  const out = getCSSStylesAtomic({
+    lineHeight: 1.15,
+  })
+  const rule = out[0][StyleObjectRules][0]
+  expect(rule).toContain('line-height:1.15')
+  expect(rule).not.toContain('line-height:1.15px')
+})
+
+test(`integer lineHeight should not get px appended`, () => {
+  const out = getCSSStylesAtomic({
+    lineHeight: 2,
+  })
+  const rule = out[0][StyleObjectRules][0]
+  expect(rule).toContain('line-height:2')
+  expect(rule).not.toContain('line-height:2px')
+})
+
+test(`string percentage lineHeight passes through unchanged`, () => {
+  const out = getCSSStylesAtomic({
+    lineHeight: '150%',
+  })
+  const rule = out[0][StyleObjectRules][0]
+  expect(rule).toContain('line-height:150%')
+})
+
+test(`opacity remains unitless (regression guard)`, () => {
+  const out = getCSSStylesAtomic({
+    opacity: 0.5,
+  })
+  const rule = out[0][StyleObjectRules][0]
+  expect(rule).toContain('opacity:0.5')
+  expect(rule).not.toContain('opacity:0.5px')
+})
+
+test(`fontSize still gets px appended (regression guard)`, () => {
+  const out = getCSSStylesAtomic({
+    fontSize: 16,
+  })
+  const rule = out[0][StyleObjectRules][0]
+  expect(rule).toContain('font-size:16px')
+})
+
 // test(`should be fast`, () => {
 //   // need to compare it in a cpu-insensitive way, so compare to common operations
 

--- a/code/core/helpers/src/validStyleProps.ts
+++ b/code/core/helpers/src/validStyleProps.ts
@@ -119,6 +119,7 @@ export const stylePropsUnitless = {
   gridColumnStart: true,
   gridTemplateColumns: true,
   gridTemplateAreas: true,
+  lineHeight: true,
   lineClamp: true,
   opacity: true,
   order: true,

--- a/code/core/react-native-web-internals/src/modules/unitlessNumbers/index.tsx
+++ b/code/core/react-native-web-internals/src/modules/unitlessNumbers/index.tsx
@@ -36,6 +36,7 @@ export const unitlessNumbers = {
   gridColumnEnd: true,
   gridColumnGap: true,
   gridColumnStart: true,
+  lineHeight: true,
   lineClamp: true,
   opacity: true,
   order: true,


### PR DESCRIPTION
## Summary

- Numeric `lineHeight` values (e.g., `1.15`) were incorrectly getting `px` appended during CSS extraction, producing `line-height:1.15px` instead of `line-height:1.15`
- Per CSS spec, unitless `line-height` is a multiplier of font-size — `1.15px` is an absolute ~1px height that causes text to visually collapse
- Added `lineHeight` to `stylePropsUnitless` (helpers) and `unitlessNumbers` (react-native-web-internals) so both runtime and compiler paths treat it as unitless
- Native/RN is unaffected — `normalizeValueWithProperty` bails on `!isWeb` before consulting the unitless list

## Trade-offs

- In React Native, `lineHeight: 62` means 62 absolute pixels. After this fix, on web it becomes `line-height: 62` (a 62x multiplier). However:
  - Font tokens resolve to CSS variables (strings), not raw numbers — unaffected
  - Users who need absolute px on web can write `lineHeight: '62px'`
  - This matches CSS spec and how other CSS-in-JS libraries handle `lineHeight`

## Test plan

- [x] Added 5 new tests to `getStylesAtomic.web.test.tsx`: numeric lineHeight, integer lineHeight, string percentage passthrough, opacity unitless guard, fontSize px guard
- [x] All 161 existing `core-test` web tests pass with zero regressions