### PR TITLE
ci(detox): retry safeLaunchApp on transient iOS simctl launch errors

### DIFF
--- a/code/kitchen-sink/e2e/utils/detox.ts
+++ b/code/kitchen-sink/e2e/utils/detox.ts
@@ -32,7 +32,26 @@ const DEFAULT_LAUNCH_ARGS = {
 const POST_LAUNCH_SETTLE_MS = 1500
 const PRE_RELOAD_SETTLE_MS = 250
 
+// xcrun simctl launch occasionally returns FBSOpenApplicationServiceErrorDomain
+// (code=1 / code=4) on iOS simulators after a few prior tests in the same
+// session - the simulator's frontboard service gets into a transient bad state
+// where it refuses to open the app even though it's installed. Sleeping briefly
+// and re-launching nearly always recovers. Without this retry, ThemeMutation /
+// any test that runs late in a shard intermittently fails with all 4 cases
+// reporting the same FBSOpenApplicationService error in <100ms.
+const LAUNCH_RETRY_DELAY_MS = 3000
+const LAUNCH_MAX_ATTEMPTS = 3
+const RETRYABLE_LAUNCH_PATTERNS = [
+  'FBSOpenApplicationServiceErrorDomain',
+  'FBSOpenApplicationErrorDomain',
+]
+
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+const isRetryableLaunchError = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err)
+  return RETRYABLE_LAUNCH_PATTERNS.some((p) => msg.includes(p))
+}
 
 /**
  * Launch app then disable sync. Must launch first so Detox can connect,
@@ -41,15 +60,32 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 export async function safeLaunchApp(
   params?: Parameters<typeof device.launchApp>[0]
 ): Promise<void> {
-  await device.launchApp({
-    ...params,
-    launchArgs: {
-      ...DEFAULT_LAUNCH_ARGS,
-      ...params?.launchArgs,
-    },
-  } as any)
-  await device.disableSynchronization()
-  await sleep(POST_LAUNCH_SETTLE_MS)
+  let lastError: unknown
+  for (let attempt = 1; attempt <= LAUNCH_MAX_ATTEMPTS; attempt++) {
+    try {
+      await device.launchApp({
+        ...params,
+        launchArgs: {
+          ...DEFAULT_LAUNCH_ARGS,
+          ...params?.launchArgs,
+        },
+      } as any)
+      await device.disableSynchronization()
+      await sleep(POST_LAUNCH_SETTLE_MS)
+      return
+    } catch (err) {
+      lastError = err
+      if (attempt === LAUNCH_MAX_ATTEMPTS || !isRetryableLaunchError(err)) {
+        throw err
+      }
+      console.warn(
+        `safeLaunchApp: attempt ${attempt}/${LAUNCH_MAX_ATTEMPTS} failed with retryable simulator error, retrying after ${LAUNCH_RETRY_DELAY_MS}ms`,
+        err instanceof Error ? err.message : err
+      )
+      await sleep(LAUNCH_RETRY_DELAY_MS)
+    }
+  }
+  throw lastError
 }
 
 /**


### PR DESCRIPTION
## Summary
- iOS simulators occasionally return `FBSOpenApplicationServiceErrorDomain code=1` from `xcrun simctl launch` a few tests into a shard - the frontboard service transiently refuses to open the app even though it's still installed. Both Jest retries hit the same instant-fail and the whole test file is reported as failed.
- Wraps `safeLaunchApp` in a 3-attempt retry with 3s backoff, only retrying on `FBSOpenApplication*` error patterns. Other launch errors still throw immediately.

Observed on https://github.com/tamagui/tamagui/actions/runs/25478593738/job/74759556134 (post-merge run for #4002) - shard 3 ThemeMutation.test.ts hit this exact pattern after MenuRadioGroup completed normally.

## Test plan
- [x] Targeted change limited to `e2e/utils/detox.ts`
- [ ] Validate on CI - shard 3 should pass; non-retryable launch errors still fail fast