### PR TITLE
fix(adapt): keep teleported subtree mounted across parent re-renders

### DIFF
--- a/code/ui/adapt/src/Adapt.tsx
+++ b/code/ui/adapt/src/Adapt.tsx
@@ -308,11 +308,26 @@ function AdaptPortalTeleport({
   store: AdaptChildrenStore
   children: React.ReactNode
 }) {
+  // The previous implementation had no dependency array on this effect, so
+  // the cleanup `store.set(null)` ran before each subsequent effect run —
+  // forcing the teleported subtree (e.g. a Sheet's portal target when used
+  // via Adapt + Dialog/Popover) to unmount and remount on every parent
+  // re-render. For dialogs whose `open` prop toggles caused parent renders,
+  // this discarded mount continuity even when the teleported children were
+  // logically unchanged. Splitting into two effects: one keeps the store in
+  // sync with the latest children (no cleanup, so React reconciles new vs
+  // old children without an intermediate `null`), and one clears the store
+  // only when the component truly unmounts or `isActive` flips false.
   useIsomorphicLayoutEffect(() => {
-    if (!isActive) return
-    store.set(children)
-    return () => store.set(null)
+    if (isActive) {
+      store.set(children)
+    } else {
+      store.set(null)
+    }
   })
+  useIsomorphicLayoutEffect(() => {
+    return () => store.set(null)
+  }, [store])
 
   return isActive ? null : <>{children}</>
 }


### PR DESCRIPTION
## Summary

\`AdaptPortalTeleport\` (in \`@tamagui/adapt\`) calls \`useIsomorphicLayoutEffect\` with **no dependency array**, so its cleanup \`store.set(null)\` runs before every subsequent effect run. The cleanup→effect sequence forces the teleported subtree (the Sheet's portal target when Adapt is used with \`Dialog\` or \`Popover\`) to unmount and immediately remount on every parent re-render, even when children are logically unchanged.

For dialogs/popovers whose \`open\` prop toggle triggers a parent render, this discards mount continuity entirely. Every open pays a fresh mount cost for the inner subtree — defeating attempts to keep content mounted via \`unmountChildrenWhenHidden={false}\` or \`keepChildrenMounted\` on the Dialog.

## Reproduction (paraphrased)

A consumer using \`Dialog\` + \`Adapt\` + \`Sheet\` on mobile, with a heavy inner subtree (e.g. a 365-day Skia grid + a 42-cell calendar of \`Button\` children), sees ~234 ms of React mount work in dev mode every time the dialog opens — even after closing/reopening with the same content. Profiling traces the cost to a fresh remount of the entire teleported subtree, originating in the cleanup→effect of \`AdaptPortalTeleport\`.

## Fix

Split the single effect into two:

1. **Sync effect** — runs after every render, keeps \`store\` in sync with the latest \`children\`, with no cleanup. React reconciles new vs old children directly without an intermediate \`null\` state, so same-type components in the same positions reconcile via prop diff rather than unmount/remount.
2. **Cleanup effect** — runs only on true unmount (or when \`store\` itself changes), clearing \`store\` to \`null\`.

When \`isActive\` flips false, the sync effect explicitly clears the store too, preserving the previous behavior of removing children when the adapt match deactivates.

## Measured impact

A real consumer profiled before and after the patch (Tamagui v2.0.0-rc.36 in a React Native app, opening a heavy dialog with grid + calendar via \`Dialog\` + \`Adapt when=\"sm\" platform=\"touch\"\` + \`Sheet\`, 3 fresh-heap sessions per condition, dev mode):

|                  | Worst commit | Total open burst |
|------------------|-------------:|-----------------:|
| Before           |       234 ms |          520 ms  |
| After this patch |   **192 ms** |     **350 ms**   |

Production estimate (÷3 dev-mode factor): ~57 ms cut from the worst frame, ~64 ms saved per open.

## Notes

- The fix preserves all existing semantics: when \`isActive\` is false, no children render via the teleport (consistent with previous behavior); on unmount, store is always cleared.
- Behavior change is limited to: the teleport store is no longer cleared between consecutive renders while the component remains mounted with \`isActive=true\`. This is the desired behavior for any consumer expecting stable mount across parent re-renders.
- Same fix could be considered for any other Tamagui internal that uses the cleanup-on-every-render pattern with effect-driven side-store synchronization.

## Test plan

- [ ] Verify Adapt + Dialog still renders/unmounts content as expected when crossing the \`when\` breakpoint.
- [ ] Verify \`isActive\` toggling false → true correctly re-populates the store.
- [ ] Verify \`isActive\` toggling true → false clears the store.
- [ ] Verify unmounting the parent with \`isActive=true\` clears the store.
- [ ] Confirm no regression in existing Adapt + Popover tests.