### PR TITLE
ci: retry maestro flows per-flow instead of re-running the whole suite

### DIFF
--- a/.github/scripts/run-maestro-flows.sh
+++ b/.github/scripts/run-maestro-flows.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# run each maestro flow as its own invocation, retrying ONLY the flow that
+# fails. the previous harness re-ran the WHOLE suite on any failure and only
+# passed on a single fully-clean attempt, so a transient flake landing on a
+# DIFFERENT flow each attempt could never go green even though every flow
+# passed at least once (observed on iOS Native: attempt 1 failed `Select`,
+# attempt 2 failed `OpenApp`, each passed on the other attempt -> suite red).
+#
+# per-flow retry isolates a flake to its own flow and keeps the other flows'
+# passes, so the suite goes green as long as every flow passes within its
+# own attempt budget.
+#
+# configuration (env vars, all optional):
+#   FLOWS_DIR      directory of flow .yaml files            (default: ./flows)
+#   BUNDLE_ID      app to terminate between attempts        (default: com.tamagui.tamaguikitchensink)
+#   MAX_ATTEMPTS   attempts per flow before giving up       (default: 3)
+#   SKIP_FLOWS     space-separated basenames to skip; these are util
+#                  sub-flows / warm-ups, not standalone tests
+#                                                            (default: "OpenApp.yaml WarmUp.yaml")
+#   METRO_PID_FILE if the pid in this file is dead, abort    (default: /tmp/metro-pid)
+#
+# NOT using `set -e`: a failing `maestro test` is expected and handled inline.
+
+set -uo pipefail
+
+FLOWS_DIR="${FLOWS_DIR:-./flows}"
+BUNDLE_ID="${BUNDLE_ID:-com.tamagui.tamaguikitchensink}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+SKIP_FLOWS="${SKIP_FLOWS:-OpenApp.yaml WarmUp.yaml}"
+METRO_PID_FILE="${METRO_PID_FILE:-/tmp/metro-pid}"
+
+metro_alive() {
+  local pid
+  pid="$(cat "$METRO_PID_FILE" 2>/dev/null || true)"
+  [ -z "$pid" ] && return 0 # no tracked pid -> nothing to check
+  kill -0 "$pid" 2>/dev/null
+}
+
+recover_sim() {
+  echo "recovering simulator state (terminate app, keep Hermes bytecode cache)..."
+  xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+  sleep 2
+  if ! metro_alive; then
+    echo "::error::Metro died during test run — aborting (every retry would fail)"
+    tail -50 /tmp/metro.log 2>/dev/null || true
+    exit 1
+  fi
+}
+
+shopt -s nullglob
+flows=("$FLOWS_DIR"/*.yaml "$FLOWS_DIR"/*.yml)
+shopt -u nullglob
+
+if [ "${#flows[@]}" -eq 0 ]; then
+  echo "::error::no flow files found in $FLOWS_DIR"
+  exit 1
+fi
+
+failed=""
+for flow in "${flows[@]}"; do
+  base="$(basename "$flow")"
+  case " $SKIP_FLOWS " in
+    *" $base "*)
+      echo "skipping util sub-flow: $base"
+      continue
+      ;;
+  esac
+
+  name="${base%.*}"
+  passed=false
+  for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    echo "::group::$name (attempt $attempt/$MAX_ATTEMPTS)"
+    if maestro test "$flow" --no-ansi; then
+      passed=true
+      echo "::endgroup::"
+      echo "✓ $name passed (attempt $attempt/$MAX_ATTEMPTS)"
+      break
+    fi
+    echo "::endgroup::"
+    echo "::warning::$name failed (attempt $attempt/$MAX_ATTEMPTS)"
+    if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+      recover_sim
+    fi
+  done
+  if [ "$passed" = false ]; then
+    failed="$failed $name"
+  fi
+done
+
+if [ -n "$failed" ]; then
+  echo "::error::flows failed after $MAX_ATTEMPTS attempts:$failed"
+  exit 1
+fi
+
+echo "all flows passed"

--- a/.github/workflows/test-ios-kitchensink-go.yml
+++ b/.github/workflows/test-ios-kitchensink-go.yml
@@ -112,21 +112,13 @@ jobs:
           done
           xcrun simctl list devices booted
 
+      # per-flow retry (shared with test-ios-native): a flake in one flow is
+      # retried in isolation instead of re-running the whole suite. runs Expo
+      # Go (host.exp.Exponent), so terminate that between attempts.
       - name: Run Maestro Tests
-        run: |
-          for attempt in 1 2; do
-            echo "Test attempt $attempt of 2..."
-            if maestro test ./flows --exclude-tags=util --no-ansi; then
-              echo "Tests passed!"
-              exit 0
-            fi
-            if [ $attempt -lt 2 ]; then
-              echo "Attempt $attempt failed, retrying..."
-              sleep 10
-            fi
-          done
-          echo "All attempts failed"
-          exit 1
+        env:
+          BUNDLE_ID: host.exp.Exponent
+        run: bash "${{ github.workspace }}/.github/scripts/run-maestro-flows.sh"
 
       - name: Upload Maestro Artifacts on Failure
         if: failure()

--- a/.github/workflows/test-ios-native.yml
+++ b/.github/workflows/test-ios-native.yml
@@ -181,45 +181,13 @@ jobs:
             exit 1
           fi
 
+      # run each flow independently and retry ONLY the flow that flakes, so a
+      # transient flake in one flow doesn't discard the passes of the others.
+      # the OpenApp/WarmUp util sub-flows are skipped (WarmUp ran in the step
+      # above; OpenApp is invoked via runFlow by every component flow).
       - name: Run Maestro Tests
         if: env.SKIP_MAESTRO_TESTS != 'true'
-        run: |
-          BUNDLE_ID="com.tamagui.tamaguikitchensink"
-          APP_PATH="${{ github.workspace }}/${{ needs.build.outputs.built-app-path }}"
-
-          for attempt in 1 2; do
-            echo "Test attempt $attempt of 2..."
-            if maestro test ./flows --exclude-tags=util --no-ansi; then
-              echo "Tests passed on attempt $attempt"
-              exit 0
-            fi
-
-            if [ $attempt -lt 2 ]; then
-              echo "Attempt $attempt failed — recovering simulator state..."
-
-              # terminate stale app, reinstall, verify registration
-              xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
-              sleep 2
-              xcrun simctl uninstall booted "$BUNDLE_ID" 2>/dev/null || true
-              xcrun simctl install booted "$APP_PATH"
-              sleep 3
-
-              if ! xcrun simctl get_app_container booted "$BUNDLE_ID" 2>/dev/null; then
-                echo "::warning::App not registered after reinstall, retrying anyway"
-              fi
-
-              # verify Metro is still alive
-              METRO_PID=$(cat /tmp/metro-pid 2>/dev/null)
-              if [ -n "$METRO_PID" ] && ! kill -0 "$METRO_PID" 2>/dev/null; then
-                echo "::error::Metro died during test run"
-                cat /tmp/metro.log | tail -50
-                exit 1
-              fi
-            fi
-          done
-
-          echo "All attempts failed"
-          exit 1
+        run: bash "${{ github.workspace }}/.github/scripts/run-maestro-flows.sh"
 
       - name: Dump Logs on Failure
         if: failure() && env.SKIP_MAESTRO_TESTS != 'true'

--- a/code/kitchen-sink-go/flows/OpenApp.yaml
+++ b/code/kitchen-sink-go/flows/OpenApp.yaml
@@ -1,5 +1,5 @@
 appId: host.exp.Exponent
-tag:
+tags:
   - util
 ---
 # Stop the app first to ensure clean state

--- a/code/kitchen-sink/flows/OpenApp.yaml
+++ b/code/kitchen-sink/flows/OpenApp.yaml
@@ -1,5 +1,5 @@
 appId: com.tamagui.tamaguikitchensink
-tag:
+tags:
   - util
 ---
 - launchApp

--- a/code/kitchen-sink/flows/WarmUp.yaml
+++ b/code/kitchen-sink/flows/WarmUp.yaml
@@ -1,5 +1,5 @@
 appId: com.tamagui.tamaguikitchensink
-tag:
+tags:
   - util
 ---
 # cold start with clearState to prime Hermes bytecode cache


### PR DESCRIPTION
Retry each Maestro flow independently instead of re-running the whole suite.

Two root causes of the iOS Native (Maestro) flakiness:
1. whole-suite retry: the harness re-ran ALL flows and only passed on a single fully-clean attempt, so a transient flake landing on a DIFFERENT flow each attempt could never go green even though every flow passed at least once (observed: attempt 1 failed Select, attempt 2 failed OpenApp).
2. `tag:` vs `tags:` typo in OpenApp.yaml / WarmUp.yaml meant `excludeTags: util` never matched, so the bare OpenApp relaunch and the clearState WarmUp ran as standalone top-level flows (OpenApp being a frequent flake source).

A shared script (.github/scripts/run-maestro-flows.sh) now runs each flow on its own with up to 3 attempts and light terminate-only recovery (preserves the Hermes bytecode cache); util sub-flows are skipped. Wired into test-ios-native.yml (validated) and the disabled test-ios-kitchensink-go.yml.

Validated: shellcheck + local stubbed smoke test of the control flow, plus a green iOS Native (Maestro) run on this branch - the same workflow that flaked red before.