### PR TITLE
fix(detox): make iOS simulator device configurable via DETOX_DEVICE

### DIFF
--- a/code/kitchen-sink/.detoxrc.js
+++ b/code/kitchen-sink/.detoxrc.js
@@ -68,7 +68,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 15',
+        type: process.env.DETOX_DEVICE || 'iPhone 15',
       },
     },
     attached: {

--- a/code/kitchen-sink/run-detox.sh
+++ b/code/kitchen-sink/run-detox.sh
@@ -20,6 +20,7 @@
 #   FORCE_BUILD=1       - Force rebuild even if app exists
 #   SKIP_BUILD=1        - Skip build check entirely
 #   SKIP_METRO=1        - Don't start Metro (assume it's running)
+#   DETOX_DEVICE=name   - iOS simulator device type (default: iPhone 15)
 #
 
 set -e
@@ -104,6 +105,7 @@ echo "  Detox Test Runner"
 echo "========================================"
 echo "Platform:    $PLATFORM"
 echo "Config:      $CONFIG"
+echo "Device:      ${DETOX_DEVICE:-iPhone 15}"
 echo "Test filter: ${TEST_FILTER:-<all tests>}"
 echo ""
 


### PR DESCRIPTION
## Summary
- iOS simulator device was hardcoded to `iPhone 15` in `.detoxrc.js`
- Now configurable via `DETOX_DEVICE` env var, matching the existing `DETOX_AVD_NAME` pattern for Android
- Default remains `iPhone 15` for parity with current behavior

### Usage
```bash
# Default (iPhone 15)
bun run detox:run:ios

# Override device
DETOX_DEVICE="iPhone 16 Pro" bun run detox:run:ios
```

## Test plan
- [ ] `bun run detox:run:ios` works with default device
- [ ] `DETOX_DEVICE="iPhone 16" bun run detox:run:ios` picks up the override