### PR TITLE
fix(core): allow fallback radius and zIndex tokens in config-less type resolution

### DIFF
--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -1697,11 +1697,13 @@ export type ColorTokens =
 export type ZIndexTokens =
   | SpecificTokensSpecial
   | GetTokenString<keyof Tokens['zIndex']>
+  | ThemeValueFallbackZIndex
   | number
 
 export type RadiusTokens =
   | SpecificTokensSpecial
   | GetTokenString<keyof Tokens['radius']>
+  | ThemeValueFallbackRadius
   | number
   | RemString
 
@@ -1825,21 +1827,21 @@ export type OpacityKeys = 'opacity'
 export type ThemeValueGet<K extends string | number | symbol> = K extends 'theme'
   ? ThemeTokens
   : K extends SizeKeys
-    ? SizeTokens | ThemeValueFallbackSize
+    ? SizeTokens
     : K extends FontKeys
       ? FontTokens
       : K extends FontSizeKeys
         ? FontSizeTokens
         : K extends `${`border${string | ''}Radius`}`
-          ? RadiusTokens | ThemeValueFallbackRadius
+          ? RadiusTokens
           : K extends SpaceKeys
             ? K extends 'shadowOffset'
               ? { width: SpaceTokens; height: SpaceTokens }
-              : SpaceTokens | ThemeValueFallbackSpace
+              : SpaceTokens
             : K extends ColorKeys
               ? ColorTokens | ThemeValueFallbackColor
               : K extends ZIndexKeys
-                ? ZIndexTokens | ThemeValueFallbackZIndex
+                ? ZIndexTokens
                 : K extends LineHeightKeys
                   ? FontLineHeightTokens
                   : K extends FontWeightKeys

--- a/code/core/web/types/types.d.ts
+++ b/code/core/web/types/types.d.ts
@@ -974,8 +974,8 @@ export type SpecificTokensSpecial = TamaguiSettings extends {
 export type SizeTokens = SpecificTokensSpecial | ThemeValueFallbackSize | GetTokenString<keyof Tokens['size']>;
 export type SpaceTokens = SpecificTokensSpecial | GetTokenString<keyof Tokens['space']> | ThemeValueFallbackSpace;
 export type ColorTokens = SpecificTokensSpecial | GetTokenString<keyof Tokens['color']> | GetTokenString<keyof ThemeParsed> | CSSColorNames;
-export type ZIndexTokens = SpecificTokensSpecial | GetTokenString<keyof Tokens['zIndex']> | number;
-export type RadiusTokens = SpecificTokensSpecial | GetTokenString<keyof Tokens['radius']> | number | RemString;
+export type ZIndexTokens = SpecificTokensSpecial | GetTokenString<keyof Tokens['zIndex']> | ThemeValueFallbackZIndex | number;
+export type RadiusTokens = SpecificTokensSpecial | GetTokenString<keyof Tokens['radius']> | ThemeValueFallbackRadius | number | RemString;
 export type NonSpecificTokens = GetTokenString<keyof Tokens['radius']> | GetTokenString<keyof Tokens['zIndex']> | GetTokenString<keyof Tokens['color']> | GetTokenString<keyof Tokens['space']> | GetTokenString<keyof Tokens['size']>;
 export type Token = NonSpecificTokens | (TamaguiSettings extends {
     autocompleteSpecificTokens: false;
@@ -1015,10 +1015,10 @@ export type FontLetterSpacingKeys = 'letterSpacing';
 export type LineHeightKeys = 'lineHeight';
 export type ZIndexKeys = 'zIndex';
 export type OpacityKeys = 'opacity';
-export type ThemeValueGet<K extends string | number | symbol> = K extends 'theme' ? ThemeTokens : K extends SizeKeys ? SizeTokens | ThemeValueFallbackSize : K extends FontKeys ? FontTokens : K extends FontSizeKeys ? FontSizeTokens : K extends `${`border${string | ''}Radius`}` ? RadiusTokens | ThemeValueFallbackRadius : K extends SpaceKeys ? K extends 'shadowOffset' ? {
+export type ThemeValueGet<K extends string | number | symbol> = K extends 'theme' ? ThemeTokens : K extends SizeKeys ? SizeTokens : K extends FontKeys ? FontTokens : K extends FontSizeKeys ? FontSizeTokens : K extends `${`border${string | ''}Radius`}` ? RadiusTokens : K extends SpaceKeys ? K extends 'shadowOffset' ? {
     width: SpaceTokens;
     height: SpaceTokens;
-} : SpaceTokens | ThemeValueFallbackSpace : K extends ColorKeys ? ColorTokens | ThemeValueFallbackColor : K extends ZIndexKeys ? ZIndexTokens | ThemeValueFallbackZIndex : K extends LineHeightKeys ? FontLineHeightTokens : K extends FontWeightKeys ? FontWeightTokens : K extends FontLetterSpacingKeys ? FontLetterSpacingTokens : K extends OpacityKeys ? SpecificTokens | ThemeValueFallback : never;
+} : SpaceTokens : K extends ColorKeys ? ColorTokens | ThemeValueFallbackColor : K extends ZIndexKeys ? ZIndexTokens : K extends LineHeightKeys ? FontLineHeightTokens : K extends FontWeightKeys ? FontWeightTokens : K extends FontLetterSpacingKeys ? FontLetterSpacingTokens : K extends OpacityKeys ? SpecificTokens | ThemeValueFallback : never;
 export type GetThemeValueForKey<K extends string | symbol | number> = ThemeValueGet<K> | ThemeValueFallback | (TamaguiSettings extends {
     autocompleteSpecificTokens: infer Val;
 } ? Val extends true | undefined ? SpecificTokens : never : never);


### PR DESCRIPTION
## Summary

- fix token type resolution for config-less Tamagui setups
- allow fallback radius and zIndex tokens directly in `RadiusTokens` and `ZIndexTokens`

## Why

When following the [design systems guide](https://tamagui.dev/docs/guides/design-systems) without defining a local Tamagui config, TypeScript could reject valid token-style values because fallback token support was not included directly in some token types.

For example, this could fail with `TS2322`:

```tsx
export const MyComponent = ({
    borderRadius = '$8',
}: MyComponentProps): JSX.Element | null => {
```

TypeScript saw `'$8'` as incompatible with `RadiusTokens` in config-less setups, even though that usage should be supported.

`RadiusTokens` appear as follows currently:

```
(alias) type RadiusTokens = number | `${number}rem` | `$${string}.${string}` | `$${string}.${number}`
```