### PR TITLE
fix(site): recover from stuck OAuth popup instead of alert+stranding

### DIFF
--- a/code/tamagui.dev/app/(site)/login.tsx
+++ b/code/tamagui.dev/app/(site)/login.tsx
@@ -41,6 +41,14 @@ function SignIn() {
     emailRef.current?.focus()
   }, [])
 
+  // surface error passed back from /auth after a failed code exchange
+  useEffect(() => {
+    const err = new URLSearchParams(window.location.search).get('error')
+    if (err) {
+      setMessage({ type: 'error', content: err })
+    }
+  }, [])
+
   useForwardToDashboard()
 
   // auto-trigger GitHub OAuth when opened as a popup (from checkout flow)

--- a/code/tamagui.dev/app/auth.tsx
+++ b/code/tamagui.dev/app/auth.tsx
@@ -1,9 +1,10 @@
 import { useSupabase } from '~/features/auth/useSupabaseClient'
-import { useLayoutEffect } from 'react'
-import { YStack, Text, Spinner } from 'tamagui'
+import { useEffect, useLayoutEffect, useState } from 'react'
+import { YStack, Text, Spinner, Button, Paragraph } from 'tamagui'
 
 export default function Auth() {
   const { supabase } = useSupabase()
+  const [slow, setSlow] = useState(false)
 
   useLayoutEffect(() => {
     if (supabase) {
@@ -11,20 +12,64 @@ export default function Auth() {
     }
   }, [supabase])
 
+  // surface a fallback after 8s so users are never stuck silently
+  useEffect(() => {
+    const id = setTimeout(() => setSlow(true), 8000)
+    return () => clearTimeout(id)
+  }, [])
+
   return (
     <YStack
       flex={1}
       justify="center"
       items="center"
-      gap="$8"
+      gap="$6"
       width="100%"
       height="100%"
       minH={400}
     >
       <Text>Authenticating...</Text>
       <Spinner size="large" />
+      {slow ? (
+        <YStack gap="$2" items="center" maxW={360} px="$4">
+          <Paragraph size="$2" color="$color10" text="center">
+            Taking longer than expected?
+          </Paragraph>
+          <Button
+            size="$3"
+            onPress={() => {
+              clearPkceState()
+              window.location.href = '/login'
+            }}
+          >
+            Back to login
+          </Button>
+        </YStack>
+      ) : null}
     </YStack>
   )
+}
+
+// clear stale PKCE verifier so the next attempt starts with a fresh flow
+const clearPkceState = () => {
+  try {
+    localStorage.removeItem('sb-auth-token-code-verifier')
+  } catch {}
+}
+
+const finishPopupOrRedirect = (target: string, message: any) => {
+  if (window.opener && window.opener !== window) {
+    try {
+      window.opener.postMessage(message, window.location.origin)
+    } catch {}
+    window.close()
+    // close can be blocked; fall back to redirect after a tick so the user isn't stranded
+    setTimeout(() => {
+      if (!window.closed) window.location.href = target
+    }, 250)
+    return
+  }
+  window.location.href = target
 }
 
 const exchangeSession = async (supabase: ReturnType<typeof useSupabase>['supabase']) => {
@@ -33,18 +78,15 @@ const exchangeSession = async (supabase: ReturnType<typeof useSupabase>['supabas
 
   if (!supabase) {
     console.error(`no supabase?`)
+    finishPopupOrRedirect('/login?error=client_unavailable', {
+      type: 'SUPABASE_AUTH_ERROR',
+      error: 'client_unavailable',
+    })
     return
   }
 
   if (!code) {
-    // no code is our new flow we can remove old one
-    if (window.opener && window.opener !== window) {
-      window.opener.postMessage({ type: 'SUPABASE_AUTH_SUCCESS' }, window.location.origin)
-      window.close()
-    } else {
-      // not a popup, redirect to account
-      window.location.href = '/account'
-    }
+    finishPopupOrRedirect('/account', { type: 'SUPABASE_AUTH_SUCCESS' })
     return
   }
 
@@ -52,16 +94,13 @@ const exchangeSession = async (supabase: ReturnType<typeof useSupabase>['supabas
 
   if (error) {
     console.error('Error exchanging code for session:', error)
-    alert(`${error}`)
+    clearPkceState()
+    finishPopupOrRedirect(`/login?error=${encodeURIComponent(error.message)}`, {
+      type: 'SUPABASE_AUTH_ERROR',
+      error: error.message,
+    })
     return
   }
 
-  // if opened as popup, notify opener and close
-  if (window.opener && window.opener !== window) {
-    window.opener.postMessage({ type: 'SUPABASE_AUTH_SUCCESS' }, window.location.origin)
-    window.close()
-  } else {
-    // not a popup, redirect to account
-    window.location.href = '/account'
-  }
+  finishPopupOrRedirect('/account', { type: 'SUPABASE_AUTH_SUCCESS' })
 }

--- a/code/tamagui.dev/features/auth/useLoginLink.tsx
+++ b/code/tamagui.dev/features/auth/useLoginLink.tsx
@@ -39,6 +39,11 @@ export const useLoginLink = () => {
           window.removeEventListener('message', handleMessage)
           await supabaseClient.auth.refreshSession()
           userSwr.refresh()
+        } else if (event.data?.type === 'SUPABASE_AUTH_ERROR') {
+          window.removeEventListener('message', handleMessage)
+          toast.show('Login failed', {
+            message: event.data.error || 'Please try again.',
+          })
         }
       }
 


### PR DESCRIPTION
## Summary

Users were getting stranded on the `Authenticating…` spinner after a failed Supabase OAuth code exchange. Reproduced it live in Chrome — any stale PKCE flow state triggers `AuthApiError 404: flow_state_not_found`, and the prior code fired `alert(\`${error}\`)` then returned, leaving the popup frozen with no way out.

Audit log evidence: paying customer `paul@rakow.email` tried to log in **5 times in ~60 seconds** yesterday before giving up and emailing support.

## Changes

- `app/auth.tsx`: on exchange error, `postMessage` an error back to opener, redirect popup to `/login?error=<msg>`, clear the stale PKCE verifier. Added an 8s fallback UI with a "Back to login" button. Added redirect fallback if `window.close()` is blocked.
- `features/auth/useLoginLink.tsx`: main window toasts the error when it receives `SUPABASE_AUTH_ERROR`.
- `app/(site)/login.tsx`: reads `?error=` from the redirect and shows it via the existing Notice.

## Test plan

- [ ] Log in with a good flow — popup closes, main window updates to signed-in
- [ ] Double-click login button (two overlapping popups) — one succeeds, the other redirects back to /login with an error Notice instead of hanging
- [ ] Replay prod `/auth?code=<stale>` — redirects to /login with an error instead of stuck spinner
- [ ] Open `/auth` without a code parameter — still redirects to /account / posts success as before