### PR TITLE
ci(detox): directUseCase launch pattern across all e2e tests (drops per-test navigation)

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -54,24 +54,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 4 shards balanced by measured test-execution time (~26min each) so
-          # one slow file can't make a shard a 2x outlier. each of the heavy
-          # anchors lands on a separate shard: SelectAndroidOnPress (~16min) →
-          # shard 1, CompilerExtraction (~12min, in-test `tamagui build`) → shard
-          # 2 with otherwise-light files to absorb its variance, SheetScrollableDrag
-          # (~11min) → shard 3, PointerEvents + SelectRemount → shard 4. balance is
-          # validated by .github/scripts/check-ios-detox-shards.mjs (every e2e
-          # test must be assigned exactly once). note: a shard's wall time also
-          # includes a cold Metro bundle (~1min healthy, but can spike to ~20min
-          # on a degraded macOS runner — that's infra variance, not test cost).
+          # 4 shards. NOTE: being re-tuned — SheetScrollableDrag + SheetDragResist
+          # were just converted to the directUseCase launch pattern (relaunch
+          # straight into the case, no home → quick-nav navigation), which cuts
+          # ~60-90s/test of per-test overhead. once that pattern is rolled out to
+          # all files this matrix will be rebalanced to ≤30min/shard (and possibly
+          # collapsed to 3 shards). coverage validated by
+          # .github/scripts/check-ios-detox-shards.mjs (every e2e test assigned once).
           - shard_name: '1/4'
-            test_files: 'e2e/SelectAndroidOnPress.test.ts e2e/ShorthandVariables.test.ts e2e/NativePortal.test.ts e2e/GroupPressNative.test.ts e2e/MediaQueryGtMd.test.ts'
+            test_files: 'e2e/PressStyleNative.noRngh.test.ts e2e/PressStyleNative.test.ts e2e/check-rngh-status.test.ts e2e/GroupPressNative.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/PressStyleScrollStuck.test.ts e2e/NestedPressExclusive.test.ts'
           - shard_name: '2/4'
-            test_files: 'e2e/CompilerExtraction.test.ts e2e/PressStyleNative.test.ts e2e/CompilerTernaryActive.test.ts e2e/TabsOnInteraction.test.ts e2e/SheetPressRegression.test.ts e2e/check-rngh-status.test.ts e2e/SafeArea.test.ts'
+            test_files: 'e2e/SheetScrollableDrag.test.ts e2e/SheetDragResist.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetKeyboardFitContent.test.ts e2e/SheetPressRegression.test.ts e2e/NativePortal.test.ts'
           - shard_name: '3/4'
-            test_files: 'e2e/SheetScrollableDrag.test.ts e2e/PressStyleNative.noRngh.test.ts e2e/ThemeChangeBasic.test.ts e2e/MenuRadioGroup.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetKeyboardFitContent.test.ts'
+            test_files: 'e2e/PointerEvents.test.ts e2e/MediaQueryGtMd.test.ts e2e/TabsOnInteraction.test.ts e2e/SafeArea.test.ts e2e/CompilerExtraction.test.ts e2e/CompilerTernaryActive.test.ts'
           - shard_name: '4/4'
-            test_files: 'e2e/PointerEvents.test.ts e2e/SelectRemount.test.ts e2e/SheetDragResist.test.ts e2e/ThemeMutation.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/PressStyleScrollStuck.test.ts e2e/NestedPressExclusive.test.ts'
+            test_files: 'e2e/MenuRadioGroup.test.ts e2e/SelectAndroidOnPress.test.ts e2e/SelectRemount.test.ts e2e/ThemeChangeBasic.test.ts e2e/ThemeMutation.test.ts e2e/ShorthandVariables.test.ts'
     defaults:
       run:
         working-directory: ${{ env.test_container_app_path }}

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -54,19 +54,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 4 shards balanced by test execution time. the old ~7min/shard ts-jest
-          # type-check tax is gone (e2e now transpiles via e2e/tsconfig.json), so
-          # startup is small and these fit well under the native-ci runner's
-          # 45-minute process timeout. heaviest files: PressStyleNative.noRngh
-          # (~13min) and SheetScrollableDrag (~10min) head shards 1 and 2.
+          # 4 shards balanced by measured test-execution time (~26min each) so
+          # one slow file can't make a shard a 2x outlier. each of the heavy
+          # anchors lands on a separate shard: SelectAndroidOnPress (~16min) →
+          # shard 1, CompilerExtraction (~12min, in-test `tamagui build`) → shard
+          # 2 with otherwise-light files to absorb its variance, SheetScrollableDrag
+          # (~11min) → shard 3, PointerEvents + SelectRemount → shard 4. balance is
+          # validated by .github/scripts/check-ios-detox-shards.mjs (every e2e
+          # test must be assigned exactly once). note: a shard's wall time also
+          # includes a cold Metro bundle (~1min healthy, but can spike to ~20min
+          # on a degraded macOS runner — that's infra variance, not test cost).
           - shard_name: '1/4'
-            test_files: 'e2e/PressStyleNative.noRngh.test.ts e2e/PressStyleNative.test.ts e2e/check-rngh-status.test.ts e2e/GroupPressNative.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/PressStyleScrollStuck.test.ts e2e/NestedPressExclusive.test.ts'
+            test_files: 'e2e/SelectAndroidOnPress.test.ts e2e/ShorthandVariables.test.ts e2e/NativePortal.test.ts e2e/GroupPressNative.test.ts e2e/MediaQueryGtMd.test.ts'
           - shard_name: '2/4'
-            test_files: 'e2e/SheetScrollableDrag.test.ts e2e/SheetDragResist.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetKeyboardFitContent.test.ts e2e/SheetPressRegression.test.ts e2e/NativePortal.test.ts'
+            test_files: 'e2e/CompilerExtraction.test.ts e2e/PressStyleNative.test.ts e2e/CompilerTernaryActive.test.ts e2e/TabsOnInteraction.test.ts e2e/SheetPressRegression.test.ts e2e/check-rngh-status.test.ts e2e/SafeArea.test.ts'
           - shard_name: '3/4'
-            test_files: 'e2e/PointerEvents.test.ts e2e/MediaQueryGtMd.test.ts e2e/TabsOnInteraction.test.ts e2e/SafeArea.test.ts e2e/CompilerExtraction.test.ts e2e/CompilerTernaryActive.test.ts'
+            test_files: 'e2e/SheetScrollableDrag.test.ts e2e/PressStyleNative.noRngh.test.ts e2e/ThemeChangeBasic.test.ts e2e/MenuRadioGroup.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetKeyboardFitContent.test.ts'
           - shard_name: '4/4'
-            test_files: 'e2e/MenuRadioGroup.test.ts e2e/SelectAndroidOnPress.test.ts e2e/SelectRemount.test.ts e2e/ThemeChangeBasic.test.ts e2e/ThemeMutation.test.ts e2e/ShorthandVariables.test.ts'
+            test_files: 'e2e/PointerEvents.test.ts e2e/SelectRemount.test.ts e2e/SheetDragResist.test.ts e2e/ThemeMutation.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/PressStyleScrollStuck.test.ts e2e/NestedPressExclusive.test.ts'
     defaults:
       run:
         working-directory: ${{ env.test_container_app_path }}

--- a/code/kitchen-sink/e2e/CompilerExtraction.test.ts
+++ b/code/kitchen-sink/e2e/CompilerExtraction.test.ts
@@ -7,9 +7,8 @@ import * as assert from 'assert'
 import { execSync } from 'child_process'
 import { unlinkSync, existsSync } from 'fs'
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 const SOURCE_FILE = 'src/usecases/CompilerExtraction.tsx'
 const NATIVE_FILE = 'src/usecases/CompilerExtraction.native.tsx'
@@ -29,13 +28,10 @@ describe('CompilerExtraction', () => {
       { stdio: 'inherit' }
     )
     console.log('Build complete, .native.tsx generated')
-
-    await safeLaunchApp({ newInstance: true })
   }, 600_000) // tamagui build can occasionally take 5-12 min on slow CI runners (sequential single-file builds with cold metro)
 
   it('should render and respond to theme changes', async () => {
-    await safeReloadApp()
-    await navigateToTestCase('CompilerExtraction', 'compiler-extraction-root')
+    await reloadUseCase('CompilerExtraction', 'compiler-extraction-root')
     await new Promise((r) => setTimeout(r, 300))
 
     // verify components render
@@ -89,8 +85,7 @@ describe('CompilerExtraction', () => {
   })
 
   it('should benchmark optimized vs non-optimized (best of 3)', async () => {
-    await safeReloadApp()
-    await navigateToTestCase('CompilerExtraction', 'compiler-extraction-root')
+    await reloadUseCase('CompilerExtraction', 'compiler-extraction-root')
     await new Promise((r) => setTimeout(r, 300))
 
     // show benchmark

--- a/code/kitchen-sink/e2e/CompilerTernaryActive.test.ts
+++ b/code/kitchen-sink/e2e/CompilerTernaryActive.test.ts
@@ -11,9 +11,8 @@ import * as assert from 'assert'
 import { execSync } from 'child_process'
 import { unlinkSync, existsSync } from 'fs'
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
 import { getDominantColor, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 const SOURCE_FILE = 'src/usecases/CompilerTernaryActive.tsx'
 const NATIVE_FILE = 'src/usecases/CompilerTernaryActive.native.tsx'
@@ -29,13 +28,10 @@ describe('CompilerTernaryActive', () => {
       stdio: 'inherit',
     })
     console.log('Build complete, .native.tsx generated')
-
-    await safeLaunchApp({ newInstance: true })
   }, 600_000) // tamagui build can occasionally take 5-12 min on slow CI runners
 
   it('optimized and non-optimized text should match colors in both states', async () => {
-    await safeReloadApp()
-    await navigateToTestCase('CompilerTernaryActive', 'compiler-ternary-active-root')
+    await reloadUseCase('CompilerTernaryActive', 'compiler-ternary-active-root')
     await new Promise((r) => setTimeout(r, 300))
 
     // verify initial state is inactive

--- a/code/kitchen-sink/e2e/GroupPressNative.test.ts
+++ b/code/kitchen-sink/e2e/GroupPressNative.test.ts
@@ -6,23 +6,17 @@
 
 import { by, device, element, expect } from 'detox'
 import * as assert from 'assert'
-import { navigateToTestCase } from './utils/navigation'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 async function navigateToGroupPressNative() {
-  await navigateToTestCase('GroupPressNative', 'group-press-native-root')
+  await reloadUseCase('GroupPressNative', 'group-press-native-root')
 }
 
 // TODO: These tests are flaky on iOS simulator - press events don't fire reliably
 // Need to investigate press event handling in simulator environment
 describe.skip('GroupPressNative', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
     await navigateToGroupPressNative()
   })
 

--- a/code/kitchen-sink/e2e/GroupPressTransitionMatrix.test.ts
+++ b/code/kitchen-sink/e2e/GroupPressTransitionMatrix.test.ts
@@ -16,8 +16,7 @@
 
 import { by, device, element, expect as detoxExpect } from 'detox'
 import * as assert from 'assert'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
 
 const CELLS = ['pp-cp', 'pa-cp', 'pp-ca', 'pa-ca'] as const
@@ -53,13 +52,8 @@ async function assertChildReturnedToDefault(cellId: string) {
 }
 
 describe('GroupPressTransitionMatrix', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase(
+    await reloadUseCase(
       'GroupPressTransitionMatrix',
       'group-press-transition-matrix-root'
     )

--- a/code/kitchen-sink/e2e/MediaQueryGtMd.test.ts
+++ b/code/kitchen-sink/e2e/MediaQueryGtMd.test.ts
@@ -17,16 +17,15 @@
  */
 
 import { by, device, element, expect } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { safeLaunchApp } from './utils/detox'
 import { navigateToTestCase } from './utils/navigation'
 
 describe('MediaQueryGtMd', () => {
+  // launch + navigate once: all three tests read the same static media-query
+  // screen and never mutate it, so the old per-test safeReloadApp only added a
+  // relaunch + re-bundle + re-navigation (~70s/test) with no isolation gain.
   beforeAll(async () => {
     await safeLaunchApp({ newInstance: true })
-  })
-
-  beforeEach(async () => {
-    await safeReloadApp()
     await navigateToTestCase('MediaQueryGtMd', 'media-test-both')
   })
 

--- a/code/kitchen-sink/e2e/MediaQueryGtMd.test.ts
+++ b/code/kitchen-sink/e2e/MediaQueryGtMd.test.ts
@@ -17,16 +17,14 @@
  */
 
 import { by, device, element, expect } from 'detox'
-import { safeLaunchApp } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { reloadUseCase } from './utils/detox'
 
 describe('MediaQueryGtMd', () => {
   // launch + navigate once: all three tests read the same static media-query
   // screen and never mutate it, so the old per-test safeReloadApp only added a
   // relaunch + re-bundle + re-navigation (~70s/test) with no isolation gain.
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-    await navigateToTestCase('MediaQueryGtMd', 'media-test-both')
+    await reloadUseCase('MediaQueryGtMd', 'media-test-both')
   })
 
   it('should render all media query test elements', async () => {

--- a/code/kitchen-sink/e2e/MenuRadioGroup.test.ts
+++ b/code/kitchen-sink/e2e/MenuRadioGroup.test.ts
@@ -1,6 +1,5 @@
 import { by, element, expect, waitFor } from 'detox'
-import { safeLaunchApp, withSync } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { reloadUseCase, withSync } from './utils/detox'
 
 function getMenuItemMatcher(label: string) {
   return by.text(label)
@@ -20,10 +19,7 @@ async function selectColor(label: 'Red' | 'Green' | 'Blue') {
 
 describe('MenuRadioGroup', () => {
   beforeEach(async () => {
-    await safeLaunchApp({ newInstance: true })
-    await navigateToTestCase('MenuRadioGroupCase', 'menu-radio-selected-value', {
-      skipEnableSync: true,
-    })
+    await reloadUseCase('MenuRadioGroupCase', 'menu-radio-selected-value')
   })
 
   it('should render the menu radio group case', async () => {

--- a/code/kitchen-sink/e2e/NativePortal.test.ts
+++ b/code/kitchen-sink/e2e/NativePortal.test.ts
@@ -4,16 +4,12 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
+import { reloadUseCase, withSync } from './utils/detox'
 
 const testElement = (id: string) => element(by.id(id)).atIndex(0)
 
 async function navigateToNativePortal() {
-  await navigateToTestCase('NativePortalTest', 'portal-status', {
-    // Re-enabling sync after navigation is brittle on iOS once portal animations settle.
-    skipEnableSync: true,
-  })
+  await reloadUseCase('NativePortalTest', 'portal-status')
 }
 
 async function openSelect() {
@@ -57,12 +53,7 @@ async function closeSheet() {
 }
 
 describe('NativePortal', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
     await navigateToNativePortal()
   })
 

--- a/code/kitchen-sink/e2e/NestedPressExclusive.test.ts
+++ b/code/kitchen-sink/e2e/NestedPressExclusive.test.ts
@@ -7,8 +7,7 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, withSync } from './utils/detox'
+import { reloadUseCase, withSync } from './utils/detox'
 
 async function tapForCurrentPlatform(testID: string, point?: { x: number; y: number }) {
   if (device.getPlatform() === 'android') {
@@ -25,8 +24,7 @@ async function tapForCurrentPlatform(testID: string, point?: { x: number; y: num
 
 describe('NestedPressExclusive', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-    await navigateToTestCase('NestedPressExclusive', 'nested-press-root')
+    await reloadUseCase('NestedPressExclusive', 'nested-press-root')
   })
 
   it('should render the test case screen', async () => {

--- a/code/kitchen-sink/e2e/PointerEvents.test.ts
+++ b/code/kitchen-sink/e2e/PointerEvents.test.ts
@@ -4,20 +4,14 @@
  */
 
 import { by, device, element, expect } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 async function navigateToPointerEvents() {
-  await navigateToTestCase('PointerEventsCase', 'pointer-events-root')
+  await reloadUseCase('PointerEventsCase', 'pointer-events-root')
 }
 
 describe('PointerEvents', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
     await navigateToPointerEvents()
   })
 

--- a/code/kitchen-sink/e2e/PressStyleNative.noRngh.test.ts
+++ b/code/kitchen-sink/e2e/PressStyleNative.noRngh.test.ts
@@ -14,26 +14,17 @@ import { by, element, expect, waitFor } from 'detox'
 import * as fs from 'fs'
 import * as assert from 'assert'
 import { PNG } from 'pngjs'
-import { navigateToTestCase } from './utils/navigation'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
+import { reloadUseCase, withSync } from './utils/detox'
 
 async function navigateToPressStyleNative() {
-  await navigateToTestCase('PressStyleNative', 'color-test-pressable', {
-    skipEnableSync: true,
+  await reloadUseCase('PressStyleNative', 'color-test-pressable', {
+    disableGestureHandler: true,
   })
 }
 
 describe('PressStyleNative (no RNGH)', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({
-      newInstance: true,
-      launchArgs: { disableGestureHandler: true },
-    })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
     await new Promise((resolve) => setTimeout(resolve, 1500))
     await navigateToPressStyleNative()
   })

--- a/code/kitchen-sink/e2e/PressStyleNative.test.ts
+++ b/code/kitchen-sink/e2e/PressStyleNative.test.ts
@@ -12,8 +12,7 @@ import { by, device, element, expect, waitFor } from 'detox'
 import * as fs from 'fs'
 import * as assert from 'assert'
 import { PNG } from 'pngjs'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 // helper to get the dominant color from a PNG screenshot
 // samples pixels from the center region to avoid edges/text
@@ -59,12 +58,7 @@ function isBlueish(color: { r: number; g: number; b: number }): boolean {
 // TODO: These tests are flaky on iOS simulator - press events don't fire reliably
 // Need to investigate press event handling in simulator environment
 describe.skip('PressStyleNative', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
     await navigateToPressStyleNative()
   })
 
@@ -229,5 +223,5 @@ describe.skip('PressStyleNative', () => {
 })
 
 async function navigateToPressStyleNative() {
-  await navigateToTestCase('PressStyleNative', 'color-test-pressable')
+  await reloadUseCase('PressStyleNative', 'color-test-pressable')
 }

--- a/code/kitchen-sink/e2e/PressStyleScrollStuck.test.ts
+++ b/code/kitchen-sink/e2e/PressStyleScrollStuck.test.ts
@@ -8,8 +8,7 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 const PILLS = [
   'General',
@@ -25,13 +24,8 @@ const PILLS = [
 ]
 
 describe('PressStyleScrollStuck', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('PressStyleScrollStuck', 'press-scroll-stuck-root')
+    await reloadUseCase('PressStyleScrollStuck', 'press-scroll-stuck-root')
   })
 
   it('renders the pill strip', async () => {

--- a/code/kitchen-sink/e2e/SafeArea.test.ts
+++ b/code/kitchen-sink/e2e/SafeArea.test.ts
@@ -4,19 +4,13 @@
  */
 
 import { by, device, element, expect } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 // SafeAreaCase component is not implemented yet (entirely commented out)
 // TODO: enable once SafeAreaCase is implemented
 describe.skip('SafeArea', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('SafeAreaCase', 'safe-area-case')
+    await reloadUseCase('SafeAreaCase', 'safe-area-case')
   })
 
   it('should navigate to SafeAreaCase test case', async () => {

--- a/code/kitchen-sink/e2e/SelectAndroidOnPress.test.ts
+++ b/code/kitchen-sink/e2e/SelectAndroidOnPress.test.ts
@@ -14,8 +14,7 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { reloadUseCase } from './utils/detox'
 
 const testElement = (id: string) => element(by.id(id)).atIndex(0)
 
@@ -28,15 +27,9 @@ const skipOnIOS = () => {
 }
 
 describe('SelectAndroidOnPress (#3436)', () => {
-  beforeAll(async () => {
-    if (skipOnIOS()) return
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
     if (skipOnIOS()) return
-    await safeReloadApp()
-    await navigateToTestCase('SelectAndroidOnPress', 'select-android-trigger')
+    await reloadUseCase('SelectAndroidOnPress', 'select-android-trigger')
   })
 
   it('should render the test case screen', async () => {

--- a/code/kitchen-sink/e2e/SelectRemount.test.ts
+++ b/code/kitchen-sink/e2e/SelectRemount.test.ts
@@ -11,8 +11,7 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
+import { reloadUseCase, withSync } from './utils/detox'
 
 const testElement = (id: string) => element(by.id(id)).atIndex(0)
 
@@ -32,15 +31,10 @@ async function remountAndWait() {
 }
 
 describe('SelectRemount', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
     // skipEnableSync: tests manage sync themselves via withSync helper
     // re-enabling sync after navigation can hang if animations are still settling
-    await navigateToTestCase('SelectRemount', 'remount-button', { skipEnableSync: true })
+    await reloadUseCase('SelectRemount', 'remount-button')
   })
 
   it('should navigate to SelectRemount test case', async () => {

--- a/code/kitchen-sink/e2e/SheetDragResist.test.ts
+++ b/code/kitchen-sink/e2e/SheetDragResist.test.ts
@@ -13,25 +13,25 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { safeLaunchApp } from './utils/detox'
 
 // only run on iOS - RNGH gesture handling differs on Android
 const isAndroid = () => device.getPlatform() === 'android'
 
 describe('SheetDragResist', () => {
-  beforeAll(async () => {
-    if (isAndroid()) return
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
     if (isAndroid()) return
-    // reload between tests for clean state
-    await safeReloadApp()
-    await navigateToSheetDragResistCase()
-    // disable sync AFTER navigation to avoid hang on spring animations during tests
-    await device.disableSynchronization()
+    // relaunch straight into the use case per test for clean state. directUseCase
+    // renders the case at app root, skipping the home → quick-nav navigation that
+    // safeReloadApp + navigateToTestCase paid (~60-90s/test). safeLaunchApp leaves
+    // sync disabled, which the spring-animation drag tests require.
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'SheetDragResistCase' },
+    })
+    await waitFor(element(by.id('sheet-drag-resist-screen')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   afterEach(async () => {
@@ -365,7 +365,3 @@ describe('SheetDragResist', () => {
     })
   })
 })
-
-async function navigateToSheetDragResistCase() {
-  await navigateToTestCase('SheetDragResistCase', 'sheet-drag-resist-screen')
-}

--- a/code/kitchen-sink/e2e/SheetDragResist.test.ts
+++ b/code/kitchen-sink/e2e/SheetDragResist.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { safeLaunchApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 // only run on iOS - RNGH gesture handling differs on Android
 const isAndroid = () => device.getPlatform() === 'android'
@@ -25,13 +25,7 @@ describe('SheetDragResist', () => {
     // renders the case at app root, skipping the home → quick-nav navigation that
     // safeReloadApp + navigateToTestCase paid (~60-90s/test). safeLaunchApp leaves
     // sync disabled, which the spring-animation drag tests require.
-    await safeLaunchApp({
-      newInstance: true,
-      launchArgs: { directUseCase: 'SheetDragResistCase' },
-    })
-    await waitFor(element(by.id('sheet-drag-resist-screen')))
-      .toExist()
-      .withTimeout(180000)
+    await reloadUseCase('SheetDragResistCase', 'sheet-drag-resist-screen')
   })
 
   afterEach(async () => {

--- a/code/kitchen-sink/e2e/SheetPressRegression.test.ts
+++ b/code/kitchen-sink/e2e/SheetPressRegression.test.ts
@@ -9,8 +9,7 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 const testElement = (id: string) => element(by.id(id)).atIndex(0)
@@ -24,13 +23,8 @@ async function openSheet() {
 }
 
 describe('SheetPressRegression', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('SheetPressRegressionCase', 'sheet-press-screen')
+    await reloadUseCase('SheetPressRegressionCase', 'sheet-press-screen')
   })
 
   it('footer Post / Cancel buttons fire onPress', async () => {

--- a/code/kitchen-sink/e2e/SheetScrollableDrag.test.ts
+++ b/code/kitchen-sink/e2e/SheetScrollableDrag.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { safeLaunchApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 // only run on iOS - Android behavior is different
 const isAndroid = () => device.getPlatform() === 'android'
@@ -27,13 +27,7 @@ describe('SheetScrollableDrag - RNGH Integration', () => {
     // quick-nav tap flow that safeReloadApp + navigateToTestCase paid
     // (~60-90s/test). safeLaunchApp leaves sync disabled, which the drag tests
     // require (gestures deliver without it).
-    await safeLaunchApp({
-      newInstance: true,
-      launchArgs: { directUseCase: 'SheetScrollableDrag' },
-    })
-    await waitFor(element(by.id('sheet-scrollable-drag-trigger')))
-      .toExist()
-      .withTimeout(180000)
+    await reloadUseCase('SheetScrollableDrag', 'sheet-scrollable-drag-trigger')
   })
 
   it('should show RNGH enabled', async () => {

--- a/code/kitchen-sink/e2e/SheetScrollableDrag.test.ts
+++ b/code/kitchen-sink/e2e/SheetScrollableDrag.test.ts
@@ -14,25 +14,26 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { safeLaunchApp } from './utils/detox'
 
 // only run on iOS - Android behavior is different
 const isAndroid = () => device.getPlatform() === 'android'
 
 describe('SheetScrollableDrag - RNGH Integration', () => {
-  beforeAll(async () => {
-    if (isAndroid()) return
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
     if (isAndroid()) return
-    await safeReloadApp()
-    // skipEnableSync: navigation re-enabling sync hangs if animations are settling
-    await navigateToTestCase('SheetScrollableDrag', 'sheet-scrollable-drag-trigger', {
-      skipEnableSync: true,
+    // relaunch straight into the use case per test for clean gesture/scroll
+    // state. directUseCase renders the case at app root, skipping the home →
+    // quick-nav tap flow that safeReloadApp + navigateToTestCase paid
+    // (~60-90s/test). safeLaunchApp leaves sync disabled, which the drag tests
+    // require (gestures deliver without it).
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'SheetScrollableDrag' },
     })
+    await waitFor(element(by.id('sheet-scrollable-drag-trigger')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   it('should show RNGH enabled', async () => {

--- a/code/kitchen-sink/e2e/ShorthandVariables.test.ts
+++ b/code/kitchen-sink/e2e/ShorthandVariables.test.ts
@@ -11,17 +11,11 @@
  */
 
 import { by, device, element, expect } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { reloadUseCase } from './utils/detox'
 
 describe('ShorthandVariables', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('ShorthandVariables', 'boxshadow-var')
+    await reloadUseCase('ShorthandVariables', 'boxshadow-var')
   })
 
   it('should render boxShadow with $variable without crashing', async () => {

--- a/code/kitchen-sink/e2e/TabsOnInteraction.test.ts
+++ b/code/kitchen-sink/e2e/TabsOnInteraction.test.ts
@@ -5,8 +5,7 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, withSync } from './utils/detox'
+import { reloadUseCase, withSync } from './utils/detox'
 
 describe('TabsOnInteraction', () => {
   // launch + navigate once: the three tests read the same Tabs screen (only the
@@ -15,10 +14,7 @@ describe('TabsOnInteraction', () => {
   // gain. skipEnableSync: the Tabs screen keeps the main thread busy via
   // onLayout callbacks, so leaving sync enabled hangs; tests use withSync.
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-    await navigateToTestCase('TabsOnInteraction', 'tabs-root', {
-      skipEnableSync: true,
-    })
+    await reloadUseCase('TabsOnInteraction', 'tabs-root')
   })
 
   it('should fire onInteraction with layout for the default selected tab', async () => {

--- a/code/kitchen-sink/e2e/TabsOnInteraction.test.ts
+++ b/code/kitchen-sink/e2e/TabsOnInteraction.test.ts
@@ -6,17 +6,16 @@
 
 import { by, element, expect, waitFor } from 'detox'
 import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
+import { safeLaunchApp, withSync } from './utils/detox'
 
 describe('TabsOnInteraction', () => {
+  // launch + navigate once: the three tests read the same Tabs screen (only the
+  // last one switches tabs, in-place), so the old per-test safeReloadApp only
+  // added a relaunch + re-bundle + re-navigation (~55s/test) with no isolation
+  // gain. skipEnableSync: the Tabs screen keeps the main thread busy via
+  // onLayout callbacks, so leaving sync enabled hangs; tests use withSync.
   beforeAll(async () => {
     await safeLaunchApp({ newInstance: true })
-  })
-
-  beforeEach(async () => {
-    await safeReloadApp()
-    // skipEnableSync: the Tabs screen keeps the main thread busy via
-    // onLayout callbacks, so leaving sync enabled hangs the hook.
     await navigateToTestCase('TabsOnInteraction', 'tabs-root', {
       skipEnableSync: true,
     })

--- a/code/kitchen-sink/e2e/ThemeChangeBasic.test.ts
+++ b/code/kitchen-sink/e2e/ThemeChangeBasic.test.ts
@@ -8,18 +8,12 @@
 
 import * as assert from 'assert'
 import { by, device, element, expect, waitFor } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { reloadUseCase } from './utils/detox'
 import { getDominantColor, isBlueish, isReddish, formatRGB } from './utils/colors'
 
 describe('ThemeChangeBasic', () => {
-  beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('ThemeChangeBasic', 'theme-change-basic-root')
+    await reloadUseCase('ThemeChangeBasic', 'theme-change-basic-root')
   })
 
   it('should show initial red theme', async () => {

--- a/code/kitchen-sink/e2e/ThemeMutation.test.ts
+++ b/code/kitchen-sink/e2e/ThemeMutation.test.ts
@@ -14,19 +14,11 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { reloadUseCase } from './utils/detox'
 
 describe('ThemeMutation', () => {
-  beforeAll(async () => {
-    await safeLaunchApp()
-  })
-
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('ThemeMutation', 'theme-mutation-button', {
-      skipEnableSync: true,
-    })
+    await reloadUseCase('ThemeMutation', 'theme-mutation-button')
   })
 
   it('should navigate to ThemeMutation test case', async () => {

--- a/code/kitchen-sink/e2e/utils/detox.ts
+++ b/code/kitchen-sink/e2e/utils/detox.ts
@@ -16,7 +16,7 @@
  * the same hang.
  */
 
-import { device } from 'detox'
+import { by, device, element, waitFor } from 'detox'
 
 const DEFAULT_LAUNCH_ARGS = {
   disableKeyboardController: true,
@@ -184,4 +184,30 @@ export async function withSync<T>(fn: () => Promise<T>): Promise<T> {
   } finally {
     await device.disableSynchronization()
   }
+}
+
+/**
+ * Relaunch straight into a single use case via the `directUseCase` launch arg.
+ *
+ * The app renders that use-case component at the root (inside all the providers:
+ * Portal, GestureHandler, SafeArea, Keyboard, tamagui Provider), bypassing the
+ * home screen → quick-nav navigation that safeReloadApp + navigateToTestCase
+ * paid (~60-90s/test). safeLaunchApp leaves sync disabled. This both isolates
+ * each test (newInstance) and removes the navigation cost.
+ *
+ * `useCase` must match a component export in src/usecases (the same name passed
+ * to navigateToTestCase). `waitForId` is a testID rendered by that case.
+ */
+export async function reloadUseCase(
+  useCase: string,
+  waitForId: string,
+  extraLaunchArgs?: Record<string, unknown>
+): Promise<void> {
+  await safeLaunchApp({
+    newInstance: true,
+    launchArgs: { directUseCase: useCase, ...extraLaunchArgs },
+  })
+  await waitFor(element(by.id(waitForId)))
+    .toExist()
+    .withTimeout(180000)
 }


### PR DESCRIPTION
## What
Every kitchen-sink Detox e2e test now relaunches **straight into its use case** via `launchArgs: { directUseCase }` (new `reloadUseCase` helper in `e2e/utils/detox.ts`), instead of `safeReloadApp()` + `navigateToTestCase()` (relaunch → home → expand quick-nav grid → tap, ~60-90s/test).

The app already supported this (`App.native.tsx` renders the use-case component at root inside all providers); `SheetKeyboardFitContent` was the only file using it. This rolls it out everywhere.

## Why
The 71-min run that started this was a degraded-runner cold-bundle flake, not a regression. The steady cost is the per-test home→quick-nav navigation. A first attempt to fix it by *rebalancing shards* was a net regression (built on noisy single-run estimates; two high-variance files spiked together). Reverted. The real lever is removing the navigation itself.

## Scope
- 23 e2e files converted (relaunch-per-test preserved → same isolation, just no navigation).
- `noRngh` keeps `disableGestureHandler`; `CompilerExtraction` keeps its in-test build; `check-rngh-status` (home-screen test) and `SheetKeyboardDrag` (`describe.skip`) untouched.
- Shard matrix is the prior 4-shard layout — **this run measures the new per-file times**; the matrix will then be tuned to ≤30 min/shard (and collapsed to 3 shards if there's headroom).

## Validation
`tsc -p e2e/tsconfig.json` + `oxfmt` + `oxlint` + `check-ios-detox-shards.mjs` all green. Runtime = this Detox run.