### PR TITLE
fix(avatar): replace fullscreen prop on Image with explicit position styles

### DIFF
--- a/code/ui/avatar/src/Avatar.tsx
+++ b/code/ui/avatar/src/Avatar.tsx
@@ -83,7 +83,11 @@ const AvatarImage = React.forwardRef<TamaguiElement, AvatarImageProps>(
     return (
       <YStack fullscreen zIndex={1}>
         <Image
-          fullscreen
+          position="absolute"
+          top={0}
+          left={0}
+          right={0}
+          bottom={0}
           objectFit="cover"
           {...(typeof shapeSize === 'number' &&
             !Number.isNaN(shapeSize) && {


### PR DESCRIPTION
`Avatar.Image` was passing `fullscreen={true}` to `<Image>`, which renders as `<img>` on web. Since Image doesn't define a fullscreen variant, the boolean prop was unrecognized and leaked directly to the DOM.

Fix by replacing `fullscreen` with the equivalent explicit style props `(position="absolute" top={0} left={0} right={0} bottom={0})`.