### PR TITLE
docs: replace maxMd with max-md in v2 docs

### DIFF
--- a/code/tamagui.dev/data/docs/components/dialog/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/dialog/2.0.0.mdx
@@ -373,7 +373,7 @@ export default () => (
     </Dialog.Portal>
 
     {/* optionally change to sheet when small screen */}
-    <Dialog.Adapt when="maxMd">
+    <Dialog.Adapt when="max-md">
       <Dialog.Sheet>
         <Dialog.Sheet.Frame>
           <Dialog.Adapt.Contents />

--- a/code/tamagui.dev/data/docs/components/popover/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/popover/2.0.0.mdx
@@ -67,7 +67,7 @@ export default () => (
 
     {/* optionally change to sheet when small screen */}
     {/* you can also use <Popover.Adapt /> */}
-    <Adapt when="maxMd">
+    <Adapt when="max-md">
       <Sheet>
         <Sheet.Overlay />
         <Sheet.Frame>

--- a/code/tamagui.dev/data/docs/components/select/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/select/2.0.0.mdx
@@ -374,7 +374,7 @@ export default () => (
       <Select.Value placeholder="Search..." />
     </Select.Trigger>
 
-    <Adapt when="maxMd" platform="touch">
+    <Adapt when="max-md" platform="touch">
       {/* or <Select.Sheet> */}
       <Sheet>
         <Sheet.Frame>


### PR DESCRIPTION
Default `@tamagui/config/v5` config has `max-md`, not `maxMd`. Using `maxMd` was breaking Select, Dialog and Popover components.