### PR TITLE
fix(vite-plugin): import.meta.resolve crash in CJS

### DIFF
--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -2,7 +2,6 @@ import type { TamaguiOptions, ExtractedResponse } from '@tamagui/static-worker'
 import * as Static from '@tamagui/static-worker'
 import { getPragmaOptions } from '@tamagui/static-worker'
 import { createHash } from 'node:crypto'
-import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -15,7 +14,11 @@ import {
   ensureFullConfigLoaded,
 } from './loadTamagui'
 
-const resolve = (name: string) => fileURLToPath(import.meta.resolve(name))
+// handle ESM/CJS duality for plugin dependencies - resolve from plugin's location, not user's project
+const _pluginRequire = createRequire(
+  typeof __filename === 'string' ? __filename : fileURLToPath(import.meta.url)
+)
+const resolve = (name: string) => _pluginRequire.resolve(name)
 
 // shared cache across all plugin instances/environments via globalThis
 type CacheEntry = {

--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -358,23 +358,18 @@ export function tamaguiPlugin({
       // from sub-entries — vite's dep crawler can otherwise split them into a
       // separate chunk with its own tamagui copy, producing two ThemeStateContext
       // instances and "Missing theme" errors at runtime.
-      addIfInstalled(userConf, userConf.root, [
-        '@tamagui/toast',
-        '@tamagui/toast/v2',
-      ])
+      addIfInstalled(userConf, userConf.root, ['@tamagui/toast', '@tamagui/toast/v2'])
 
       // dedupe tamagui packages so nested resolutions collapse to a single
       // instance. pairs with the include above: include pre-bundles, dedupe
       // prevents duplicate bundling when sub-deps re-resolve them.
       userConf.resolve ||= {}
       userConf.resolve.dedupe ||= []
-      for (const id of [
-        'tamagui',
-        '@tamagui/core',
-        '@tamagui/web',
-        '@tamagui/toast',
-      ]) {
-        if (!userConf.resolve.dedupe.includes(id) && isInstalled(userConf.root || process.cwd(), id)) {
+      for (const id of ['tamagui', '@tamagui/core', '@tamagui/web', '@tamagui/toast']) {
+        if (
+          !userConf.resolve.dedupe.includes(id) &&
+          isInstalled(userConf.root || process.cwd(), id)
+        ) {
           userConf.resolve.dedupe.push(id)
         }
       }


### PR DESCRIPTION
## Problem

Version: v2 - problem persisting in latest (2.0.0-rc.41)

When `@tamagui/vite-plugin` is loaded in a CJS context the plugin crashes on startup with:

```
import_meta.resolve is not a function
```

**Root cause:** `plugin.ts` used `import.meta.resolve(name)` to resolve dependency paths relative to the plugin's own install location. When esbuild compiles the ESM source to `dist/cjs/plugin.cjs`, it shims `import.meta` to `const import_meta = {}` (an empty object). At runtime `import_meta.resolve` is `undefined`, so the first call to `resolve()` throws.

## Fix

Replace `import.meta.resolve` with [`createRequire`](https://nodejs.org/api/module.html#modulecreaterequirefilename) (already imported in the file, used elsewhere for project-root resolution). Use a runtime guard to pick the right anchor path for each context:

```ts
const _pluginRequire = createRequire(
  typeof __filename === 'string' ? __filename : fileURLToPath(import.meta.url)
)
const resolve = (name: string) => _pluginRequire.resolve(name)
```

- **CJS context** (`dist/cjs/plugin.cjs`): `__filename` is the CJS global (string) → `createRequire(__filename)` anchors resolution to the plugin file's own directory.
- **ESM context** (`dist/esm/plugin.mjs`): `__filename` is not defined → falls through to `fileURLToPath(import.meta.url)`, identical to the original behaviour.

No build-tooling changes needed — verified by inspecting the built CJS and ESM outputs.

### Out of scope

I ran and fixed formating issues in the impacted module as per the contributing guidelines. Not related but 🤷 .
