### PR TITLE
fix(static): resolve react-native-reanimated to proxy-worm in esbuild

### DIFF
--- a/code/compiler/static/src/extractor/bundle.ts
+++ b/code/compiler/static/src/extractor/bundle.ts
@@ -124,8 +124,7 @@ function getESBuildConfig(
 
           build.onResolve({ filter: /react-native-reanimated/ }, () => {
             return {
-              path: 'react-native-reanimated',
-              external: true,
+              path: require.resolve('@tamagui/proxy-worm'),
             }
           })
 


### PR DESCRIPTION
## Summary
- Marking `react-native-reanimated` as `external: true` in the esbuild config fails on Node 22+ macOS because `require()` of its ESM code can't resolve extensionless relative imports
- Since reanimated isn't needed for static extraction, resolve it to `@tamagui/proxy-worm` (no-op proxy) instead — matching the existing pattern for `react-native`
- Fixes local kitchen-sink Playwright tests on macOS

## Test plan
- [x] `bun run build` in `code/compiler/static` succeeds
- [x] `bun test` in `code/compiler/static-tests` — no regressions (31 pass, 24 pre-existing failures unrelated to this change)
- [ ] Kitchen-sink Playwright tests pass locally on macOS with Node 22+