### PR TITLE
fix(image): omit undefined width/height from style on native

### DIFF
--- a/code/ui/image/src/createImage.tsx
+++ b/code/ui/image/src/createImage.tsx
@@ -172,10 +172,15 @@ export function createImage<C extends ComponentType<any>>(
       height: resolvedHeight,
     })
 
+    const incomingStyle = Array.isArray(rest.style)
+      ? Object.assign({}, ...rest.style.flat())
+      : rest.style
+
     const finalProps: any = {
       ...rest,
       source: finalSource,
       style: {
+        ...incomingStyle,
         ...(resolvedWidth !== undefined && { width: resolvedWidth }),
         ...(resolvedHeight !== undefined && { height: resolvedHeight }),
       },


### PR DESCRIPTION
> When no size is set, Image breaks —
> undefined dims override intrinsic.
> Style arrays lost in the spread —
> merge what's passed, omit what's absent.

## Summary

Two bugs in `createImage` on native:

### 1. Undefined dimensions override intrinsic sizing

`createImage` always sets `style: { width, height }` even when both are `undefined`. This overrides React Native Image's intrinsic sizing from `require()` assets, causing images to render at 0×0.

**Fix:** Only spread `width`/`height` into the style object when actually provided.

### 2. Caller's `style` prop is discarded

When a caller passes `style={[styles.image, styles.size]}`, the style array ends up in `rest.style` via `...rest`. The explicit `style: { width, height }` then overwrites it entirely, discarding the caller's dimensions and other style properties.

**Fix:** Flatten the incoming style (handling arrays) and spread it first. Explicit `width`/`height` props still take precedence since they spread after `incomingStyle`.

## Reproduction

```tsx
// Bug 1: renders at 0×0 — RN can't read intrinsic dimensions
<Image src={require('./photo.png')} />

// Bug 2: style is ignored — image renders without width/height constraints
<Image style={[styles.image, styles.anywhere]} src={require('./photo.png')} />
``` 

## Test plan

- Verified require() assets auto-size when no dimensions are passed
- Verified style prop (both object and array forms) is preserved
- When width/height are passed as props, they take precedence over style
- No impact on web (separate code path)