### PR TITLE
fix(static): emit non-style props once and rename dynamic ones

### DIFF
--- a/code/compiler/static-tests/tests/babel.web.test.tsx
+++ b/code/compiler/static-tests/tests/babel.web.test.tsx
@@ -754,3 +754,33 @@ test('boxShadow with multiple $variables extracts correctly', async () => {
   const varMatches = output?.styles?.match(/var\(--/g)
   expect(varMatches?.length).toBeGreaterThanOrEqual(2)
 })
+
+// Regression: createDOMProps unconditionally emits a (possibly empty) style
+// key. Without removing it after the call, Object.keys(out) iterates twice
+// for what was a single non-style prop, and the same JSXAttribute is emitted
+// twice in the output JSX. Separately, the later attribute-rename pass that
+// converts testID -> data-testid only runs when the value is statically
+// evaluable, so dynamic testIDs were emitted as raw `<div testID={...}>`
+// and silently dropped by React.
+test('non-static testID with template literal is rewritten to data-testid', async () => {
+  const output = await extractForWeb(
+    `
+    import { View } from '@tamagui/core'
+
+    export function Test({ x }: { x: string }) {
+      return <View testID={\`a-\${x}\`} />
+    }
+  `,
+    {
+      options: {
+        platform: 'web',
+        components: ['@tamagui/core'],
+      },
+    }
+  )
+
+  // Should be rewritten to data-testid (not raw testID) and only emitted once.
+  expect(output?.js).toContain('data-testid={`a-${x}`}')
+  expect(output?.js?.match(/data-testid=/g)?.length).toBe(1)
+  expect(output?.js?.match(/\btestID=/g) ?? []).toHaveLength(0)
+})

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -1444,6 +1444,12 @@ export function createExtractor(
                   )
                   // remove className - we dont use rnw styling
                   delete out.className
+                  // remove style - rnw createDOMProps unconditionally emits a
+                  // (possibly empty) style key, but we passed it a single
+                  // non-style prop. Leaving it in causes Object.keys(out) to
+                  // iterate twice and emit the original JSXAttribute twice
+                  // (e.g. duplicate testID), breaking the DOM output.
+                  delete out.style
                 }
               }
 
@@ -1467,6 +1473,26 @@ export function createExtractor(
                   key === '__source' ||
                   key === '__self'
                 ) {
+                  if (
+                    styleValue === FAILED_EVAL &&
+                    key !== name &&
+                    t.isJSXAttribute(attr.value)
+                  ) {
+                    // createDOMProps renamed the prop (e.g. testID -> data-testid).
+                    // Preserve the original expression value but use the new
+                    // attribute name. Restricted to FAILED_EVAL because the
+                    // later `case 'attr'` rename pass only runs on
+                    // statically-evaluable values; for static values that pass
+                    // intentionally preserves some prop names (e.g. focusable
+                    // in v2) instead of doing the createDOMProps rename.
+                    return {
+                      type: 'attr',
+                      value: t.jsxAttribute(
+                        t.jsxIdentifier(key),
+                        attr.value.value
+                      ),
+                    } as const
+                  }
                   return attr
                 }
                 if (shouldPrintDebug) {
@@ -2155,6 +2181,10 @@ export function createExtractor(
                       )
                       // remove rnw className use ours
                       out.className = cn
+                      // see note in single-prop branch above; createDOMProps
+                      // also emits a stray style key here that would duplicate
+                      // emitted JSXAttributes downstream.
+                      delete out.style
                     }
                     if (shouldPrintDebug) {
                       logger.info([' - expanded variant', name, out].join(' '))


### PR DESCRIPTION
## Summary

Two related bugs in the web extractor's handling of single non-style JSX props (e.g. `testID`):

**1. Duplicate-attribute emit.** The extractor routes a single non-style prop through `react-native-web-internals.createDOMProps` to get the RNW prop rewrite (`testID` → `data-testid`). `createDOMProps` unconditionally sets `domProps.style = stylesAtomic.reduce(...)` — i.e. always emits a `style` key (`{}` when no style was involved). The extractor strips `out.className` but not the stray `out.style`, so `Object.keys(out)` yields two keys for what was a single input prop and the same `JSXAttribute` reference is emitted twice in the output JSX.

**2. Dynamic testID never gets renamed to data-testid.** For static-string testIDs the duplicate was masked because the later `case "attr"` pass uses `getProps()` to discover the new key and rewrites the attribute name. Both refs point to the same `JSXAttribute`, so they end up identical (still wrong, just hidden). For values that can't be statically evaluated (template literals, identifier refs) that pass is skipped because it's gated on `attemptEvalSafe(value) !== FAILED_EVAL`. The output ends up as `<div testID={...} testID={...}>` — Vite warns "Duplicate testID attribute in JSX element", React keeps only the last instance, but it's still raw `testID` (an unknown HTML attribute) that React then drops, so `data-testid` never makes it onto the DOM and `getByTestId` queries that rely on dynamic testIDs silently break.

## Fix

1. `delete out.style` after `createDOMProps` in both the single-prop branch and the variant-expansion branch in [`createExtractor.ts`](code/compiler/static/src/extractor/createExtractor.ts). With only the actual emitted-key left in `out`, `Object.keys(out).map(...)` runs once and emits a single attribute.

2. In the data/aria/HTML-attribute branch, when `styleValue === FAILED_EVAL` and `createDOMProps` produced a different output key from the original prop name, build a fresh `JSXAttribute` with the new name and the original expression value. This handles dynamic `testID` → `data-testid` (and similar pure-rename cases) symmetrically with the static path.

   Restricted to `FAILED_EVAL` because static values still flow through `case "attr"`, which intentionally keeps some prop names (e.g. `focusable` in v2) instead of doing the RNW rename — the existing `webAlignment.web.test.tsx` "focusable is NOT converted to tabIndex in v2" test exercises that, and would fail if the rename ran for static values too.

## Repro

```tsx
import { View } from '@tamagui/core'

export function Test({ x }: { x: string }) {
  return <View testID={`a-${x}`} />
}
```

Before this PR:
```tsx
return <div className={_cn} testID={`a-${x}`} testID={`a-${x}`} />
```

After this PR:
```tsx
return <div className={_cn} data-testid={`a-${x}`} />
```

## Test plan

- [x] Added `non-static testID with template literal is rewritten to data-testid` regression test in [`babel.web.test.tsx`](code/compiler/static-tests/tests/babel.web.test.tsx) that asserts `data-testid={`a-${x}`}` is in the output exactly once and there is no raw `testID=`.
- [x] Verified the new test fails on the unfixed code (`expected: 1 to be 2` — the duplicate emission).
- [x] Verified the full `bun run test:web` suite still passes (9 test files, 82 passed + 1 skipped, 0 failed) and the webpack suite (18 passed) — no regressions.
- [x] Verified in a downstream consumer (Tamagui v2.0.0-rc.41 via `pnpm patch`) that the fix unblocks Playwright `getByTestId` queries that rely on template-literal testIDs.
