### PR TITLE
ci(detox): bump compiler-test hook timeouts and home-title wait for slow CI runners

### DIFF
--- a/code/kitchen-sink/e2e/CompilerExtraction.test.ts
+++ b/code/kitchen-sink/e2e/CompilerExtraction.test.ts
@@ -31,7 +31,7 @@ describe('CompilerExtraction', () => {
     console.log('Build complete, .native.tsx generated')
 
     await safeLaunchApp({ newInstance: true })
-  }, 300_000) // tamagui build can take 60-120s on slow CI runners; default jest hook timeout is 5s, package-level setupTimeout is 180s
+  }, 600_000) // tamagui build can occasionally take 5-12 min on slow CI runners (sequential single-file builds with cold metro)
 
   it('should render and respond to theme changes', async () => {
     await safeReloadApp()

--- a/code/kitchen-sink/e2e/CompilerTernaryActive.test.ts
+++ b/code/kitchen-sink/e2e/CompilerTernaryActive.test.ts
@@ -31,7 +31,7 @@ describe('CompilerTernaryActive', () => {
     console.log('Build complete, .native.tsx generated')
 
     await safeLaunchApp({ newInstance: true })
-  })
+  }, 600_000) // tamagui build can occasionally take 5-12 min on slow CI runners
 
   it('optimized and non-optimized text should match colors in both states', async () => {
     await safeReloadApp()

--- a/code/kitchen-sink/e2e/utils/navigation.ts
+++ b/code/kitchen-sink/e2e/utils/navigation.ts
@@ -21,10 +21,11 @@ export async function navigateToTestCase(
   // disable sync to avoid animation driver blocking
   await device.disableSynchronization()
 
-  // wait for home screen to load
+  // wait for home screen to load - generous because safeReloadApp triggers a
+  // metro re-bundle that can exceed 60s on slow CI runners
   await waitFor(element(by.id('home-title')))
     .toExist()
-    .withTimeout(60000)
+    .withTimeout(180000)
 
   // small delay for UI to settle before tapping
   await new Promise((r) => setTimeout(r, 500))


### PR DESCRIPTION
## Summary
Follow-up to #4003 - the timeout bumps were on the same branch but the merge queue squash-merged before the second commit landed.

- CompilerTernaryActive's beforeAll relied on jest's 180s default; the tamagui build alone took 12 min on a slow CI run. Bump to 600s to match CompilerExtraction.
- CompilerExtraction beforeAll bumped 300s to 600s for the same reason.
- navigateToTestCase home-title wait bumped 60s to 180s because safeReloadApp triggers a metro re-bundle that exceeded 60s on a slow runner.

Observed on https://github.com/tamagui/tamagui/actions/runs/25478593738/job/74759556134 - all three failures were timeout-driven, none were product bugs.

## Test plan
- [x] Targeted to compiler test files and one nav helper
- [ ] Validate on CI