### PR TITLE
docs(variants): note that variant names shadow HTML attributes

### DIFF
--- a/code/core/core-test/variantPropLeak.web.test.tsx
+++ b/code/core/core-test/variantPropLeak.web.test.tsx
@@ -1,0 +1,118 @@
+process.env.TAMAGUI_TARGET = 'web'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { render } from '@testing-library/react'
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+import * as React from 'react'
+
+import { View, TamaguiProvider, createTamagui, styled } from '../web/src'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+const W = ({ children }: { children: React.ReactNode }) => (
+  <TamaguiProvider config={conf} defaultTheme="light">
+    {children}
+  </TamaguiProvider>
+)
+
+// regression: a prop declared as a variant ANYWHERE in the inheritance chain
+// must not leak to the host element even when the leaf component doesn't
+// actively consume it. covers the soot tooltip pattern (TooltipContent unstyled)
+// where intermediaries pass the prop through `.styleable` chains.
+describe('variant prop does not leak to host element', () => {
+  test(`<C unstyled /> with variant declared on C`, () => {
+    const C = styled(View, {
+      variants: { unstyled: { true: {} } } as const,
+    })
+    const { container } = render(
+      <W>
+        <C unstyled data-testid="c" />
+      </W>
+    )
+    expect(container.querySelector('[data-testid="c"]')!.hasAttribute('unstyled')).toBe(
+      false
+    )
+  })
+
+  test(`<Outer unstyled /> with variant inherited via styled chain`, () => {
+    const Inner = styled(View, {
+      variants: { unstyled: { true: {} } } as const,
+    })
+    const Outer = styled(Inner, {})
+    const { container } = render(
+      <W>
+        <Outer unstyled data-testid="o" />
+      </W>
+    )
+    expect(container.querySelector('[data-testid="o"]')!.hasAttribute('unstyled')).toBe(
+      false
+    )
+  })
+
+  test(`<C unstyled={false} /> with variant only declaring 'true' (resolveVariants returns undefined)`, () => {
+    const C = styled(View, {
+      variants: { unstyled: { true: {} } } as const,
+    })
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { container } = render(
+      <W>
+        <C unstyled={false} data-testid="c" />
+      </W>
+    )
+    expect(container.querySelector('[data-testid="c"]')!.hasAttribute('unstyled')).toBe(
+      false
+    )
+    const warn = errSpy.mock.calls.find(
+      (a) =>
+        typeof a[0] === 'string' && a[0].includes('Received') && a.includes('unstyled')
+    )
+    expect(warn).toBeUndefined()
+    errSpy.mockRestore()
+  })
+
+  test(`.styleable HOC chain forwarding to leaf with variant (soot tooltip pattern)`, () => {
+    const Frame = styled(View, {
+      variants: { unstyled: { true: {} } } as const,
+    })
+    const PopoverContent = (Frame as any).styleable(
+      function PopoverContent(props: any, ref: any) {
+        return <Frame ref={ref} {...props} />
+      }
+    )
+    const TooltipContent = (Frame as any).styleable(
+      function TooltipContent(props: any, ref: any) {
+        return <PopoverContent ref={ref} {...props} />
+      }
+    )
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { container } = render(
+      <W>
+        <TooltipContent unstyled data-testid="t" />
+      </W>
+    )
+    expect(container.querySelector('[data-testid="t"]')!.hasAttribute('unstyled')).toBe(
+      false
+    )
+    const warn = errSpy.mock.calls.find(
+      (a) =>
+        typeof a[0] === 'string' && a[0].includes('Received') && a.includes('unstyled')
+    )
+    expect(warn).toBeUndefined()
+    errSpy.mockRestore()
+  })
+
+  test(`userland variant prop (not unstyled) also doesn't leak`, () => {
+    const C = styled(View, {
+      variants: { myToggle: { true: {} } } as const,
+    })
+    const { container } = render(
+      <W>
+        {/* @ts-expect-error - testing custom variant prop */}
+        <C myToggle data-testid="c" />
+      </W>
+    )
+    expect(container.querySelector('[data-testid="c"]')!.hasAttribute('mytoggle')).toBe(
+      false
+    )
+  })
+})

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -585,6 +585,20 @@ export const getSplitStyles: StyleSplitter = (
       const isStyledContextProp = styledContext && key in styledContext
 
       if (!isHOC && disablePropMap && !isStyledContextProp && !isMediaOrPseudo) {
+        // backstop for the shortcut path: a prop only reaches here when it's not
+        // a style key / variant / pseudo / media on this component. but if it's
+        // declared as a variant ANYWHERE in the inheritance chain (own or
+        // parent's), the variant pipeline already produced its effect (or chose
+        // to no-op for an unsupported value like `unstyled={false}` with only
+        // `true: {}` declared) — don't leak the boolean to the host element.
+        // edge case: a userland variant whose name shadows a real HTML attribute
+        // also gets dropped here, accepted as not worth distinguishing.
+        if (
+          (variants && key in variants) ||
+          (parentVariants && key in parentVariants)
+        ) {
+          return
+        }
         viewProps[key] = val
         return
       }

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -585,20 +585,6 @@ export const getSplitStyles: StyleSplitter = (
       const isStyledContextProp = styledContext && key in styledContext
 
       if (!isHOC && disablePropMap && !isStyledContextProp && !isMediaOrPseudo) {
-        // backstop for the shortcut path: a prop only reaches here when it's not
-        // a style key / variant / pseudo / media on this component. but if it's
-        // declared as a variant ANYWHERE in the inheritance chain (own or
-        // parent's), the variant pipeline already produced its effect (or chose
-        // to no-op for an unsupported value like `unstyled={false}` with only
-        // `true: {}` declared) — don't leak the boolean to the host element.
-        // edge case: a userland variant whose name shadows a real HTML attribute
-        // also gets dropped here, accepted as not worth distinguishing.
-        if (
-          (variants && key in variants) ||
-          (parentVariants && key in parentVariants)
-        ) {
-          return
-        }
         viewProps[key] = val
         return
       }

--- a/code/kitchen-sink/src/usecases/UnstyledLeakCase.tsx
+++ b/code/kitchen-sink/src/usecases/UnstyledLeakCase.tsx
@@ -1,0 +1,76 @@
+// reproduces soot's "unstyled forwards to DOM" report on the tooltip portal path.
+// soot has: <TamaguiTooltip {...tooltipProps}> ... <TooltipContent unstyled ...>
+// the goal is to render this pattern and see if React-DOM (dev build, so the
+// "Received `%s` for a non-boolean attribute `unstyled`" warning is present)
+// fires when the tooltip provider renders.
+import { useEffect, useState } from 'react'
+import {
+  Button,
+  Paragraph,
+  Tooltip,
+  TooltipGroup,
+  XStack,
+  YStack,
+} from 'tamagui'
+
+export function UnstyledLeakCase() {
+  // toggle to force re-renders of the provider chain
+  const [tick, setTick] = useState(0)
+  useEffect(() => {
+    const i = setInterval(() => setTick((t) => t + 1), 800)
+    return () => clearInterval(i)
+  }, [])
+
+  return (
+    <YStack gap="$4" p="$4">
+      <Paragraph>UnstyledLeakCase — tick: {tick}</Paragraph>
+      <XStack gap="$3">
+        {/* mirrors soot's GlobalTooltipProvider pattern: a Tooltip that always
+            renders a TooltipContent with `unstyled` */}
+        <Tooltip placement="bottom">
+          <Tooltip.Trigger asChild>
+            <Button id="leak-trigger-1">Hover me</Button>
+          </Tooltip.Trigger>
+          <Tooltip.Content
+            unstyled
+            enterStyle={{ x: 0, y: -3, opacity: 0 }}
+            exitStyle={{ x: 0, y: -3, opacity: 0 }}
+            x={0}
+            scale={1}
+            y={0}
+            opacity={1}
+            pointerEvents="none"
+            py="$1.5"
+            px="$2"
+            maxWidth={320}
+            borderRadius="$2"
+            animatePosition
+            animateOnly={['transform', 'opacity', 'width', 'height']}
+            transition={'200ms' as any}
+            backgroundColor="$color"
+          >
+            <Tooltip.Arrow />
+            <Paragraph color="$background">tooltip text</Paragraph>
+          </Tooltip.Content>
+        </Tooltip>
+
+        {/* same again wrapped in TooltipGroup like soot's GlobalTooltipProvider */}
+        <TooltipGroup delay={0}>
+          <Tooltip placement="bottom">
+            <Tooltip.Trigger asChild>
+              <Button id="leak-trigger-2">Hover me 2</Button>
+            </Tooltip.Trigger>
+            <Tooltip.Content
+              unstyled
+              backgroundColor="$color"
+              py="$1.5"
+              px="$2"
+            >
+              <Paragraph color="$background">tooltip 2</Paragraph>
+            </Tooltip.Content>
+          </Tooltip>
+        </TooltipGroup>
+      </XStack>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -3,6 +3,7 @@
 // - react-native-actions-sheet
 // - react-native-teleport
 
+export { UnstyledLeakCase } from './UnstyledLeakCase'
 export { AnimatedByProp } from './AnimatedByProp'
 export { AnimatePresenceEnterExitCase } from './AnimatePresenceEnterExitCase'
 export { AnimatePresenceExitTest } from './AnimatePresenceExitTest'

--- a/code/tamagui.dev/data/docs/core/variants.mdx
+++ b/code/tamagui.dev/data/docs/core/variants.mdx
@@ -439,3 +439,31 @@ const MyParagraph = styled(ColorfulText, {
   } as const,
 })
 ```
+
+### Variant names and HTML attributes
+
+A declared variant name owns that prop. Tamagui's variant pipeline consumes
+the prop to produce styles, so it never lands on the underlying host element.
+
+That means if you pick a variant name that happens to match a real HTML
+attribute (`title`, `role`, `slot`, `form`, etc.) on a styled component that
+renders to a DOM element, the attribute is **silently swallowed** rather than
+forwarded:
+
+```tsx
+const Card = styled(View, {
+  variants: {
+    title: {
+      // careful: this shadows the HTML `title` attribute
+      true: { fontWeight: 'bold' },
+    },
+  } as const,
+})
+
+// the HTML `title` attribute does NOT get set — `title` is now your variant
+<Card title="tooltip text" />
+```
+
+Pick variant names that don't collide with attributes you care about, or
+choose a Tamagui-specific name and pass the HTML attribute alongside as a
+separate explicit prop.


### PR DESCRIPTION
## Summary

I went looking for a code-level fix for an `unstyled` prop leaking to host elements on tooltip/popover paths, but the variant pipeline already handles this correctly — when a variant is declared anywhere in the inheritance chain, `isVariant` is true at line 468 and the prop is consumed before it can reach `viewProps`. My initial guard at the shortcut was unreachable dead code.

The real edge case worth documenting: **variant names own that prop**. If you pick a variant name that matches a real HTML attribute (`title`, `role`, `slot`, `form`, …) on a styled component that renders to a host element, the attribute is silently swallowed rather than forwarded.

## Changes

- **`code/tamagui.dev/data/docs/core/variants.mdx`** — new "Variant names and HTML attributes" section explaining the collision and how to avoid it.
- **`code/core/core-test/variantPropLeak.web.test.tsx`** — 5 regression tests asserting that variant props don't leak to host elements (direct, inherited via `styled` chain, variant value with no matching declaration, `.styleable` HOC chain mirroring the tooltip pattern, userland custom variant). Full web suite: 166 passed, no regressions.
- **`code/kitchen-sink/src/usecases/UnstyledLeakCase.tsx`** — manual reproducer for the soot tooltip pattern. Useful when chasing future reports of this class of issue.

## Test plan

- [x] `bun run test:web` in `core/core-test` — all 166 tests pass.
- [x] Manual kitchen-sink case loads and re-renders without producing the React-DOM "Received \`...\` for a non-boolean attribute \`unstyled\`" warning.