### PR TITLE
chore: improve local testing setup for Playwright and Detox

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,47 @@ bun run kitchen-sink:build:ios
 
 You can run `bun run sandbox` or `bun run dev` (the tamagui website).
 
+### Local Testing Setup
+
+#### Playwright (web integration tests)
+
+Install browser binaries before first run:
+
+```bash
+cd code/kitchen-sink
+bun run test:web:setup   # installs chromium
+bun run start:web        # start dev server (background)
+bun run test:web         # run all web tests
+```
+
+#### Detox (iOS E2E tests)
+
+Install dependencies:
+
+```bash
+npm install -g detox-cli
+brew tap wix/brew && brew install applesimutils
+```
+
+The `run-detox.sh` script will automatically:
+- Run `expo prebuild` if the `ios/` directory doesn't exist
+- Build the Detox framework cache if missing (needed after Xcode updates)
+- Start Metro if not already running
+- Build the app if the binary is missing or outdated
+
+```bash
+cd code/kitchen-sink
+bun run detox:run:ios                              # run all iOS tests
+bun run detox:run:ios "Sheet"                      # filter by test name
+DETOX_DEVICE="iPhone 16 Pro" bun run detox:run:ios # override simulator device
+```
+
+If the Detox framework cache gets corrupted after an Xcode update:
+
+```bash
+npx detox clean-framework-cache && npx detox build-framework-cache
+```
+
 ### Fixing libraries
 
 All compiler and CSS generation tests live in `code/compiler/static-tests`.

--- a/code/kitchen-sink/.detoxrc.js
+++ b/code/kitchen-sink/.detoxrc.js
@@ -68,7 +68,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 15',
+        type: process.env.DETOX_DEVICE || 'iPhone 15',
       },
     },
     attached: {

--- a/code/kitchen-sink/package.json
+++ b/code/kitchen-sink/package.json
@@ -24,6 +24,7 @@
     "test:native:ios": "bun run ../packages/native-ci/src/cli.ts test ios --project-root .",
     "test:native:android": "bun run ../packages/native-ci/src/cli.ts test android --project-root .",
     "test:native:maestro": "bun run ../packages/native-ci/src/cli.ts test maestro --project-root .",
+    "test:web:setup": "npx playwright install chromium",
     "test:web": "bun run-tests-parallel.ts",
     "test:web:seq": "NODE_ENV=test node -r esbuild-register ../../node_modules/.bin/playwright test",
     "test:web:driver": "NODE_ENV=test node -r esbuild-register ../../node_modules/.bin/playwright test",

--- a/code/kitchen-sink/run-detox.sh
+++ b/code/kitchen-sink/run-detox.sh
@@ -20,9 +20,45 @@
 #   FORCE_BUILD=1       - Force rebuild even if app exists
 #   SKIP_BUILD=1        - Skip build check entirely
 #   SKIP_METRO=1        - Don't start Metro (assume it's running)
+#   DETOX_DEVICE=name   - iOS simulator device type (default: iPhone 15)
 #
 
 set -e
+
+# --- Prerequisites check ---
+check_prerequisites() {
+  local missing=false
+
+  if ! command -v detox &> /dev/null; then
+    echo "detox-cli not found. Install with: npm install -g detox-cli"
+    missing=true
+  fi
+
+  if [ "$PLATFORM" = "ios" ] && ! command -v applesimutils &> /dev/null; then
+    echo "applesimutils not found. Install with: brew tap wix/brew && brew install applesimutils"
+    missing=true
+  fi
+
+  if [ "$missing" = true ]; then
+    echo ""
+    echo "Install missing dependencies and try again."
+    exit 1
+  fi
+
+  # Detox framework cache (needed after Xcode updates)
+  if [ "$PLATFORM" = "ios" ] && [ ! -d "$HOME/Library/Detox/ios/framework" ]; then
+    echo "Detox framework cache not found. Building..."
+    npx detox clean-framework-cache && npx detox build-framework-cache
+    echo ""
+  fi
+
+  # iOS directory (expo prebuild)
+  if [ "$PLATFORM" = "ios" ] && [ ! -d "ios" ]; then
+    echo "No ios/ directory found. Running expo prebuild..."
+    npx expo prebuild --platform ios
+    echo ""
+  fi
+}
 
 PLATFORM="${1:-ios}"  # ios or android
 TEST_FILTER="${2:-}"  # optional test name filter
@@ -104,7 +140,13 @@ echo "  Detox Test Runner"
 echo "========================================"
 echo "Platform:    $PLATFORM"
 echo "Config:      $CONFIG"
+echo "Device:      ${DETOX_DEVICE:-iPhone 15}"
 echo "Test filter: ${TEST_FILTER:-<all tests>}"
+echo ""
+
+# step 0: check prerequisites
+echo "=== Step 0: Checking prerequisites ==="
+check_prerequisites
 echo ""
 
 # step 1: check if build needed


### PR DESCRIPTION
## Summary
- **`run-detox.sh`**: Add automatic prerequisite checks — auto-runs `expo prebuild` if `ios/` is missing, builds Detox framework cache after Xcode updates, validates `detox-cli` and `applesimutils` are installed
- **`.detoxrc.js`**: Make iOS simulator device configurable via `DETOX_DEVICE` env var (default: `iPhone 15`), matching the existing `DETOX_AVD_NAME` pattern for Android
- **`package.json`**: Add `test:web:setup` script for Playwright chromium installation
- **`CONTRIBUTING.md`**: Document local testing setup for both Playwright and Detox

### Usage
```bash
# Playwright
cd code/kitchen-sink
bun run test:web:setup   # one-time: install chromium
bun run start:web        # start dev server
bun run test:web         # run tests

# Detox — prerequisites auto-checked, just run:
bun run detox:run:ios
DETOX_DEVICE="iPhone 16 Pro" bun run detox:run:ios
```

## Test plan
- [x] Playwright: 408 passed, 0 failed after `test:web:setup`
- [x] Detox: 59 passed, 5 failed (pre-existing), `DETOX_DEVICE` override works correctly
- [x] Prerequisite checks catch missing tools with actionable error messages