### PR TITLE
chore: add Git LFS tracking rules for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,12 @@
 package.json merge=packagejson
+
+# Git LFS tracking for binary assets
+*.sketch filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
+*.otf filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.gltf filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- Adds .gitattributes rules to track binary file types via Git LFS going forward
- Covers: sketch, psd, otf, ttf, jpg, jpeg, png, mp4, gltf
- Forward-only — existing files in history are not affected
- New/modified binary files will automatically use LFS after this merges

## Context
The .git directory is 888 MB. Binary assets (sketch, fonts, images) total ~147 MB in HEAD and ~375 MB across history. This prevents future bloat.

## After merging
Contributors need `git lfs install` (one-time). GitHub Actions runners have git-lfs pre-installed.