### PR TITLE
fix(sheet): web keyboard handling (lift frame above keyboard, deterministic anchor, autofocus)

### DIFF
--- a/code/kitchen-sink/scripts/sheet-analyze.mjs
+++ b/code/kitchen-sink/scripts/sheet-analyze.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// crunch the sheet telemetry (frames.jsonl) into the few derived numbers that
+// actually decide pass/fail — so the keyboard-avoidance loop reads geometry from
+// disk instead of eyeballing slow simulator screenshots.
+//
+// usage: node sheet-analyze.mjs [path-to-frames.jsonl]
+//
+// metrics (all in CSS px, screen-relative):
+//   keyboardTop = vo + vv          top edge of the soft keyboard / accessory bar
+//   input clear = keyboardTop - iB focused input bottom vs keyboard (+ = visible)
+//   post  clear = keyboardTop - pB submit button bottom vs keyboard  (+ = reachable)
+//   maxScroll   = sC - sH          how far the content can scroll
+// the success bar: at full scroll the post button clears the keyboard by a margin,
+// and the frame does NOT move when the keyboard toggles (no resize/jank).
+
+import { readFileSync } from 'node:fs'
+
+const path = process.argv[2] || '/tmp/sheet-frames/frames.jsonl'
+const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean)
+const samples = []
+for (const l of lines) {
+  try {
+    const s = JSON.parse(l)
+    if (s.k === 'pos') samples.push(s)
+  } catch {}
+}
+if (!samples.length) {
+  console.log('no pos samples in', path)
+  process.exit(0)
+}
+
+const kbTop = (s) => (s.vo || 0) + s.vv
+const fin = (n) => typeof n === 'number' && !Number.isNaN(n)
+const clr = (top, bottom) => (fin(bottom) ? top - bottom : null) // + = above kb
+
+// a sheet is OPEN only when its frame is on-screen. closed/hidden sheets sit at
+// or below the layout viewport (fT >= de, or the 10000 hidden sentinel) — exclude
+// them so the jank check compares open-vs-open, not open-vs-closed.
+const isOpen = (s) => fin(s.fT) && s.fT < (s.de || 1e9) - 20
+const kbUp = samples.filter((s) => s.kb >= 80 && isOpen(s))
+const kbDown = samples.filter((s) => s.kb < 80 && isOpen(s))
+
+// pick the settled keyboard-up sample with the DEEPEST scroll — that's the worst
+// case for the post button (furthest the user can push the content up).
+const deepest = kbUp.length
+  ? kbUp.reduce((a, b) => (b.sT > a.sT ? b : a))
+  : samples[samples.length - 1]
+
+// best post-button clearance achieved across all kb-up samples (did it ever clear?)
+let bestPost = null
+for (const s of kbUp) {
+  const c = clr(kbTop(s), s.pB)
+  if (c !== null && (bestPost === null || c > bestPost.c)) bestPost = { c, s }
+}
+
+const fmt = (s) => {
+  const kt = kbTop(s)
+  const max = s.sC - s.sH
+  return [
+    `  frame   fT=${s.fT} fB=${s.fB} fH=${s.fH}`,
+    `  scroll  sT=${s.sT}/${max} (${max > 0 ? Math.round((s.sT / max) * 100) : 0}%)  sH=${s.sH} sC=${s.sC}`,
+    `  kb      vv=${s.vv} vo=${s.vo} kb=${s.kb}  -> keyboardTop=${kt}  layoutVP=${s.de}`,
+    `  input   iT=${s.iT} iB=${s.iB}  clearance=${clr(kt, s.iB)}`,
+    `  post    pT=${s.pT} pB=${s.pB}  clearance=${clr(kt, s.pB)}`,
+  ].join('\n')
+}
+
+console.log(
+  `== ${samples.length} pos samples (${kbUp.length} kb-up, ${kbDown.length} kb-down) ==\n`
+)
+
+console.log('LAST kb-up @ deepest scroll:')
+console.log(fmt(deepest))
+
+if (bestPost) {
+  console.log(
+    `\nbest post clearance across kb-up: ${bestPost.c}px  (at sT=${bestPost.s.sT}/${bestPost.s.sC - bestPost.s.sH})`
+  )
+}
+
+// jank check: frame top/bottom should be IDENTICAL between a kb-down and a kb-up
+// settled sample (the frame must not resize/move when the keyboard toggles).
+if (kbDown.length && kbUp.length) {
+  const d = kbDown[kbDown.length - 1]
+  const u = kbUp[kbUp.length - 1]
+  const moved = d.fT !== u.fT || d.fB !== u.fB || d.fH !== u.fH
+  console.log(
+    `\njank check  kb-down(fT=${d.fT} fB=${d.fB} fH=${d.fH})  vs  kb-up(fT=${u.fT} fB=${u.fB} fH=${u.fH})  -> ${moved ? 'FRAME MOVED (jank!)' : 'stable (no jank)'}`
+  )
+} else {
+  console.log(
+    '\njank check: need both kb-down and kb-up samples (capture an open before focusing)'
+  )
+}
+
+// verdict
+if (bestPost) {
+  const ok = bestPost.c >= 12
+  console.log(
+    `\nVERDICT post-reachable: ${ok ? 'PASS' : 'FAIL'} (best clearance ${bestPost.c}px, want >= 12)`
+  )
+}

--- a/code/kitchen-sink/src/usecases/SheetWebKeyboardAutoFocusCase.tsx
+++ b/code/kitchen-sink/src/usecases/SheetWebKeyboardAutoFocusCase.tsx
@@ -30,26 +30,46 @@ export function SheetWebKeyboardAutoFocusCase() {
   const dimensions = useWindowDimensions()
   const maxHeight = Math.round(dimensions.height * 0.7)
   const titleRef = useRef<TextInput>(null)
+  const bodyRef = useRef<TextInput>(null)
   const track = params.get('track') === '1'
+  // which field autofocuses on open. default 'title' (top of the sheet, already
+  // above the keyboard). 'body' autofocuses a field that STARTS BEHIND the
+  // keyboard, which is the real-world case (3pc's autofocused field isn't at the
+  // very top) and the one that exercises the auto-scroll-into-view on open.
+  const focusTarget = params.get('focus') === 'body' ? 'body' : 'title'
+  // optional focus-bait input on the underlying page (?bait=1). lets a driver
+  // raise the soft keyboard BEFORE opening the sheet, so the sheet's very first
+  // layout happens with the keyboard already up — the deterministic encoding of
+  // the autofocus seed race on a real device/sim (where synthetic open taps
+  // otherwise always land in the keyboard-rises-after-layout good path).
+  const bait = params.get('bait') === '1'
 
   useEffect(() => {
     if (track) startSheetTracker()
   }, [track])
 
-  // autofocus the first input as the sheet opens — the keyboard rises with the
-  // open animation. mirrors the 3pc create-thread sheet's autoFocus. focus
+  // autofocus an input as the sheet opens — the keyboard rises with the open
+  // animation. mirrors the 3pc create-thread sheet's autoFocus. focus
   // synchronously (no setTimeout) so focusin fires during the open render,
   // before the frame's first keyboard-free layout can land.
   useEffect(() => {
     if (!open) return
-    titleRef.current?.focus?.()
-  }, [open])
+    const ref = focusTarget === 'body' ? bodyRef : titleRef
+    ref.current?.focus?.()
+  }, [open, focusTarget])
 
   return (
     <YStack padding="$4" gap="$4" testID="sheet-web-kb-af-screen">
       <Text fontSize="$5" fontWeight="bold">
         Sheet + Web Keyboard (autofocus on open)
       </Text>
+
+      {bait ? (
+        <Input
+          testID="sheet-web-kb-af-bait"
+          placeholder="focus me first (raises keyboard)"
+        />
+      ) : null}
 
       <Button testID="sheet-web-kb-af-open" theme="blue" onPress={() => setOpen(true)}>
         Open Sheet
@@ -97,6 +117,7 @@ export function SheetWebKeyboardAutoFocusCase() {
               />
 
               <TextArea
+                ref={bodyRef}
                 testID="sheet-web-kb-af-body"
                 placeholder="Body"
                 value={body}

--- a/code/kitchen-sink/src/usecases/sheetFrameTracker.ts
+++ b/code/kitchen-sink/src/usecases/sheetFrameTracker.ts
@@ -80,6 +80,7 @@ let last = {
   fH: NaN,
   sT: NaN,
   iB: NaN,
+  pB: NaN,
   vv: NaN,
 }
 
@@ -128,6 +129,19 @@ function measure() {
     iB = ri(r.bottom)
   }
 
+  // the submit/post button (fixed testid). its clearance above the keyboard is
+  // the real success metric — the primary action must be reachable, not occluded.
+  // tracked independent of focus so we can read it straight from the telemetry.
+  let pT = NaN,
+    pB = NaN
+  const post = (document.querySelector('[data-testid="sheet-web-kb-post"]') ||
+    document.querySelector('[data-testid="sheet-web-kb-af-post"]')) as HTMLElement | null
+  if (post) {
+    const pr = post.getBoundingClientRect()
+    pT = ri(pr.top)
+    pB = ri(pr.bottom)
+  }
+
   // NaN-safe inequality: NaN vs NaN counts as equal (no spurious change)
   const ne = (a: number, b: number) =>
     Number.isNaN(a) && Number.isNaN(b) ? false : a !== b
@@ -137,13 +151,32 @@ function measure() {
     ne(fH, last.fH) ||
     ne(sT, last.sT) ||
     ne(iB, last.iB) ||
+    ne(pB, last.pB) ||
     ne(vv, last.vv)
   if (changed) {
-    last = { fT, fB, fH, sT, iB, vv }
+    last = { fT, fB, fH, sT, iB, pB, vv }
     const ae = document.activeElement
     const aeTag = ae ? ae.tagName : ''
     const de = document.documentElement.clientHeight
-    push({ k: 'pos', fT, fB, fH, sT, sH, sC, iT, iB, vv, vo, in: inn, kb, ae: aeTag, de })
+    push({
+      k: 'pos',
+      fT,
+      fB,
+      fH,
+      sT,
+      sH,
+      sC,
+      iT,
+      iB,
+      pT,
+      pB,
+      vv,
+      vo,
+      in: inn,
+      kb,
+      ae: aeTag,
+      de,
+    })
   }
 }
 

--- a/code/kitchen-sink/tests/SheetWebKeyboard.test.tsx
+++ b/code/kitchen-sink/tests/SheetWebKeyboard.test.tsx
@@ -10,8 +10,12 @@ import { setupPage } from './test-utils'
  * Bugs covered:
  *  1. Keyboard avoidance: a fit-mode sheet sized off useWindowDimensions shrank
  *     when the keyboard opened (window.visualViewport — which RNW Dimensions
- *     tracks — shrinks by the keyboard height). The sheet must MOVE UP and keep
- *     its height, not collapse. (the frame-height teleport / "goes back down".)
+ *     tracks — shrinks by the keyboard height). The correct behavior: the sheet
+ *     is always full device height, slid down via translate to its resting
+ *     position; when the keyboard opens the WHOLE frame translates UP by the
+ *     keyboard height (capped so its top never crosses the top safe area), so
+ *     its content clears the keyboard. It keeps its height — it does not resize,
+ *     collapse, or stay anchored. (the frame-height teleport / "goes back down".)
  *  2. Drag double-drive: on web the PanResponder and the scroll-view touch hook
  *     both drove the animated position, so a pull-down jittered/jumped. With one
  *     owner the pull-down follows the finger monotonically.
@@ -69,7 +73,7 @@ async function openSheet(
 }
 
 test.describe('Sheet web keyboard avoidance', () => {
-  test('keyboard open keeps the sheet ANCHORED at the bottom (no shift, no resize)', async ({
+  test('keyboard open LIFTS the whole sheet up by the keyboard height (capped at the safe area), keeping its height', async ({
     page,
   }) => {
     await openSheet(page)
@@ -84,15 +88,20 @@ test.describe('Sheet web keyboard avoidance', () => {
     const after = await rect(page, 'sheet-web-kb-frame')
     expect(after).toBeTruthy()
 
-    // the sheet must NOT move or resize on web: it stays anchored at the bottom
-    // (the transparent keyboard overlays it; content scrolls instead). before the
-    // fixes it either shrank by the keyboard height OR flew up off-frame.
-    expect(Math.abs(after!.bottom - before!.bottom)).toBeLessThan(8)
-    expect(Math.abs(after!.top - before!.top)).toBeLessThan(8)
+    // the WHOLE frame translates UP so its content clears the keyboard — it does
+    // NOT stay anchored and it does NOT resize. the shift is the keyboard height,
+    // capped so the frame top never crosses the safe-area top (~0 in the test).
+    // before the fix it either stayed put (occluded) or collapsed/flew off-frame.
+    const shift = before!.bottom - after!.bottom
+    const expectedShift = Math.min(KB_HEIGHT, before!.top) // capped at safe-area top
+    expect(Math.abs(shift - expectedShift)).toBeLessThan(12)
+    // height is preserved (no resize/collapse)
     expect(Math.abs(after!.height - before!.height)).toBeLessThan(8)
+    // capped: the top never goes above the safe area
+    expect(after!.top).toBeGreaterThanOrEqual(-4)
   })
 
-  test('content becomes scrollable when the keyboard opens (tail padding)', async ({
+  test('a tall sheet whose lift is capped can scroll its lower content above the keyboard', async ({
     page,
   }) => {
     await openSheet(page)
@@ -100,15 +109,17 @@ test.describe('Sheet web keyboard avoidance', () => {
     await simulateKeyboard(page, KB_HEIGHT)
     await page.waitForTimeout(700)
 
-    // the keyboardOccludedHeight tail padding makes the content scrollable so the
-    // focused input can scroll above the keyboard while the sheet stays anchored.
+    // this fixture's sheet is taller than the visible band, so once it has lifted
+    // as far as the safe-area cap allows, its lowest content still sits behind the
+    // keyboard. the keyboardOccludedHeight spacer (= exactly that occluded amount)
+    // makes the content scrollable so the footer can reach above the keyboard.
     const canScroll = await page.evaluate(() => {
       const n = document.querySelector(
         '[data-testid="sheet-web-kb-scrollview"]'
       ) as HTMLElement
       return n ? n.scrollHeight - n.clientHeight : 0
     })
-    expect(canScroll).toBeGreaterThan(KB_HEIGHT - 40)
+    expect(canScroll).toBeGreaterThan(40)
   })
 
   test('keyboard close keeps the sheet anchored (no teleport)', async ({ page }) => {

--- a/code/kitchen-sink/tests/SheetWebKeyboardAutoFocus.test.tsx
+++ b/code/kitchen-sink/tests/SheetWebKeyboardAutoFocus.test.tsx
@@ -9,14 +9,14 @@ import { expect, test } from '@playwright/test'
  *
  * Bug: when the sheet autofocuses its first input as it opens, the soft keyboard
  * rises SIMULTANEOUSLY with the open animation, so it is already up at the
- * sheet's first layout pass. handleAnimationViewLayout / handleMaxContentViewLayout
- * drop any layout measured while the keyboard is up, so the keyboard-free frame
- * baseline (stableKbGeom.frame) is never captured — it stays 0. freezeForKb and
- * keyboardStableFrameHeight then stay 0, the SheetScrollView height freeze never
- * engages, and the frame COLLAPSES to the shrunk useWindowDimensions*0.7 cap with
- * the bottom "Post Thread" button occluded under the keyboard. Re-toggling the
- * keyboard doesn't fix it (still no keyboard-free baseline) and the sheet also
- * can't be scrolled to reveal the footer — exactly the consumer's report.
+ * sheet's first layout pass. layouts measured while the keyboard is up are
+ * dropped (they carry the shrunk viewport), so the frame must keep its full
+ * device-height size from before the keyboard and the WHOLE frame translates UP
+ * by the keyboard height (capped at the top safe area) so its content clears the
+ * keyboard. Before the fix the frame instead COLLAPSED to the shrunk
+ * useWindowDimensions*0.7 cap with the bottom "Post Thread" button occluded under
+ * the keyboard, and it could not be scrolled to reveal the footer — exactly the
+ * consumer's report.
  *
  * Reproduction: the keyboard is emulated by shrinking visualViewport.height and
  * dispatching one 'resize' (what a real iOS keyboard fires). To deterministically
@@ -163,8 +163,44 @@ async function touchDragSampling(
   )
 }
 
+// open with autofocus on a field that STARTS BEHIND the keyboard (?focus=body).
+// this is the real-world case — the consumer's autofocused field isn't at the very
+// top of the sheet — and it exercises the auto-scroll-into-view (an autofocused
+// field below the fold must be lifted above the keyboard on open, not left cut off).
+async function openWithBehindKeyboardAutofocus(page: import('@playwright/test').Page) {
+  await page.addInitScript((kb) => {
+    const apply = () => {
+      const vv = window.visualViewport
+      if (!vv) return
+      const base = window.innerHeight || 844
+      Object.defineProperty(vv, 'height', { configurable: true, get: () => base - kb })
+      Object.defineProperty(vv, 'offsetTop', { configurable: true, get: () => 0 })
+    }
+    apply()
+    window.addEventListener('DOMContentLoaded', apply)
+  }, KB_HEIGHT)
+
+  await page.goto(
+    '/?test=SheetWebKeyboardAutoFocusCase&animationDriver=css&open=1&focus=body',
+    { waitUntil: 'domcontentloaded' }
+  )
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById('root')
+      return root && root.children.length > 0
+    },
+    { timeout: 8000, polling: 50 }
+  )
+  await expect(page.getByTestId('sheet-web-kb-af-frame')).toBeVisible({ timeout: 5000 })
+  await page.waitForTimeout(1200)
+  // the fixture autofocused the Body; fire a resize so the keyboard hook latches the
+  // height, then give the auto-scroll-into-view a beat to lift the field.
+  await page.evaluate(() => window.visualViewport?.dispatchEvent(new Event('resize')))
+  await page.waitForTimeout(800)
+}
+
 test.describe('Sheet web keyboard avoidance — autofocus on open', () => {
-  test('keyboard rising with the open animation still anchors the sheet (frame keeps height)', async ({
+  test('keyboard rising with the open animation LIFTS the sheet above the keyboard (keeps height)', async ({
     page,
   }) => {
     await openWithAutofocusKeyboard(page)
@@ -172,16 +208,15 @@ test.describe('Sheet web keyboard avoidance — autofocus on open', () => {
     const frame = await rect(page, 'sheet-web-kb-af-frame')
     expect(frame).toBeTruthy()
 
-    // the sheet must keep a real (un-collapsed) height. before the fix the frame
-    // collapsed to the shrunk useWindowDimensions*0.7 cap (~366) because the
-    // keyboard-up first layout was dropped and the height freeze never engaged.
-    expect(frame!.height).toBeGreaterThan(KB_HEIGHT + 80)
-
-    // and it stays anchored to the screen bottom (the transparent keyboard
-    // overlays its lower part; content scrolls to clear it).
-    expect(Math.abs(frame!.bottom - VH)).toBeLessThan(8)
-    // its top is above the keyboard so its content is reachable.
-    expect(frame!.top).toBeLessThan(KEYBOARD_TOP)
+    // the sheet keeps a real (un-collapsed) height. before the fix the frame
+    // collapsed to the shrunk useWindowDimensions*0.7 cap.
+    expect(frame!.height).toBeGreaterThan(KB_HEIGHT)
+    // it LIFTS UP so its bottom sits at/above the keyboard top — it is NOT anchored
+    // at the screen bottom (that was the old, wrong behavior).
+    expect(frame!.bottom).toBeLessThanOrEqual(KEYBOARD_TOP + 8)
+    expect(frame!.bottom).toBeLessThan(VH - 100)
+    // capped: the top never crosses the safe-area top.
+    expect(frame!.top).toBeGreaterThanOrEqual(-4)
   })
 
   test('content becomes scrollable when the keyboard opens with autofocus', async ({
@@ -195,10 +230,10 @@ test.describe('Sheet web keyboard avoidance — autofocus on open', () => {
       ) as HTMLElement
       return n ? n.scrollHeight - n.clientHeight : 0
     })
-    // the keyboardOccludedHeight tail padding makes the content scrollable so the
-    // footer / focused input can scroll above the keyboard. before the fix the
-    // collapsed sheet wasn't anchored and this padding wasn't applied.
-    expect(canScroll).toBeGreaterThan(KB_HEIGHT - 40)
+    // the sheet is taller than the visible band, so after lifting (capped at the
+    // safe area) its lower content can still scroll up to reach above the keyboard
+    // — the keyboardOccludedHeight spacer (= the occluded amount) enables that.
+    expect(canScroll).toBeGreaterThan(40)
   })
 
   test('the bottom "Post Thread" button can be scrolled above the keyboard', async ({
@@ -244,5 +279,23 @@ test.describe('Sheet web keyboard avoidance — autofocus on open', () => {
       if (back > maxBackward) maxBackward = back
     }
     expect(maxBackward).toBeLessThan(12)
+  })
+
+  test('an autofocused field that starts behind the keyboard is scrolled above it', async ({
+    page,
+  }) => {
+    await openWithBehindKeyboardAutofocus(page)
+
+    // the whole sheet LIFTS up so its bottom sits at/above the keyboard top — it is
+    // NOT anchored at the screen bottom.
+    const frame = await rect(page, 'sheet-web-kb-af-frame')
+    expect(frame).toBeTruthy()
+    expect(frame!.bottom).toBeLessThanOrEqual(KEYBOARD_TOP + 8)
+
+    // the autofocused Body — which lays out BELOW the keyboard line at rest — ends
+    // up clear of the keyboard once the sheet has lifted, not cut off under it.
+    const body = await rect(page, 'sheet-web-kb-af-body')
+    expect(body).toBeTruthy()
+    expect(body!.bottom).toBeLessThanOrEqual(KEYBOARD_TOP + 8)
   })
 })

--- a/code/ui/sheet/src/SheetImplementationCustom.tsx
+++ b/code/ui/sheet/src/SheetImplementationCustom.tsx
@@ -199,59 +199,17 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
     // would mismatch).
     const isWebKbSheet = isWeb && hasFit && moveOnKeyboardChange
 
-    // whether we ever captured geometry while the keyboard was CLOSED. that's the
-    // authoritative baseline; until we have it, the autofocus-on-open seed below
-    // reconstructs one from keyboard-up measurements.
-    const hasCleanKbBaseline = React.useRef(false)
-    // the autofocus-on-open seed has settled on a stable frame height (the
-    // unclipped content stopped growing). until then we keep the seed phase open.
-    const seedSettled = React.useRef(false)
-    const stableKbGeom = React.useRef({ frame: 0, screen: 0 })
-    if ((!isWeb || !isKeyboardVisible) && frameSize > 0 && screenSize > 0) {
-      // keyboard-free render — the authoritative baseline. mutate in place: the
-      // ref is only ever read field-by-field, never identity-compared, so this
-      // avoids a per-render allocation.
-      stableKbGeom.current.frame = frameSize
-      stableKbGeom.current.screen = screenSize
-      hasCleanKbBaseline.current = true
-    } else if (
-      isWebKbSheet &&
-      isKeyboardVisible &&
-      !hasCleanKbBaseline.current &&
-      screenSize > 0
-    ) {
-      // AUTOFOCUS-ON-OPEN seed. when the input autofocuses as the sheet animates
-      // in, the keyboard rises BEFORE any keyboard-free layout lands, so the
-      // branch above never runs (frameSize/screenSize were 0 the whole time the
-      // keyboard was up) and freezeForKb stays false, collapsing the sheet to the
-      // shrunk consumer maxHeight. instead, reconstruct the baseline from the
-      // keyboard-up render: screen = the stable layout viewport
-      // (keyboard-independent). the frame is grown by the seeding layout path
-      // below: while seeding, the tail padding is suppressed and the scroll view
-      // is unclipped (via keyboardStableFrameHeight = stable screen), so the frame
-      // converges on its pure pre-keyboard content height across a couple layout
-      // passes. a real keyboard-free render later replaces it with the exact value
-      // (branch above).
-      stableKbGeom.current.screen = Math.max(stableKbGeom.current.screen, screenSize)
-    }
-    // are we still reconstructing the baseline from a keyboard-up render? true
-    // until either a clean baseline lands or the seeded frame settles.
-    const seedingKbBaseline =
-      isWebKbSheet &&
-      isKeyboardVisible &&
-      !hasCleanKbBaseline.current &&
-      !seedSettled.current
-    const freezeForKb =
-      isWebKbSheet && isKeyboardVisible && stableKbGeom.current.frame > 0
-    const effScreenSize = freezeForKb ? stableKbGeom.current.screen : screenSize
+    // the space the snap positions are built against. WEB: the stable layout
+    // viewport (document.documentElement.clientHeight), which the soft keyboard
+    // never shrinks (unlike the measured screenSize / visualViewport). NATIVE:
+    // the measured screenSize. positions are then shifted UP by keyboardHeight
+    // when the keyboard opens (activePositions, below) — the whole device-height
+    // frame slides up so its content clears the keyboard, capped at the safe area.
+    const effScreenSize = isWebKbSheet ? getStableViewportHeight() : screenSize
 
-    // use stableFrameSize when closing to prevent position jumps during exit animation
-    // but when opening, always use the current frameSize so positions update correctly
-    const effectiveFrameSize = freezeForKb
-      ? stableKbGeom.current.frame
-      : open
-        ? frameSize
-        : stableFrameSize.current || frameSize
+    // use stableFrameSize when closing to prevent position jumps during the exit
+    // animation; while open use the live frameSize.
+    const effectiveFrameSize = open ? frameSize : stableFrameSize.current || frameSize
 
     const positions = React.useMemo(
       () =>
@@ -285,13 +243,11 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
     // keyboard-adjusted snap positions.
     //
     // WEB: the sheet stays ANCHORED at the bottom and keeps its full pre-keyboard
-    // height — it does NOT shift up or resize. Shifting/resizing with the
-    // translateY model detaches the bottom from the screen edge or teleports it.
-    // Instead the frame's anchor geometry is frozen (effScreenSize/effectiveFrameSize
-    // above) and its height is pinned (keyboardStableFrameHeight -> SheetScrollView);
-    // the scroll content is padded by keyboardOccludedHeight and the browser
-    // scroll-into-view lifts the focused input above the keyboard. So
-    // activePositions === positions on web.
+    // height — the keyboard is an overlay, so the frame neither shifts nor resizes.
+    // Avoidance is handled below the frame: a bottom spacer (keyboardOccludedHeight
+    // = keyboardHeight) extends the scroll content so the lower content (e.g. the
+    // footer) can scroll up clear of the keyboard, and SheetScrollView scrolls the
+    // focused input above it. So activePositions === positions on web (no shift).
     //
     // NATIVE: shift snap points up by keyboard height (the native keyboard is
     // opaque and pushes content), capped at the safe-area top inset.
@@ -304,7 +260,7 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
       if (isDragging || isDraggingRef.current) return activePositionsRef.current
 
       let result: number[]
-      if (isWeb || !isKeyboardVisible || keyboardHeight <= 0) {
+      if (!isKeyboardVisible || keyboardHeight <= 0) {
         result = positions
       } else {
         const safeAreaTop = getSafeAreaTopInset()
@@ -320,39 +276,26 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
       return result
     }, [positions, isKeyboardVisible, keyboardHeight, screenSize, isDragging])
 
-    const keyboardOccludedHeight = seedingKbBaseline
-      ? // while seeding, suppress the keyboard tail padding so the frame measures
-        // its PURE pre-keyboard content height (the padding would otherwise inflate
-        // it toward the full screen). re-enabled once the baseline is captured.
-        0
-      : getKeyboardOccludedHeight({
-          frameSize: effectiveFrameSize,
-          isKeyboardVisible,
-          keyboardHeight,
-          screenSize: effScreenSize,
-          sheetY: position >= 0 ? activePositions[position] : undefined,
-        })
+    // bottom spacer for a sheet TALLER than the visible band: once the frame has
+    // shifted up as far as the safe-area cap allows, its lowest content can still
+    // sit behind the keyboard. the spacer = exactly that occluded height, so the
+    // footer can scroll up clear of the keyboard. when the sheet fits above the
+    // keyboard this returns 0 (no spacer, no over-scroll). same logic web + native.
+    const keyboardOccludedHeight = getKeyboardOccludedHeight({
+      frameSize: effectiveFrameSize,
+      isKeyboardVisible,
+      keyboardHeight,
+      screenSize: effScreenSize,
+      sheetY: position >= 0 ? activePositions[position] : undefined,
+    })
 
-    // the authoritative pre-keyboard frame height to pin the scroll view to while
-    // the keyboard is open (web). stableKbGeom.frame is captured every render the
-    // keyboard is closed, so it survives the open transition; SheetScrollView
-    // gates application on its own live keyboard check.
-    //
-    // AUTOFOCUS-ON-OPEN seed: while still reconstructing the baseline (seeding,
-    // not yet settled) we use the STABLE SCREEN SIZE — a safe upper bound (a fit
-    // frame never exceeds the screen) that is > 0, so SheetScrollView's height
-    // override engages and UNCLIPS the scroll view from the shrunk consumer
-    // maxHeight. with the tail padding suppressed (above) the content then lays
-    // out to its pure intrinsic height, which the seeding layout grows the frame
-    // baseline toward across a couple passes. once settled (or once a real
-    // keyboard-free baseline lands) we pin that exact frame height.
-    const keyboardStableFrameHeight = !isWebKbSheet
-      ? 0
-      : seedingKbBaseline
-        ? stableKbGeom.current.screen || screenSize
-        : stableKbGeom.current.frame > 0
-          ? stableKbGeom.current.frame
-          : 0
+    // pin the scroll view to the held (pre-keyboard) frame height while the
+    // keyboard is up on web. on older iOS the consumer's window-derived maxHeight
+    // shrinks with the keyboard, which would clip the scroll view (and the frame)
+    // smaller; this override keeps it at the full height so the frame only
+    // translates up, never resizes. 0 = no override (use the consumer maxHeight).
+    const keyboardStableFrameHeight =
+      isWebKbSheet && isKeyboardVisible && frameSize > 0 ? frameSize : 0
 
     const { useAnimatedNumber, useAnimatedNumberStyle, useAnimatedNumberReaction } =
       animationDriver
@@ -571,6 +514,10 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
           scrollBridge.setScrollEnabled?.(false)
         }
       }
+      // NOTE: effScreenSize/effectiveFrameSize are intentionally NOT deps. With the
+      // spacer approach the frame's position target is frozen across keyboard
+      // open/close (same stable baseline), so it must NOT re-animate — keyboard
+      // avoidance is the bottom spacer + scroll, not a frame move.
     }, [hasntMeasured, disableAnimation, isHidden, frameSize, screenSize, open, position])
 
     const disableDrag = props.disableDrag ?? controller?.disableDrag
@@ -778,16 +725,16 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
       setPosition,
     ])
 
-    // animate to keyboard-adjusted position when keyboard state changes.
-    // WEB skips this: the sheet stays anchored at its frozen position/height
-    // (activePositions don't change with the keyboard, and the anchor geometry is
-    // frozen), so there's nothing to re-animate. Running a timing animation here
-    // would only introduce movement where the sheet should hold perfectly still.
+    // animate to the keyboard-adjusted position when the keyboard state changes.
+    // both web and native shift the whole frame UP by the keyboard height (capped
+    // at the top safe area, in activePositions) so the content keeps its position
+    // relative to the visible area — it was resting on the device bottom, now it
+    // rests on the keyboard top. the frame is device-height, so sliding it up never
+    // reveals a gap below the content.
     React.useEffect(() => {
-      if (isWeb) return
       if (isDragging || isHidden || !open || disableAnimation) return
       if (!frameSize || !screenSize) return
-      // use timing animation to match iOS keyboard animation (~250ms)
+      // timing animation matches the iOS keyboard animation (~250ms)
       animateTo(position, { type: 'timing', duration: 250 })
     }, [isKeyboardVisible, keyboardHeight])
 
@@ -852,90 +799,45 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
       () => isWeb && moveOnKeyboardChange && getWebKeyboardHeight() >= MIN_KEYBOARD_HEIGHT
     )
 
-    // AUTOFOCUS-ON-OPEN seed gates. normally a layout measured while the keyboard
-    // is up is dropped (it's the shrunk/collapsed sheet). but if the keyboard rose
-    // before ANY keyboard-free baseline was captured (the autofocus race),
-    // dropping every measurement leaves frameSize/screenSize stuck at 0 forever
-    // and the freeze never engages.
-    //
-    // frame: while seeding (not settled) the scroll view is unclipped and the
-    // tail padding suppressed, so the frame measures toward its pure pre-keyboard
-    // content height. the first keyboard-up pass is still clipped at the consumer
-    // maxHeight; the override only unclips it the following pass, so the frame
-    // grows. we take the MAX and mark the seed SETTLED once it stops growing
-    // (handled in handleAnimationViewLayout) — then later keyboard-up layouts are
-    // dropped again so the re-enabled tail padding can't inflate the frame.
-    const shouldSeedKbFrame = useEvent(
-      () =>
-        isWebKbSheet &&
-        !hasCleanKbBaseline.current &&
-        !seedSettled.current &&
-        ignoreLayoutForKeyboard()
-    )
-    // screen (= maxContentSize): keep reconstructing from the stable viewport for
-    // the whole keyboard-up-without-clean-baseline window.
-    const shouldSeedKbScreen = useEvent(
-      () => isWebKbSheet && !hasCleanKbBaseline.current && ignoreLayoutForKeyboard()
-    )
-
     const handleAnimationViewLayout = useEvent((e: LayoutChangeEvent) => {
       // don't update frameSize during exit animation to prevent position jumps
       if (!open && stableFrameSize.current !== 0) {
         return
       }
 
-      const seeding = shouldSeedKbFrame()
-      if (!seeding && ignoreLayoutForKeyboard()) return
+      const layoutHeight = e.nativeEvent?.layout.height
+      // drop a layout measured while the keyboard is up: on older iOS the web
+      // viewport shrinks and the frame would resize. keep the pre-keyboard frame
+      // height so the frame just TRANSLATES up (activePositions) without resizing.
+      // exception: if we have no frame height yet (sheet opened with the keyboard
+      // already up), accept it so the sheet can appear at all.
+      if (ignoreLayoutForKeyboard() && frameSize > 0) return
 
       // avoid bugs where it grows forever for whatever reason
       // For inline mode (non-modal), don't cap at window height - use actual layout
-      const layoutHeight = e.nativeEvent?.layout.height
-      // while seeding, the keyboardStableFrameHeight fallback has unclipped the
-      // scroll view (capped at the stable screen) and the tail padding is
-      // suppressed, so this measures the pure pre-keyboard content height — cap it
-      // at the stable viewport like modal does.
-      const next =
-        modal || seeding
-          ? Math.min(layoutHeight, getStableViewportHeight())
-          : layoutHeight
+      const next = modal
+        ? Math.min(layoutHeight, getStableViewportHeight())
+        : layoutHeight
       if (!next) return
       // round: web onLayout reports sub-pixel heights (e.g. 499.99996) that jitter
       // frame to frame as the view transforms; the raw float would re-fire every
       // effect that depends on frameSize on each drag move.
-      const rounded = Math.round(next)
-      // seeding the frame: grow the baseline toward the unclipped content height.
-      // the first keyboard-up pass is clipped; the scroll-view override unclips it
-      // the next pass so it grows. once a pass doesn't exceed the running max the
-      // content has settled — mark the seed done so the next render exits the seed
-      // phase (freezeForKb pins this height, tail padding re-enables for scroll).
-      if (seeding) {
-        if (rounded > stableKbGeom.current.frame) {
-          stableKbGeom.current.frame = rounded
-        } else if (stableKbGeom.current.frame > 0) {
-          seedSettled.current = true
-        }
-      }
-      setFrameSize(rounded)
+      setFrameSize(Math.round(next))
     })
 
     const handleMaxContentViewLayout = React.useCallback(
       (e: LayoutChangeEvent) => {
-        // same keyboard guard so screenSize (= maxContentSize) stays the full
-        // pre-keyboard viewport — except while seeding the baseline (see above),
-        // where we use the stable layout viewport directly so screenSize lands at
-        // the full pre-keyboard height instead of the shrunk visual viewport.
-        if (shouldSeedKbScreen()) {
-          setMaxContentSize(Math.round(getStableViewportHeight()))
-          return
-        }
-        if (ignoreLayoutForKeyboard()) return
+        // keep maxContentSize at the full pre-keyboard viewport: drop layouts
+        // measured while the keyboard is up (the shrunk viewport), unless we have
+        // none yet (keyboard-already-up open).
+        if (ignoreLayoutForKeyboard() && screenSize > 0) return
         // avoid bugs where it grows forever for whatever reason
         const next = Math.min(e.nativeEvent?.layout.height, getStableViewportHeight())
         if (!next) return
         // round to avoid sub-pixel churn re-firing size-dependent effects
         setMaxContentSize(Math.round(next))
       },
-      [ignoreLayoutForKeyboard, shouldSeedKbScreen]
+      [ignoreLayoutForKeyboard, screenSize]
     )
 
     const getAnimatedNumberStyle = React.useCallback(
@@ -988,7 +890,6 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
             keyboardOccludedHeight={keyboardOccludedHeight}
             isKeyboardVisible={isKeyboardVisible}
             keyboardStableFrameHeight={keyboardStableFrameHeight}
-            isKeyboardSeeding={seedingKbBaseline}
             setHasScrollView={setHasScrollView}
           >
             <GestureSheetProvider

--- a/code/ui/sheet/src/SheetScrollView.tsx
+++ b/code/ui/sheet/src/SheetScrollView.tsx
@@ -67,27 +67,15 @@ export const SheetScrollView = React.forwardRef<
         }
       : { flex: 1 }
 
-    // AUTOFOCUS-ON-OPEN seed (web): the sheet is still reconstructing its
-    // pre-keyboard frame baseline and needs THIS scroll view to size to its
-    // content so it can measure the true content height. so we apply the stable
-    // screen only as a maxHeight cap (UNCLIP from the shrunk consumer maxHeight)
-    // and leave height undefined so it stays content-sized.
-    const isKeyboardSeeding = context.isKeyboardSeeding === true
-
-    // when the keyboard is open the sheet stays ANCHORED at the bottom and keeps
-    // its full pre-keyboard height — the keyboard overlays its lower part and the
-    // keyboardOccludedHeight tail padding (added to the scroll content below) +
-    // browser scroll-into-view lift the focused input above the keyboard. so we
-    // pin the height to the sheet's authoritative frozenFrameHeight, overriding
-    // any consumer maxHeight (on web that's often tied to useWindowDimensions,
-    // which SHRINKS when the keyboard opens and would otherwise collapse the
-    // sheet). holding the height constant means nothing animates on keyboard
-    // open/close — no jump/teleport. applied AFTER {...props} so it wins.
+    // when the keyboard is open, pin the scroll view to the sheet's pre-keyboard
+    // frame height (frozenFrameHeight), overriding any consumer maxHeight. on web
+    // that maxHeight is often tied to useWindowDimensions, which SHRINKS when the
+    // keyboard opens and would otherwise collapse the sheet. holding the height
+    // constant means the frame only TRANSLATES up (no resize, no jump). applied
+    // AFTER {...props} so it wins.
     const keyboardFrozenOverride =
       hasFit && isKeyboardVisible && frozenFrameHeight > 0
-        ? isKeyboardSeeding
-          ? { maxHeight: frozenFrameHeight }
-          : { height: frozenFrameHeight, maxHeight: frozenFrameHeight }
+        ? { height: frozenFrameHeight, maxHeight: frozenFrameHeight }
         : null
 
     const panGestureRef = gestureContext?.panGestureRef

--- a/code/ui/sheet/src/nativeSheet.tsx
+++ b/code/ui/sheet/src/nativeSheet.tsx
@@ -64,7 +64,6 @@ export function setupNativeSheet(
             keyboardOccludedHeight={0}
             isKeyboardVisible={false}
             keyboardStableFrameHeight={0}
-            isKeyboardSeeding={false}
             {...providerProps}
             onlyShowFrame
           >

--- a/code/ui/sheet/src/useKeyboardControllerSheet.ts
+++ b/code/ui/sheet/src/useKeyboardControllerSheet.ts
@@ -31,8 +31,25 @@ export function useKeyboardControllerSheet(
 ): KeyboardControllerSheetResult {
   const { enabled } = options
 
-  const [keyboardHeight, setKeyboardHeight] = useState(0)
-  const [isKeyboardVisible, setIsKeyboardVisible] = useState(false)
+  // initialize from the CURRENT viewport, not blindly from 0/false. when the
+  // sheet opens with the soft keyboard already up (e.g. it was raised by a field
+  // on the page behind, or by an autofocus whose keyboard wins the race against
+  // the first layout), a false initial value makes the sheet's very first render
+  // believe the keyboard is down — it captures a keyboard-free baseline from a
+  // keyboard-shrunk layout and the anchor/seed machinery has to recover. reading
+  // the viewport synchronously here removes that first-render race: the sheet
+  // knows the keyboard is up on render 1 and takes the seed path deterministically.
+  const [keyboardHeight, setKeyboardHeight] = useState(() =>
+    isWeb && enabled && typeof window !== 'undefined' && window.visualViewport
+      ? (() => {
+          const h = getWebKeyboardHeight()
+          return h >= MIN_KEYBOARD_HEIGHT && isEditableElement(document.activeElement)
+            ? h
+            : 0
+        })()
+      : 0
+  )
+  const [isKeyboardVisible, setIsKeyboardVisible] = useState(() => keyboardHeight > 0)
 
   // action-sheet pattern: pause keyboard hide events during drag so the sheet
   // position doesn't revert mid-gesture when a TextInput blurs.

--- a/code/ui/sheet/src/useSheetProviderProps.tsx
+++ b/code/ui/sheet/src/useSheetProviderProps.tsx
@@ -14,17 +14,11 @@ export type SheetContextValue = ReturnType<typeof useSheetProviderProps> & {
   // the fit-mode height freeze must persist for the whole time the keyboard is
   // open, not just while occluded, or it releases and the sheet collapses.
   isKeyboardVisible: boolean
-  // the sheet's authoritative pre-keyboard frame height (web). SheetScrollView
-  // pins its height to this while the keyboard is open so the frame stays its
-  // full size (anchored to the screen bottom) instead of collapsing to a
-  // consumer maxHeight that shrank with the viewport. 0 when not applicable.
+  // the sheet's pre-keyboard frame height (web). SheetScrollView pins its height
+  // to this while the keyboard is open so the frame keeps its full size (and just
+  // translates up) instead of collapsing to a consumer maxHeight that shrank with
+  // the viewport. 0 when not applicable.
   keyboardStableFrameHeight: number
-  // AUTOFOCUS-ON-OPEN seed phase (web). while reconstructing the pre-keyboard
-  // baseline, SheetScrollView must UNCLIP (apply keyboardStableFrameHeight as
-  // maxHeight only, not a fixed height) so it sizes to its content and the sheet
-  // can measure the true content height. once settled the fixed-height pin
-  // applies. false outside the seed window.
-  isKeyboardSeeding: boolean
   setHasScrollView: (val: boolean) => void
 }
 

--- a/code/ui/sheet/types/SheetContext.d.ts
+++ b/code/ui/sheet/types/SheetContext.d.ts
@@ -35,7 +35,6 @@ export declare const SheetProvider: (props: {
     keyboardOccludedHeight: number;
     isKeyboardVisible: boolean;
     keyboardStableFrameHeight: number;
-    isKeyboardSeeding: boolean;
     setHasScrollView: (val: boolean) => void;
 } & {
     scope: import("@tamagui/create-context").Scope<SheetContextValue>;

--- a/code/ui/sheet/types/useSheetProviderProps.d.ts
+++ b/code/ui/sheet/types/useSheetProviderProps.d.ts
@@ -6,7 +6,6 @@ export type SheetContextValue = ReturnType<typeof useSheetProviderProps> & {
     keyboardOccludedHeight: number;
     isKeyboardVisible: boolean;
     keyboardStableFrameHeight: number;
-    isKeyboardSeeding: boolean;
     setHasScrollView: (val: boolean) => void;
 };
 export declare function useSheetProviderProps(props: SheetProps, state: SheetOpenState, options?: {


### PR DESCRIPTION
Sheet mobile-web keyboard fixes (split out from the combined detox/sheet branch).

## Changes
- Lift the whole sheet frame above the keyboard on web instead of anchor+scroll.
- Seed web keyboard state from the current viewport on mount; wait for the keyboard to settle before lifting the focused field.
- Deterministic web-keyboard anchor + robust focus scroll-into-view; avoid web keyboard with a bottom spacer (not a frame resize).
- Lift web fit-sheet above keyboard on autofocus-open.

## Scope
`code/ui/sheet/*` library changes + kitchen-sink web-keyboard usecases/tests (`SheetWebKeyboardAutoFocusCase`, `sheetFrameTracker`, `SheetWebKeyboard*` tests, `sheet-analyze` telemetry). No detox/CI changes — those are in a separate PR.