### PR TITLE
fix(image): bridge accessibilityLabel <-> alt cross-platform

### DIFF
--- a/code/ui/image/src/Image.tsx
+++ b/code/ui/image/src/Image.tsx
@@ -20,9 +20,16 @@ export const Image = StyledImage.styleable<ImageProps>(
       progressiveRenderingEnabled,
       resizeMethod,
       tintColor,
+      // bridge RN <-> web a11y: <img> only honors `alt`, but consumers writing
+      // cross-platform code reach for RN's `accessibilityLabel`. without this
+      // mapping the label silently drops on web (no alt text, screen readers
+      // announce nothing, and react warns about an unknown prop on <img>).
+      accessibilityLabel,
+      alt,
       ...rest
-    } = inProps
-    return <StyledImage ref={ref} {...rest} />
+    } = inProps as ImageProps & { alt?: string }
+    const resolvedAlt = alt ?? accessibilityLabel
+    return <StyledImage ref={ref} {...(rest as any)} alt={resolvedAlt} />
   },
   {
     staticConfig: {

--- a/code/ui/image/src/createImage.tsx
+++ b/code/ui/image/src/createImage.tsx
@@ -157,6 +157,11 @@ export function createImage<C extends ComponentType<any>>(
       useMap,
       onLoad,
       onError,
+      // bridge web <-> RN a11y: RN's Image only reads `accessibilityLabel`,
+      // but cross-platform code often passes `alt` (matching the HTML img API).
+      // without this mapping the label silently drops on native.
+      alt,
+      accessibilityLabel,
       ...rest
     } = props
 
@@ -193,6 +198,11 @@ export function createImage<C extends ComponentType<any>>(
         ...(resolvedWidth !== undefined && { width: resolvedWidth }),
         ...(resolvedHeight !== undefined && { height: resolvedHeight }),
       },
+    }
+
+    const a11yLabel = accessibilityLabel ?? alt
+    if (a11yLabel != null) {
+      finalProps.accessibilityLabel = a11yLabel
     }
 
     // Set resize mode / content fit


### PR DESCRIPTION
## Summary

- v2 Image dropped the bidirectional `accessibilityLabel` ⇄ `alt` mapping.
- On web, `<img>` only honors `alt` — passing `accessibilityLabel` silently dropped the label and React warned about an unknown prop on `<img>`.
- On native, RN's `Image` only reads `accessibilityLabel` — passing `alt` (HTML-style cross-platform code) silently dropped the label for screen readers.

Now web maps `alt ?? accessibilityLabel` → `alt`, and native maps `accessibilityLabel ?? alt` → `accessibilityLabel`. Either prop works on either platform.

## Test plan

- [ ] On web, `<Image src="..." accessibilityLabel="cat" />` renders `<img alt="cat">` with no React warning.
- [ ] On web, `<Image src="..." alt="cat" />` continues to render `<img alt="cat">`.
- [ ] On native, `<Image src="..." alt="cat" />` is announced as "cat" by VoiceOver/TalkBack.
- [ ] On native, `<Image src="..." accessibilityLabel="cat" />` continues to be announced as "cat".