### PR TITLE
ci(detox): launch-once directUseCase/remount conversion + CompilerExtraction-isolated shard matrix

### DIFF
--- a/.github/scripts/check-ios-detox-shards.mjs
+++ b/.github/scripts/check-ios-detox-shards.mjs
@@ -5,7 +5,15 @@ const repoRoot = process.cwd()
 const workflowPath = join(repoRoot, '.github/workflows/test-native.yml')
 const e2eDir = join(repoRoot, 'code/kitchen-sink/e2e')
 
-const explicitlyExcludedTests = new Map()
+const explicitlyExcludedTests = new Map([
+  // android-only: every test skips on iOS (device.getPlatform() === 'ios'), so running
+  // it on the iOS sim produced zero coverage while burning ~6.6min. it still runs in the
+  // android Detox job, which executes all e2e files unsharded.
+  [
+    'SelectAndroidOnPress.test.ts',
+    'android-only (skips on iOS); runs in the android job',
+  ],
+])
 
 const workflow = readFileSync(workflowPath, 'utf8')
 const shardMatches = [...workflow.matchAll(/test_files:\s*'([^']*)'/g)]

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -57,16 +57,21 @@ jobs:
           # 4 shards balanced by test execution time. the old ~7min/shard ts-jest
           # type-check tax is gone (e2e now transpiles via e2e/tsconfig.json), so
           # startup is small and these fit well under the native-ci runner's
-          # 45-minute process timeout. heaviest files: PressStyleNative.noRngh
-          # (~13min) and SheetScrollableDrag (~10min) head shards 1 and 2.
+          # 45-minute process timeout. CompilerExtraction runs an in-test
+          # `npx tamagui build` (~12-19min, variable) so it gets its OWN shard
+          # (with the iOS-skipped SafeArea/SheetKeyboardDrag, which cost ~0); the
+          # remaining files are bin-packed to ~14.5min test-exec each (~25min wall).
+          # SelectAndroidOnPress is android-only (excluded here via
+          # check-ios-detox-shards.mjs, still runs in the android job). Coverage
+          # validated by that script (every e2e test assigned exactly once).
           - shard_name: '1/4'
-            test_files: 'e2e/PressStyleNative.noRngh.test.ts e2e/PressStyleNative.test.ts e2e/check-rngh-status.test.ts e2e/GroupPressNative.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/PressStyleScrollStuck.test.ts e2e/NestedPressExclusive.test.ts'
+            test_files: 'e2e/CompilerExtraction.test.ts e2e/SafeArea.test.ts e2e/SheetKeyboardDrag.test.ts'
           - shard_name: '2/4'
-            test_files: 'e2e/SheetScrollableDrag.test.ts e2e/SheetDragResist.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetKeyboardFitContent.test.ts e2e/SheetPressRegression.test.ts e2e/NativePortal.test.ts'
+            test_files: 'e2e/PressStyleNative.noRngh.test.ts e2e/CompilerTernaryActive.test.ts e2e/TabsOnInteraction.test.ts e2e/PointerEvents.test.ts e2e/GroupPressNative.test.ts e2e/ShorthandVariables.test.ts e2e/check-rngh-status.test.ts'
           - shard_name: '3/4'
-            test_files: 'e2e/PointerEvents.test.ts e2e/MediaQueryGtMd.test.ts e2e/TabsOnInteraction.test.ts e2e/SafeArea.test.ts e2e/CompilerExtraction.test.ts e2e/CompilerTernaryActive.test.ts'
+            test_files: 'e2e/SheetScrollableDrag.test.ts e2e/ThemeMutation.test.ts e2e/NativePortal.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/MenuRadioGroup.test.ts e2e/PressStyleScrollStuck.test.ts'
           - shard_name: '4/4'
-            test_files: 'e2e/MenuRadioGroup.test.ts e2e/SelectAndroidOnPress.test.ts e2e/SelectRemount.test.ts e2e/ThemeChangeBasic.test.ts e2e/ThemeMutation.test.ts e2e/ShorthandVariables.test.ts'
+            test_files: 'e2e/PressStyleNative.test.ts e2e/SheetPressRegression.test.ts e2e/SheetKeyboardFitContent.test.ts e2e/SelectRemount.test.ts e2e/SheetDragResist.test.ts e2e/ThemeChangeBasic.test.ts e2e/NestedPressExclusive.test.ts e2e/MediaQueryGtMd.test.ts'
     defaults:
       run:
         working-directory: ${{ env.test_container_app_path }}
@@ -216,7 +221,10 @@ jobs:
         env:
           DETOX_IOS_APP_PATH: build/Build/Products/Debug-iphonesimulator/tamaguikitchensink.app
         run: |
-          bun run ../packages/native-ci/src/run-detox-ios.ts --project-root "$PWD" --record-logs failing --retries 1 ${{ matrix.test_files }}
+          # --retries 0: no whole-file retry (that re-ran beforeAll + every test of a
+          # flaky file, the 2x wall-time variance). individual flaky tests retry
+          # in-place via jest.retryTimes (e2e/jest.setup.ts).
+          bun run ../packages/native-ci/src/run-detox-ios.ts --project-root "$PWD" --record-logs failing --retries 0 ${{ matrix.test_files }}
 
       - name: Report iOS Test Status
         if: always() && env.SKIP_IOS_TESTS == 'true'
@@ -617,8 +625,8 @@ jobs:
 
             # Let Detox handle APK installation and ADB reverse setup via reversePorts config
             # Android emulator is flaky - capture exit code but don't fail the job
-            # --retries 1 retries individual failing test files once (no full-suite retry — that's done at workflow level if at all)
-            bun run ../packages/native-ci/src/run-detox-android.ts --headless --project-root "$PWD" --record-logs failing --retries 1 || echo "ANDROID_TESTS_FAILED=true" >> $GITHUB_ENV
+            # --retries 0: no whole-file retry; individual tests retry via jest.retryTimes (e2e/jest.setup.ts)
+            bun run ../packages/native-ci/src/run-detox-android.ts --headless --project-root "$PWD" --record-logs failing --retries 0 || echo "ANDROID_TESTS_FAILED=true" >> $GITHUB_ENV
 
       - name: Report Android Test Status
         if: always()

--- a/code/kitchen-sink/.detoxrc.js
+++ b/code/kitchen-sink/.detoxrc.js
@@ -62,8 +62,11 @@ module.exports = {
       maxWorkers,
     },
     jest: {
-      setupTimeout: 300000, // 5 minutes - slow CI runners + retries can exceed 180s, especially for tests that compile in beforeAll
-      retries: 1, // Retry flaky tests once
+      setupTimeout: 300000, // 5 minutes - slow CI runners can exceed 180s, especially for tests that compile in beforeAll
+      // no whole-file retry: detox --retries re-runs the entire spec file (beforeAll +
+      // every test again), which is the 2x wall-time variance we're killing. individual
+      // flaky tests retry in-place via jest.retryTimes (see e2e/jest.setup.ts), which
+      // re-runs just the test + its beforeEach (fresh app) - far cheaper.
     },
   },
   artifacts: {
@@ -77,6 +80,11 @@ module.exports = {
     init: {
       exposeGlobals: true,
     },
+    // NOTE: do NOT set launchApp: 'manual' here. In detox 'manual' does not mean
+    // "the test calls device.launchApp itself" (that's always allowed) - it makes
+    // RuntimeDevice.launchApp route through waitForAppLaunch, which printLaunchHint()
+    // + pressAnyKey() and crashes in CI ('process.stdin.setRawMode is not a function')
+    // since stdin isn't a TTY. Leave it at the default 'auto'.
   },
   apps: {
     'ios.debug': {

--- a/code/kitchen-sink/e2e/CompilerExtraction.test.ts
+++ b/code/kitchen-sink/e2e/CompilerExtraction.test.ts
@@ -6,10 +6,10 @@
 import * as assert from 'assert'
 import { execSync } from 'child_process'
 import { unlinkSync, existsSync } from 'fs'
-import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
+import { by, element, expect, waitFor } from 'detox'
+import { remountDirectUseCase } from './utils/navigation'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { safeLaunchApp } from './utils/detox'
 
 const SOURCE_FILE = 'src/usecases/CompilerExtraction.tsx'
 const NATIVE_FILE = 'src/usecases/CompilerExtraction.native.tsx'
@@ -30,12 +30,20 @@ describe('CompilerExtraction', () => {
     )
     console.log('Build complete, .native.tsx generated')
 
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'CompilerExtraction' },
+    })
+    await waitFor(element(by.id('compiler-extraction-root')))
+      .toExist()
+      .withTimeout(180000)
   }, 600_000) // tamagui build can occasionally take 5-12 min on slow CI runners (sequential single-file builds with cold metro)
 
+  beforeEach(async () => {
+    await remountDirectUseCase('compiler-extraction-root')
+  })
+
   it('should render and respond to theme changes', async () => {
-    await safeReloadApp()
-    await navigateToTestCase('CompilerExtraction', 'compiler-extraction-root')
     await new Promise((r) => setTimeout(r, 300))
 
     // verify components render
@@ -89,8 +97,6 @@ describe('CompilerExtraction', () => {
   })
 
   it('should benchmark optimized vs non-optimized (best of 3)', async () => {
-    await safeReloadApp()
-    await navigateToTestCase('CompilerExtraction', 'compiler-extraction-root')
     await new Promise((r) => setTimeout(r, 300))
 
     // show benchmark

--- a/code/kitchen-sink/e2e/CompilerTernaryActive.test.ts
+++ b/code/kitchen-sink/e2e/CompilerTernaryActive.test.ts
@@ -10,10 +10,10 @@
 import * as assert from 'assert'
 import { execSync } from 'child_process'
 import { unlinkSync, existsSync } from 'fs'
-import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
+import { by, element, expect, waitFor } from 'detox'
+import { remountDirectUseCase } from './utils/navigation'
 import { getDominantColor, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { safeLaunchApp } from './utils/detox'
 
 const SOURCE_FILE = 'src/usecases/CompilerTernaryActive.tsx'
 const NATIVE_FILE = 'src/usecases/CompilerTernaryActive.native.tsx'
@@ -30,12 +30,20 @@ describe('CompilerTernaryActive', () => {
     })
     console.log('Build complete, .native.tsx generated')
 
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'CompilerTernaryActive' },
+    })
+    await waitFor(element(by.id('compiler-ternary-active-root')))
+      .toExist()
+      .withTimeout(180000)
   }, 600_000) // tamagui build can occasionally take 5-12 min on slow CI runners
 
+  beforeEach(async () => {
+    await remountDirectUseCase('compiler-ternary-active-root')
+  })
+
   it('optimized and non-optimized text should match colors in both states', async () => {
-    await safeReloadApp()
-    await navigateToTestCase('CompilerTernaryActive', 'compiler-ternary-active-root')
     await new Promise((r) => setTimeout(r, 300))
 
     // verify initial state is inactive

--- a/code/kitchen-sink/e2e/GroupPressNative.test.ts
+++ b/code/kitchen-sink/e2e/GroupPressNative.test.ts
@@ -4,26 +4,27 @@
  * Verifies actual pixel colors change correctly
  */
 
-import { by, device, element, expect } from 'detox'
+import { by, element, expect, waitFor } from 'detox'
 import * as assert from 'assert'
-import { navigateToTestCase } from './utils/navigation'
+import { remountDirectUseCase } from './utils/navigation'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-
-async function navigateToGroupPressNative() {
-  await navigateToTestCase('GroupPressNative', 'group-press-native-root')
-}
+import { safeLaunchApp } from './utils/detox'
 
 // TODO: These tests are flaky on iOS simulator - press events don't fire reliably
 // Need to investigate press event handling in simulator environment
 describe.skip('GroupPressNative', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'GroupPressNative' },
+    })
+    await waitFor(element(by.id('group-press-native-root')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToGroupPressNative()
+    await remountDirectUseCase('group-press-native-root')
   })
 
   it('should render the test case screen', async () => {

--- a/code/kitchen-sink/e2e/GroupPressTransitionMatrix.test.ts
+++ b/code/kitchen-sink/e2e/GroupPressTransitionMatrix.test.ts
@@ -14,10 +14,10 @@
  * catch regressions if the fix accidentally breaks another combination.
  */
 
-import { by, device, element, expect as detoxExpect } from 'detox'
+import { by, element, expect as detoxExpect, waitFor } from 'detox'
 import * as assert from 'assert'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
 
 const CELLS = ['pp-cp', 'pa-cp', 'pp-ca', 'pa-ca'] as const
@@ -54,15 +54,17 @@ async function assertChildReturnedToDefault(cellId: string) {
 
 describe('GroupPressTransitionMatrix', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'GroupPressTransitionMatrix' },
+    })
+    await waitFor(element(by.id('group-press-transition-matrix-root')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase(
-      'GroupPressTransitionMatrix',
-      'group-press-transition-matrix-root'
-    )
+    await remountDirectUseCase('group-press-transition-matrix-root')
   })
 
   it('renders every cell and the release target', async () => {

--- a/code/kitchen-sink/e2e/MediaQueryGtMd.test.ts
+++ b/code/kitchen-sink/e2e/MediaQueryGtMd.test.ts
@@ -14,20 +14,26 @@
  * 1. Verifies elements render correctly
  * 2. Takes screenshots for visual verification
  * 3. Future: Could use pixel sampling to verify actual colors
+ *
+ * Launch model: directUseCase renders the case at app root, so we launch the
+ * native app ONCE in beforeAll and never relaunch. The three assertions are
+ * read-only against the same render, so no per-test reset is needed. This
+ * removes the per-test app relaunch (the only place the Detox connect-flake
+ * bites) and the navigation round-trip.
  */
 
-import { by, device, element, expect } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { by, device, element, expect, waitFor } from 'detox'
+import { safeLaunchApp } from './utils/detox'
 
 describe('MediaQueryGtMd', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
-  beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('MediaQueryGtMd', 'media-test-both')
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'MediaQueryGtMd' },
+    })
+    await waitFor(element(by.id('media-test-both')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   it('should render all media query test elements', async () => {

--- a/code/kitchen-sink/e2e/MenuRadioGroup.test.ts
+++ b/code/kitchen-sink/e2e/MenuRadioGroup.test.ts
@@ -1,6 +1,6 @@
 import { by, element, expect, waitFor } from 'detox'
 import { safeLaunchApp, withSync } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { remountDirectUseCase } from './utils/navigation'
 
 function getMenuItemMatcher(label: string) {
   return by.text(label)
@@ -19,11 +19,18 @@ async function selectColor(label: 'Red' | 'Green' | 'Blue') {
 }
 
 describe('MenuRadioGroup', () => {
-  beforeEach(async () => {
-    await safeLaunchApp({ newInstance: true })
-    await navigateToTestCase('MenuRadioGroupCase', 'menu-radio-selected-value', {
-      skipEnableSync: true,
+  beforeAll(async () => {
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'MenuRadioGroupCase' },
     })
+    await waitFor(element(by.id('menu-radio-selected-value')))
+      .toExist()
+      .withTimeout(180000)
+  })
+
+  beforeEach(async () => {
+    await remountDirectUseCase('menu-radio-selected-value', { skipEnableSync: true })
   })
 
   it('should render the menu radio group case', async () => {

--- a/code/kitchen-sink/e2e/NativePortal.test.ts
+++ b/code/kitchen-sink/e2e/NativePortal.test.ts
@@ -4,17 +4,10 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp, withSync } from './utils/detox'
 
 const testElement = (id: string) => element(by.id(id)).atIndex(0)
-
-async function navigateToNativePortal() {
-  await navigateToTestCase('NativePortalTest', 'portal-status', {
-    // Re-enabling sync after navigation is brittle on iOS once portal animations settle.
-    skipEnableSync: true,
-  })
-}
 
 async function openSelect() {
   await withSync(() => testElement('native-portal-select-trigger').tap())
@@ -58,12 +51,18 @@ async function closeSheet() {
 
 describe('NativePortal', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'NativePortalTest' },
+    })
+    await waitFor(element(by.id('portal-status')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToNativePortal()
+    // Re-enabling sync after remount is brittle on iOS once portal animations settle.
+    await remountDirectUseCase('portal-status', { skipEnableSync: true })
   })
 
   it('should navigate to NativePortalTest test case', async () => {

--- a/code/kitchen-sink/e2e/PointerEvents.test.ts
+++ b/code/kitchen-sink/e2e/PointerEvents.test.ts
@@ -3,22 +3,23 @@
  * Verifies touch events map correctly to pointer events on native
  */
 
-import { by, device, element, expect } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-
-async function navigateToPointerEvents() {
-  await navigateToTestCase('PointerEventsCase', 'pointer-events-root')
-}
+import { by, device, element, expect, waitFor } from 'detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 describe('PointerEvents', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'PointerEventsCase' },
+    })
+    await waitFor(element(by.id('pointer-events-root')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToPointerEvents()
+    await remountDirectUseCase('pointer-events-root')
   })
 
   it('should render the test case', async () => {

--- a/code/kitchen-sink/e2e/PressStyleNative.noRngh.test.ts
+++ b/code/kitchen-sink/e2e/PressStyleNative.noRngh.test.ts
@@ -14,28 +14,23 @@ import { by, element, expect, waitFor } from 'detox'
 import * as fs from 'fs'
 import * as assert from 'assert'
 import { PNG } from 'pngjs'
-import { navigateToTestCase } from './utils/navigation'
+import { remountDirectUseCase } from './utils/navigation'
 import { getDominantColor, isBlueish, formatRGB } from './utils/colors'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
-
-async function navigateToPressStyleNative() {
-  await navigateToTestCase('PressStyleNative', 'color-test-pressable', {
-    skipEnableSync: true,
-  })
-}
+import { safeLaunchApp, withSync } from './utils/detox'
 
 describe('PressStyleNative (no RNGH)', () => {
   beforeAll(async () => {
     await safeLaunchApp({
       newInstance: true,
-      launchArgs: { disableGestureHandler: true },
+      launchArgs: { directUseCase: 'PressStyleNative', disableGestureHandler: true },
     })
+    await waitFor(element(by.id('color-test-pressable')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await new Promise((resolve) => setTimeout(resolve, 1500))
-    await navigateToPressStyleNative()
+    await remountDirectUseCase('color-test-pressable', { skipEnableSync: true })
   })
 
   it('should render the test case screen', async () => {

--- a/code/kitchen-sink/e2e/PressStyleNative.test.ts
+++ b/code/kitchen-sink/e2e/PressStyleNative.test.ts
@@ -8,12 +8,12 @@
  * 4. Actual pixel colors are verified via screenshots
  */
 
-import { by, device, element, expect, waitFor } from 'detox'
+import { by, element, expect, waitFor } from 'detox'
 import * as fs from 'fs'
 import * as assert from 'assert'
 import { PNG } from 'pngjs'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 // helper to get the dominant color from a PNG screenshot
 // samples pixels from the center region to avoid edges/text
@@ -60,12 +60,17 @@ function isBlueish(color: { r: number; g: number; b: number }): boolean {
 // Need to investigate press event handling in simulator environment
 describe.skip('PressStyleNative', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'PressStyleNative' },
+    })
+    await waitFor(element(by.id('color-test-pressable')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToPressStyleNative()
+    await remountDirectUseCase('color-test-pressable')
   })
 
   it('should render the test case screen', async () => {
@@ -227,7 +232,3 @@ describe.skip('PressStyleNative', () => {
     })
   })
 })
-
-async function navigateToPressStyleNative() {
-  await navigateToTestCase('PressStyleNative', 'color-test-pressable')
-}

--- a/code/kitchen-sink/e2e/PressStyleScrollStuck.test.ts
+++ b/code/kitchen-sink/e2e/PressStyleScrollStuck.test.ts
@@ -7,9 +7,9 @@
  * on the view — the animated bg color never returns to its rest value.
  */
 
-import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { by, element, expect, waitFor } from 'detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 const PILLS = [
   'General',
@@ -26,12 +26,17 @@ const PILLS = [
 
 describe('PressStyleScrollStuck', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'PressStyleScrollStuck' },
+    })
+    await waitFor(element(by.id('press-scroll-stuck-root')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('PressStyleScrollStuck', 'press-scroll-stuck-root')
+    await remountDirectUseCase('press-scroll-stuck-root')
   })
 
   it('renders the pill strip', async () => {

--- a/code/kitchen-sink/e2e/SelectRemount.test.ts
+++ b/code/kitchen-sink/e2e/SelectRemount.test.ts
@@ -11,8 +11,8 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp, withSync } from './utils/detox'
 
 const testElement = (id: string) => element(by.id(id)).atIndex(0)
 
@@ -33,14 +33,19 @@ async function remountAndWait() {
 
 describe('SelectRemount', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'SelectRemount' },
+    })
+    await waitFor(element(by.id('remount-button')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
     // skipEnableSync: tests manage sync themselves via withSync helper
-    // re-enabling sync after navigation can hang if animations are still settling
-    await navigateToTestCase('SelectRemount', 'remount-button', { skipEnableSync: true })
+    // re-enabling sync after remount can hang if animations are still settling
+    await remountDirectUseCase('remount-button', { skipEnableSync: true })
   })
 
   it('should navigate to SelectRemount test case', async () => {

--- a/code/kitchen-sink/e2e/SheetDragResist.test.ts
+++ b/code/kitchen-sink/e2e/SheetDragResist.test.ts
@@ -13,8 +13,8 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 // only run on iOS - RNGH gesture handling differs on Android
 const isAndroid = () => device.getPlatform() === 'android'
@@ -22,15 +22,19 @@ const isAndroid = () => device.getPlatform() === 'android'
 describe('SheetDragResist', () => {
   beforeAll(async () => {
     if (isAndroid()) return
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'SheetDragResistCase' },
+    })
+    await waitFor(element(by.id('sheet-drag-resist-screen')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
     if (isAndroid()) return
-    // reload between tests for clean state
-    await safeReloadApp()
-    await navigateToSheetDragResistCase()
-    // disable sync AFTER navigation to avoid hang on spring animations during tests
+    await remountDirectUseCase('sheet-drag-resist-screen')
+    // disable sync AFTER remount to avoid hang on spring animations during tests
     await device.disableSynchronization()
   })
 
@@ -365,7 +369,3 @@ describe('SheetDragResist', () => {
     })
   })
 })
-
-async function navigateToSheetDragResistCase() {
-  await navigateToTestCase('SheetDragResistCase', 'sheet-drag-resist-screen')
-}

--- a/code/kitchen-sink/e2e/SheetKeyboardDrag.test.ts
+++ b/code/kitchen-sink/e2e/SheetKeyboardDrag.test.ts
@@ -15,7 +15,8 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 // only run on iOS - keyboard behavior differs on Android
 const isAndroid = () => device.getPlatform() === 'android'
@@ -29,15 +30,19 @@ describe.skip('SheetKeyboardDrag - Keyboard + Sheet Integration', () => {
     if (isAndroid()) return
     await safeLaunchApp({
       newInstance: true,
-      launchArgs: { disableKeyboardController: false },
+      launchArgs: {
+        directUseCase: 'SheetKeyboardDragCase',
+        disableKeyboardController: false,
+      },
     })
-    await navigateToSheetKeyboardDrag()
+    await waitFor(element(by.id('sheet-keyboard-drag-trigger')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
     if (isAndroid()) return
-    await safeReloadApp()
-    await navigateToSheetKeyboardDrag()
+    await remountDirectUseCase('sheet-keyboard-drag-trigger', { skipEnableSync: true })
   })
 
   it('should show status indicators', async () => {
@@ -234,23 +239,3 @@ describe.skip('SheetKeyboardDrag - Keyboard + Sheet Integration', () => {
     )
   })
 })
-
-async function navigateToSheetKeyboardDrag() {
-  // wait for app to load
-  await waitFor(element(by.text('Kitchen Sink')))
-    .toExist()
-    .withTimeout(30000)
-
-  await new Promise((r) => setTimeout(r, 500))
-
-  // use quick access link from home screen
-  await waitFor(element(by.id('home-sheet-keyboard-test')))
-    .toBeVisible()
-    .withTimeout(5000)
-  await element(by.id('home-sheet-keyboard-test')).tap()
-
-  // wait for test screen
-  await waitFor(element(by.id('sheet-keyboard-drag-trigger')))
-    .toExist()
-    .withTimeout(5000)
-}

--- a/code/kitchen-sink/e2e/SheetPressRegression.test.ts
+++ b/code/kitchen-sink/e2e/SheetPressRegression.test.ts
@@ -9,8 +9,8 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 const testElement = (id: string) => element(by.id(id)).atIndex(0)
@@ -25,12 +25,17 @@ async function openSheet() {
 
 describe('SheetPressRegression', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'SheetPressRegressionCase' },
+    })
+    await waitFor(element(by.id('sheet-press-screen')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('SheetPressRegressionCase', 'sheet-press-screen')
+    await remountDirectUseCase('sheet-press-screen')
   })
 
   it('footer Post / Cancel buttons fire onPress', async () => {

--- a/code/kitchen-sink/e2e/SheetScrollableDrag.test.ts
+++ b/code/kitchen-sink/e2e/SheetScrollableDrag.test.ts
@@ -14,23 +14,32 @@
  */
 
 import { by, device, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 // only run on iOS - Android behavior is different
 const isAndroid = () => device.getPlatform() === 'android'
 
+// Launch model: launch the native app ONCE with directUseCase, then remount the
+// case in-app per test (deep link, no relaunch). Each "Case" test assumes a
+// freshly-closed sheet at scrollY=0, which the remount restores. skipEnableSync
+// throughout: KeyboardProvider keeps the main thread busy and taps/swipes work
+// with sync disabled here.
 describe('SheetScrollableDrag - RNGH Integration', () => {
   beforeAll(async () => {
     if (isAndroid()) return
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'SheetScrollableDrag' },
+    })
+    await waitFor(element(by.id('sheet-scrollable-drag-trigger')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
     if (isAndroid()) return
-    await safeReloadApp()
-    // skipEnableSync: navigation re-enabling sync hangs if animations are settling
-    await navigateToTestCase('SheetScrollableDrag', 'sheet-scrollable-drag-trigger', {
+    await remountDirectUseCase('sheet-scrollable-drag-trigger', {
       skipEnableSync: true,
     })
   })

--- a/code/kitchen-sink/e2e/ShorthandVariables.test.ts
+++ b/code/kitchen-sink/e2e/ShorthandVariables.test.ts
@@ -8,20 +8,25 @@
  * 1. Elements render without crashing
  * 2. Elements are visible (which means the boxShadow style was accepted)
  * 3. The app doesn't show any red box errors
+ *
+ * Launch model: directUseCase renders the case at app root, so we launch the
+ * native app ONCE in beforeAll and never relaunch. All assertions are read-only
+ * against the same render, so no per-test reset is needed. This removes the
+ * per-test app relaunch (the only place the Detox connect-flake bites).
  */
 
-import { by, device, element, expect } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { by, element, expect, waitFor } from 'detox'
+import { safeLaunchApp } from './utils/detox'
 
 describe('ShorthandVariables', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
-  beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('ShorthandVariables', 'boxshadow-var')
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'ShorthandVariables' },
+    })
+    await waitFor(element(by.id('boxshadow-var')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   it('should render boxShadow with $variable without crashing', async () => {

--- a/code/kitchen-sink/e2e/TabsOnInteraction.test.ts
+++ b/code/kitchen-sink/e2e/TabsOnInteraction.test.ts
@@ -5,21 +5,22 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp, withSync } from './utils/detox'
+import { safeLaunchApp, withSync } from './utils/detox'
 
+// Launch model: directUseCase renders the case at app root, so we launch the
+// native app ONCE in beforeAll and never relaunch. The three tests are
+// order-safe (only the last one taps a tab; nothing depends on post-tap state),
+// so no per-test reset is needed. safeLaunchApp leaves synchronization disabled
+// after launch, which the Tabs onLayout-busy screen requires.
 describe('TabsOnInteraction', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
-  })
-
-  beforeEach(async () => {
-    await safeReloadApp()
-    // skipEnableSync: the Tabs screen keeps the main thread busy via
-    // onLayout callbacks, so leaving sync enabled hangs the hook.
-    await navigateToTestCase('TabsOnInteraction', 'tabs-root', {
-      skipEnableSync: true,
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'TabsOnInteraction' },
     })
+    await waitFor(element(by.id('tabs-root')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   it('should fire onInteraction with layout for the default selected tab', async () => {

--- a/code/kitchen-sink/e2e/ThemeChangeBasic.test.ts
+++ b/code/kitchen-sink/e2e/ThemeChangeBasic.test.ts
@@ -8,18 +8,26 @@
 
 import * as assert from 'assert'
 import { by, device, element, expect, waitFor } from 'detox'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
-import { navigateToTestCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
 import { getDominantColor, isBlueish, isReddish, formatRGB } from './utils/colors'
 
+// Launch model: launch the native app ONCE with directUseCase, then remount the
+// case in-app per test (deep link, no relaunch). The case's theme is local
+// useState('red'), so a remount restores the initial red state each test.
 describe('ThemeChangeBasic', () => {
   beforeAll(async () => {
-    await safeLaunchApp({ newInstance: true })
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'ThemeChangeBasic' },
+    })
+    await waitFor(element(by.id('theme-change-basic-root')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('ThemeChangeBasic', 'theme-change-basic-root')
+    await remountDirectUseCase('theme-change-basic-root')
   })
 
   it('should show initial red theme', async () => {

--- a/code/kitchen-sink/e2e/ThemeMutation.test.ts
+++ b/code/kitchen-sink/e2e/ThemeMutation.test.ts
@@ -14,17 +14,22 @@
  */
 
 import { by, element, expect, waitFor } from 'detox'
-import { navigateToTestCase } from './utils/navigation'
-import { safeLaunchApp, safeReloadApp } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
 
 describe('ThemeMutation', () => {
   beforeAll(async () => {
-    await safeLaunchApp()
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'ThemeMutation' },
+    })
+    await waitFor(element(by.id('theme-mutation-button')))
+      .toExist()
+      .withTimeout(180000)
   })
 
   beforeEach(async () => {
-    await safeReloadApp()
-    await navigateToTestCase('ThemeMutation', 'theme-mutation-button', {
+    await remountDirectUseCase('theme-mutation-button', {
       skipEnableSync: true,
     })
   })

--- a/code/kitchen-sink/e2e/jest.config.js
+++ b/code/kitchen-sink/e2e/jest.config.js
@@ -16,6 +16,9 @@ module.exports = {
   globalTeardown: 'detox/runners/jest/globalTeardown',
   reporters: ['detox/runners/jest/reporter'],
   testEnvironment: 'detox/runners/jest/testEnvironment',
+  // per-test retry for flaky individual tests (jest.retryTimes); replaces detox's
+  // whole-file --retries. must run after the framework is installed, hence AfterEnv.
+  setupFilesAfterEnv: ['<rootDir>/e2e/jest.setup.ts'],
   verbose: true,
   // watchman daemon disabled - jest must use node fallback watcher
   watchman: false,

--- a/code/kitchen-sink/e2e/jest.setup.ts
+++ b/code/kitchen-sink/e2e/jest.setup.ts
@@ -1,0 +1,11 @@
+// per-test retry (jest-circus), the replacement for detox's whole-file --retries.
+//
+// detox --retries re-runs an entire failed spec file: its beforeAll (app launch +
+// any compile step) plus every test in it, even the ones that passed. that doubled a
+// flaky shard's wall time. jest.retryTimes instead re-runs only the individual failing
+// test, and because each test's beforeEach calls safeReloadApp (a fresh app instance),
+// the retry starts from clean state. far cheaper, same flake resilience.
+//
+// note: retryTimes does NOT re-run beforeAll, and if the app launch itself is wedged
+// the breaker in utils/detox.ts makes the retry's beforeEach fail fast rather than hang.
+jest.retryTimes(1, { logErrorsBeforeRetry: true })

--- a/code/kitchen-sink/e2e/utils/detox.ts
+++ b/code/kitchen-sink/e2e/utils/detox.ts
@@ -32,7 +32,6 @@ const POST_LAUNCH_SETTLE_MS = 1500
 const LAUNCH_RETRY_DELAY_MS = 3000
 const LATE_LAUNCH_READY_DELAY_MS = 8000
 const LATE_LAUNCH_ACTION_TIMEOUT_MS = 5000
-const LAUNCH_MAX_ATTEMPTS = 3
 const RETRYABLE_LAUNCH_PATTERNS = [
   'FBSOpenApplicationServiceErrorDomain',
   'FBSOpenApplicationErrorDomain',
@@ -40,18 +39,35 @@ const RETRYABLE_LAUNCH_PATTERNS = [
   'Failed to run application on the device',
 ]
 
-// A healthy launch+connect is well under this even on a cold (Metro pre-warmed)
-// CI bundle, so if it fires the app is hanging, not slow. Bounding it below
-// jest's 180s hook timeout lets safeLaunchApp catch the hang itself (and trip the
-// breaker below) instead of jest killing the beforeAll hook from the outside.
-const LAUNCH_CONNECT_TIMEOUT_MS = 120000
+// Per-attempt launch+connect bound. Healthy launches on CI sims land ~30-45s (cold
+// beforeAll launch with the full bundle eval); 70s tolerates a slow spike while still
+// fitting a recovery relaunch in the deadline below. A worst case where it fires on a
+// genuinely-healthy launch just costs one extra relaunch - the test still passes.
+const LAUNCH_CONNECT_TIMEOUT_MS = 70000
+
+// terminateApp during recovery is best-effort and must never hang the path.
+const TERMINATE_TIMEOUT_MS = 15000
+
+// Total wall-time safeLaunchApp may spend recovering before it gives up. Kept under
+// jest's 180s beforeEach/test hook timeout so a flaky launch is recovered (or the
+// breaker tripped + a clean error thrown) from inside the hook, rather than jest
+// killing the hook from the outside with no chance to recover or fast-fail. The
+// reserve below keeps disableSync + settle inside this window too.
+const LAUNCH_RECOVERY_DEADLINE_MS = 165000
+
+// disableSynchronization is near-instant on a healthy app but can hang on a
+// wedged one; it runs in every test's beforeEach (via safeReloadApp), so bound
+// it tightly to avoid burning the full hook timeout here before we even attempt
+// the (also-bounded) launch.
+const DISABLE_SYNC_TIMEOUT_MS = 20000
 
 // Once a launch demonstrably can't connect to Detox (flaky simulator / app
-// registration, not a test bug), every later launch in this jest process hangs
-// the same way. Trip this so the rest of the shard's files fail instantly rather
-// than each burning the full hook timeout x retries (the ~50min runaway in
-// memory project_detox_app_connect_runaway). Resets naturally on detox's
-// process-level retry.
+// registration, not a test bug), every later launch/reload in the SAME test file
+// hangs the same way. Trip this so the rest of THIS file's tests fail instantly
+// rather than each burning the full hook timeout. Note: jest isolates the module
+// registry per test file, so this resets per file (it does not carry across files
+// in a shard) and resets on detox's process-level retry. See memory
+// project_detox_app_connect_runaway.
 let appLaunchUnrecoverable = false
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
@@ -78,6 +94,22 @@ async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 const isRetryableLaunchError = (err: unknown): boolean => {
   const msg = err instanceof Error ? err.message : String(err)
   return RETRYABLE_LAUNCH_PATTERNS.some((p) => msg.includes(p))
+}
+
+const isTimeoutError = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg.includes('timed out after')
+}
+
+// Force-kill the app between recovery attempts. The next launchApp({ newInstance })
+// also terminates the prior instance, so this is belt-and-suspenders; bound it so a
+// stuck terminate can't eat the recovery budget.
+const safeTerminate = async (): Promise<void> => {
+  try {
+    await withTimeout(device.terminateApp(), TERMINATE_TIMEOUT_MS)
+  } catch {
+    // best-effort
+  }
 }
 
 const tryRecoverLateLaunch = async (): Promise<boolean> => {
@@ -110,50 +142,75 @@ export async function safeLaunchApp(params?: LaunchAppParams): Promise<void> {
     )
   }
 
+  lastLaunchParams = params
+  const deadline = Date.now() + LAUNCH_RECOVERY_DEADLINE_MS
+  // reserve enough of the window for the post-launch disableSync + settle so a
+  // successful launch near the deadline still finishes inside the hook budget.
+  const reserveMs = DISABLE_SYNC_TIMEOUT_MS + POST_LAUNCH_SETTLE_MS + 2000
+  let attemptParams = params
+  let attempt = 0
   let lastError: unknown
-  for (let attempt = 1; attempt <= LAUNCH_MAX_ATTEMPTS; attempt++) {
+
+  while (true) {
+    const launchBudget = deadline - Date.now() - reserveMs
+    if (launchBudget <= 0) {
+      break
+    }
+    attempt++
     try {
-      lastLaunchParams = params
-      // bound the launch+connect so a hang throws here (caught below) instead of
-      // jest killing the hook at 180s with no chance to trip the breaker.
+      // bound the launch+connect AND the disableSync: either hanging means the app
+      // didn't come up cleanly, so we treat it as a failed attempt and recover below
+      // rather than letting jest kill the hook at 180s.
       await withTimeout(
         device.launchApp({
-          ...params,
+          ...attemptParams,
           launchArgs: {
             ...DEFAULT_LAUNCH_ARGS,
-            ...params?.launchArgs,
+            ...attemptParams?.launchArgs,
           },
         } as any),
-        LAUNCH_CONNECT_TIMEOUT_MS
+        Math.min(LAUNCH_CONNECT_TIMEOUT_MS, launchBudget)
       )
-      await device.disableSynchronization()
+      await withTimeout(device.disableSynchronization(), DISABLE_SYNC_TIMEOUT_MS)
       await sleep(POST_LAUNCH_SETTLE_MS)
       return
     } catch (err) {
       lastError = err
-      if (attempt === LAUNCH_MAX_ATTEMPTS || !isRetryableLaunchError(err)) {
-        if (await tryRecoverLateLaunch()) {
-          return
-        }
-        break
-      }
-
+      // android can connect a beat late; recover in place without relaunching.
       if (await tryRecoverLateLaunch()) {
         return
       }
 
+      const timedOut = isTimeoutError(err)
+      const retryableSim = isRetryableLaunchError(err)
+      if (!(timedOut || retryableSim)) {
+        // unknown error - don't burn the budget spinning on it.
+        break
+      }
+
+      if (timedOut) {
+        // the app process is likely up but never connected to Detox (or sync got
+        // stuck); force-kill it and force a fresh instance for the next attempt.
+        await safeTerminate()
+        attemptParams = { ...attemptParams, newInstance: true }
+      }
+
+      if (deadline - Date.now() - reserveMs - LAUNCH_RETRY_DELAY_MS <= 0) {
+        // no budget for another full attempt; give up to the breaker below.
+        break
+      }
       console.warn(
-        `safeLaunchApp: attempt ${attempt}/${LAUNCH_MAX_ATTEMPTS} failed with retryable simulator error, retrying after ${LAUNCH_RETRY_DELAY_MS}ms`,
+        `safeLaunchApp: attempt ${attempt} failed (${timedOut ? 'connect timeout' : 'simulator error'}), retrying after ${LAUNCH_RETRY_DELAY_MS}ms`,
         err instanceof Error ? err.message : err
       )
       await sleep(LAUNCH_RETRY_DELAY_MS)
     }
   }
 
-  // gave up after all attempts: trip the breaker so the rest of this shard's
-  // files fail instantly instead of each hanging the full hook timeout x retries.
+  // recovery window exhausted: trip the breaker so the rest of THIS file's
+  // tests/reloads fail instantly instead of each hanging the full hook timeout.
   appLaunchUnrecoverable = true
-  throw lastError
+  throw lastError ?? new Error('safeLaunchApp: launch recovery deadline exceeded')
 }
 
 /**
@@ -165,7 +222,22 @@ export async function safeLaunchApp(params?: LaunchAppParams): Promise<void> {
  * settling, leaving the app redboxed and Detox waiting on reactNativeReload.
  */
 export async function safeReloadApp(): Promise<void> {
-  await device.disableSynchronization()
+  // breaker tripped earlier in this file: a reload will hang the same way, so
+  // fail this beforeEach instantly instead of burning the disableSync + launch
+  // windows again.
+  if (appLaunchUnrecoverable) {
+    throw new Error(
+      'skipping reload: a previous launch could not connect to Detox in this file. failing fast instead of hanging.'
+    )
+  }
+  // bound disableSynchronization: on a wedged app it can hang, and it runs in
+  // every test's beforeEach. if it hangs the launch below (also bounded + breaker)
+  // surfaces the real failure.
+  try {
+    await withTimeout(device.disableSynchronization(), DISABLE_SYNC_TIMEOUT_MS)
+  } catch {
+    // best-effort
+  }
   await safeLaunchApp({
     ...lastLaunchParams,
     newInstance: true,

--- a/code/kitchen-sink/e2e/utils/navigation.ts
+++ b/code/kitchen-sink/e2e/utils/navigation.ts
@@ -56,3 +56,57 @@ export async function navigateToTestCase(
     await device.enableSynchronization()
   }
 }
+
+/**
+ * Remount the active directUseCase component without a native app relaunch.
+ *
+ * Fires a `tamagui-kitchen-sink://remount` deep link, which DirectUseCaseHost
+ * turns into a React key bump (full unmount + fresh mount of the case). This is
+ * the per-test reset for launch-once test files: same fresh-state guarantee as
+ * safeReloadApp, but it skips the native relaunch that is the sole trigger of
+ * the Detox launch/connect flake (and costs ~300ms instead of ~30s).
+ *
+ * Readiness is gated on the off-screen e2e-remount-count incrementing, because
+ * the keyed component swaps atomically and its own testIDs can't signal the swap.
+ *
+ * @param waitForElementId - optional testID to additionally wait for post-remount
+ */
+export async function remountDirectUseCase(
+  waitForElementId?: string,
+  options?: { skipEnableSync?: boolean }
+) {
+  // disable sync first: a busy animation/onLayout screen would otherwise hang
+  // the openURL + attribute reads below.
+  await device.disableSynchronization()
+
+  const before = await readRemountCount()
+  await device.openURL({ url: 'tamagui-kitchen-sink://remount' })
+
+  await waitFor(element(by.id('e2e-remount-count')))
+    .toHaveText(String(before + 1))
+    .withTimeout(15000)
+
+  // small settle for the fresh mount's first layout/animation frame
+  await new Promise((r) => setTimeout(r, 300))
+
+  if (waitForElementId) {
+    await waitFor(element(by.id(waitForElementId)))
+      .toExist()
+      .withTimeout(15000)
+  }
+
+  if (!options?.skipEnableSync) {
+    await device.enableSynchronization()
+  }
+}
+
+async function readRemountCount(): Promise<number> {
+  try {
+    const attributes = (await element(by.id('e2e-remount-count')).getAttributes()) as any
+    const value = Number.parseInt(attributes.text, 10)
+    return Number.isNaN(value) ? 0 : value
+  } catch {
+    // counter not present yet (first reset right after launch) - treat as 0
+    return 0
+  }
+}

--- a/code/kitchen-sink/src/App.native.tsx
+++ b/code/kitchen-sink/src/App.native.tsx
@@ -32,7 +32,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { KeyboardProvider } from 'react-native-keyboard-controller'
 import { useFonts } from 'expo-font'
 import React from 'react'
-import { Appearance, LogBox, useColorScheme } from 'react-native'
+import { Appearance, Linking, LogBox, Text, useColorScheme } from 'react-native'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { PortalProvider } from 'react-native-teleport'
 import { H1 } from 'tamagui'
@@ -95,7 +95,7 @@ export default function App() {
         <ThemeContext.Provider value={themeContext}>
           <Provider defaultTheme={resolvedTheme as any}>
             {DirectUseCase ? (
-              <DirectUseCase />
+              <DirectUseCaseHost Component={DirectUseCase} />
             ) : (
               <Navigation initialTestCase={launchArgs.initialTestCase} />
             )}
@@ -116,15 +116,45 @@ export default function App() {
   )
 }
 
+// Hosts a directUseCase component and remounts it on a `…://remount` deep link.
+// Detox e2e tests open that deep link in beforeEach to get a fresh component
+// mount per test WITHOUT a native app relaunch. The relaunch is the only place
+// the Detox launch/connect flake bites, so collapsing per-test relaunches into a
+// single beforeAll launch + cheap JS remounts removes the flake and the wait.
+function DirectUseCaseHost({ Component }: { Component: React.ComponentType }) {
+  const [remountKey, setRemountKey] = React.useState(0)
+
+  React.useEffect(() => {
+    const sub = Linking.addEventListener('url', ({ url }) => {
+      if (url.includes('remount')) {
+        setRemountKey((k) => k + 1)
+      }
+    })
+    return () => sub.remove()
+  }, [])
+
+  return (
+    <>
+      <Component key={remountKey} />
+      {/* off-screen remount counter: lets the e2e helper wait deterministically
+          for a remount to commit (the keyed Component swaps atomically, so its
+          own testIDs can't signal "remounted"). top:-1000 keeps it out of every
+          screenshot/visibility check; Detox reads the text attribute, not pixels. */}
+      <Text testID="e2e-remount-count" style={{ position: 'absolute', top: -1000 }}>
+        {remountKey}
+      </Text>
+    </>
+  )
+}
+
 function getDirectUseCaseComponent(name?: string): React.ComponentType | null {
   if (!name) {
     return null
   }
 
-  const useCases = require('./usecases') as Record<
-    string,
-    React.ComponentType | undefined
-  >
+  const { useCases } = require('./usecases') as {
+    useCases: Record<string, React.ComponentType | undefined>
+  }
 
   return (
     useCases[name] || (() => <H1 testID="direct-usecase-not-found">Not found: {name}</H1>)

--- a/code/kitchen-sink/src/App.tsx
+++ b/code/kitchen-sink/src/App.tsx
@@ -5,7 +5,7 @@ import React from 'react'
 import { Separator, Theme, XStack, YStack } from 'tamagui'
 import { Provider } from './provider'
 import { Sandbox } from './Sandbox'
-import * as TestCases from './usecases/index.web'
+import { useCases as TestCases } from './usecases/index.web'
 
 if (typeof require !== 'undefined') {
   globalThis['React'] = require('react') // webpack

--- a/code/kitchen-sink/src/features/home/screen.tsx
+++ b/code/kitchen-sink/src/features/home/screen.tsx
@@ -6,7 +6,7 @@ import type { UseLinkProps } from 'solito/link'
 import { useLink } from 'solito/link'
 import type { ListItemProps } from 'tamagui'
 import { Button, ListItem, Paragraph, YGroup, YStack } from 'tamagui'
-import * as TestCases from '../../usecases'
+import { useCases as TestCases } from '../../usecases'
 
 const testCaseNames = Object.keys(TestCases)
 

--- a/code/kitchen-sink/src/features/testcases/screen.tsx
+++ b/code/kitchen-sink/src/features/testcases/screen.tsx
@@ -5,7 +5,7 @@ import { useLink } from 'solito/link'
 import type { ListItemProps } from 'tamagui'
 import { H2, ListItem, YGroup, YStack } from 'tamagui'
 
-import * as TestCases from '../../usecases'
+import { useCases as TestCases } from '../../usecases'
 
 export function TestCasesScreen() {
   return (

--- a/code/kitchen-sink/src/features/testcases/test-screen.tsx
+++ b/code/kitchen-sink/src/features/testcases/test-screen.tsx
@@ -3,7 +3,7 @@ import { ScrollView } from 'react-native'
 import { createParam } from 'solito'
 import { H1, YStack } from 'tamagui'
 
-import * as UseCases from '../../usecases'
+import { useCases as UseCases } from '../../usecases'
 
 const { useParam } = createParam<{ id: string }>()
 

--- a/code/kitchen-sink/src/usecases/index.native.ts
+++ b/code/kitchen-sink/src/usecases/index.native.ts
@@ -1,133 +1,180 @@
-export { ActionsSheetComparison } from './ActionsSheetComparison'
-export { AnimatedByProp } from './AnimatedByProp'
-export { AnimatePresenceExitTest } from './AnimatePresenceExitTest'
-export { AnimationComprehensiveCase } from './AnimationComprehensiveCase'
-export { Benchmark } from './Benchmark'
-export { ButtonCircular } from './ButtonCircular'
-export { ButtonCustom } from './ButtonCustom'
-export { ButtonInverse } from './ButtonInverse'
-export { ButtonUnstyled } from './ButtonUnstyled'
-export { CheckboxDisabledOnPress } from './CheckboxDisabledOnPress'
-export { CodeExamplesInput } from './CodeExamplesInput'
-export { ColorTokenFallback } from './ColorTokenFallback'
-export { CompilerExtraction } from './CompilerExtraction'
-export { CompilerTernaryActive } from './CompilerTernaryActive'
-export { ComplexVariants } from './ComplexVariants'
-export { CrashAdaptSheet } from './CrashAdaptSheet'
-export { CustomStyledAnimatedPopover } from './CustomStyledAnimatedPopover'
-export { CustomStyledAnimatedTooltip } from './CustomStyledAnimatedTooltip'
-export { DialogFocusScopeCase } from './DialogFocusScopeCase'
-export { DialogFocusScopeDebug } from './DialogFocusScopeDebug'
-export { DialogNestedCase } from './DialogNestedCase'
-export { DialogOpenControlled } from './DialogOpenControlled'
-export { DialogPointerEventsCase } from './DialogPointerEventsCase'
-export { DialogScopedCase } from './DialogScopedCase'
-export { DialogSheetAdaptCase } from './DialogSheetAdaptCase'
-export { Example } from './Example'
-export { ExitCompletionCase } from './ExitCompletionCase'
-export { FocusVisibleButton } from './FocusVisibleButton'
-export { FocusVisibleButtonPointer } from './FocusVisibleButtonPointer'
-export { FocusVisibleButtonWithFocusStyle } from './FocusVisibleButtonWithFocusStyle'
-export { FontTokensInVariants } from './FontTokensInVariants'
-export { GroupHoverMobile } from './GroupHoverMobile'
-export { GroupPressInVariant } from './GroupPressInVariant'
-export { GroupPseudoVariantOverride } from './GroupPseudoVariantOverride'
-export { GroupPressNative } from './GroupPressNative'
-export { GroupPressTransitionMatrix } from './GroupPressTransitionMatrix'
-export { GroupProp } from './GroupProp'
-export { MediaQueryGtMd } from './MediaQueryGtMd'
-export { MediaQueriesV5 } from './MediaQueriesV5'
-export { MenuAccessibilityCase } from './MenuAccessibilityCase'
-export { MenuAsChildPositionCase } from './MenuAsChildPositionCase'
-export { MenuHighlightCase } from './MenuHighlightCase'
-export { MenuRadioGroupCase } from './MenuRadioGroupCase'
-export { MenuSubCase } from './MenuSubCase'
-export { MenuSubLeftCase } from './MenuSubLeftCase'
-export { NativePortalTest } from './NativePortalTest'
-export { GroupUseCases } from './GroupUseCases'
-export { ImageTokenStyle } from './ImageTokenStyle'
-export { ThemedListItem } from './ListItem'
-export { NewInputBasic } from './NewInputBasic'
-export { NewInputEvents } from './NewInputEvents'
-export { OverlayStyled } from './OverlayStyled'
-export { PlaceholderTextColor } from './PlaceholderTextColor'
-export { PointerEventsCase } from './PointerEventsCase'
-export { PopoverCase } from './PopoverCase'
-export { PopoverContentStyledPlusAnimations } from './PopoverContentStyledPlusAnimations'
-export { PopoverFocusScopeCase } from './PopoverFocusScopeCase'
-export { PopoverScopedCase } from './PopoverScopedCase'
-export { PopoverTriggerIsolationCase } from './PopoverTriggerIsolationCase'
-export { PressStyleNative } from './PressStyleNative'
-export { PressStyleScrollStuck } from './PressStyleScrollStuck'
-export { PseudoStyleMerge } from './PseudoStyleMerge'
-export { PseudoTransitionCase } from './PseudoTransitionCase'
-export { RenderPropCase } from './RenderPropCase'
-// export { SafeAreaCase } from './SafeAreaCase'
-export { ScrollViewRefCase } from './ScrollViewRefCase'
-export { SecondPage } from './SecondPage'
-export { SelectAndroidOnPress } from './SelectAndroidOnPress'
-export { SelectFocusScopeCase } from './SelectFocusScopeCase'
-export { SelectRemount } from './SelectRemount'
-export { Shadows } from './Shadows'
-export { ShorthandVariables } from './ShorthandVariables'
-export { SheetAnimationCase } from './SheetAnimationCase'
-export { SheetDragCase } from './SheetDragCase'
-export { SheetDragResistCase } from './SheetDragResistCase'
-export { SheetKeyboardDragCase } from './SheetKeyboardDragCase'
-export { SheetKeyboardFitContentCase } from './SheetKeyboardFitContentCase'
-export { KeyboardControllerTest } from './KeyboardControllerTest'
-export { SheetScrollableDrag } from './SheetScrollableDrag'
-export { SheetScrollLockCase } from './SheetScrollLockCase'
-export { SheetSnapPointsFitCase } from './SheetSnapPointsFitCase'
-export { SheetPressRegressionCase } from './SheetPressRegressionCase'
-export { SlowThemeReRender } from './SlowThemeReRender'
-export { SpinnerCustomColors } from './SpinnerCustomColors'
-export { StackZIndex } from './StackZIndex'
-export { StyledAnchor } from './StyledAnchor'
-export { StyledButtonAnimationAuto } from './StyledButtonAnimationAuto'
-export { StyledButtonTheme } from './StyledButtonTheme'
-export { StyledButtonVariantPseudo } from './StyledButtonVariantPseudo'
-export { StyledButtonVariantPseudoMerge } from './StyledButtonVariantPseudoMerge'
-export { StyledCheckboxTheme } from './StyledCheckboxTheme'
-export { StyledContextColor } from './StyledContextColor'
-export { StyledContextTokens } from './StyledContextTokens'
-export { StyledHOCNamed } from './StyledHOCNamed'
-export { StyledIconColor } from './StyledIconColor'
-export { StyledInputFocusStyle } from './StyledInputFocusStyle'
-export { StyledInputOnFocus } from './StyledInputOnFocus'
-export { StyledMediaQueryMerge } from './StyledMediaQueryMerge'
-export { StyledOverridePsuedo } from './StyledOverridePsuedo'
-export { StyledRNW } from './StyledRNW'
-export { StyledStyleableInputOnFocus } from './StyledStyleableInputOnFocus'
-export { StyledStyleableInputVariant } from './StyledStyleableInputVariant'
-export { StyledStyledStyleableInputOnFocus } from './StyledStyledStyleableInputOnFocus'
-export { StyledVariantTextColor } from './StyledVariantTextColor'
-export { StyledViewOnFocus } from './StyledViewOnFocus'
-export { StylePlatform } from './StylePlatform'
-export { StyleProp } from './StyleProp'
-export { TabsOnInteraction } from './TabsOnInteraction'
-export { TextNestedInheritance } from './TextNestedInheritance'
-export { ThemeChange } from './ThemeChange'
-export { ThemeChangeBasic } from './ThemeChangeBasic'
-export { ThemeComponentResolution } from './ThemeComponentResolution'
-export { ThemeMutation } from './ThemeMutation'
-export { ThemeNested } from './ThemeNested'
-export { ThemeReset } from './ThemeReset'
-export { ThemeShallowCase } from './ThemeShallowCase'
-// ToastCase removed - uses legacy v1 API
-export { ToastMultipleCase } from './ToastMultipleCase'
-export { ToastNativeBurntCase } from './ToastNativeBurntCase'
-export { ToggleGroupActiveProps } from './ToggleGroupActiveProps'
-export { TooltipAnimationCase } from './TooltipAnimationCase'
-export { TooltipCase } from './TooltipCase'
-export { TooltipGroupCase } from './TooltipGroupCase'
-export { TooltipPositionJumpCase } from './TooltipPositionJumpCase'
-export { TooltipTriggerInlineCase } from './TooltipTriggerInlineCase'
-export { TransformMediaQueryMerge } from './TransformMediaQueryMerge'
-export { UseCases } from './UseCases'
-export { UseTheme } from './UseTheme'
-export { V5ThemeBuilderOutput } from './V5ThemeBuilderOutput'
-export { VariantFontFamily } from './VariantFontFamily'
-export { VariantsOrder } from './VariantsOrder'
-export { ZIndex } from './ZIndex'
-export { NestedPressExclusive } from './NestedPressExclusive'
+// native usecase registry (lazy). includes native-only usecases.
+// AUTO-SHAPED lazy registry: each usecase module is required (and therefore
+// evaluated) only when its component is first accessed, not when this index loads.
+// Object.keys(useCases) lists names without evaluating any usecase (getters are not
+// invoked by Object.keys); useCases[name] evaluates just that one. This avoids the
+// per-launch eval of every usecase that made Detox app relaunches slow.
+import type { ComponentType } from 'react'
+
+const loaders: Record<string, () => ComponentType<any>> = {
+  ActionsSheetComparison: () =>
+    require('./ActionsSheetComparison').ActionsSheetComparison,
+  AnimatedByProp: () => require('./AnimatedByProp').AnimatedByProp,
+  AnimatePresenceExitTest: () =>
+    require('./AnimatePresenceExitTest').AnimatePresenceExitTest,
+  AnimationComprehensiveCase: () =>
+    require('./AnimationComprehensiveCase').AnimationComprehensiveCase,
+  Benchmark: () => require('./Benchmark').Benchmark,
+  ButtonCircular: () => require('./ButtonCircular').ButtonCircular,
+  ButtonCustom: () => require('./ButtonCustom').ButtonCustom,
+  ButtonInverse: () => require('./ButtonInverse').ButtonInverse,
+  ButtonUnstyled: () => require('./ButtonUnstyled').ButtonUnstyled,
+  CheckboxDisabledOnPress: () =>
+    require('./CheckboxDisabledOnPress').CheckboxDisabledOnPress,
+  CodeExamplesInput: () => require('./CodeExamplesInput').CodeExamplesInput,
+  ColorTokenFallback: () => require('./ColorTokenFallback').ColorTokenFallback,
+  CompilerExtraction: () => require('./CompilerExtraction').CompilerExtraction,
+  CompilerTernaryActive: () => require('./CompilerTernaryActive').CompilerTernaryActive,
+  ComplexVariants: () => require('./ComplexVariants').ComplexVariants,
+  CrashAdaptSheet: () => require('./CrashAdaptSheet').CrashAdaptSheet,
+  CustomStyledAnimatedPopover: () =>
+    require('./CustomStyledAnimatedPopover').CustomStyledAnimatedPopover,
+  CustomStyledAnimatedTooltip: () =>
+    require('./CustomStyledAnimatedTooltip').CustomStyledAnimatedTooltip,
+  DialogFocusScopeCase: () => require('./DialogFocusScopeCase').DialogFocusScopeCase,
+  DialogFocusScopeDebug: () => require('./DialogFocusScopeDebug').DialogFocusScopeDebug,
+  DialogNestedCase: () => require('./DialogNestedCase').DialogNestedCase,
+  DialogOpenControlled: () => require('./DialogOpenControlled').DialogOpenControlled,
+  DialogPointerEventsCase: () =>
+    require('./DialogPointerEventsCase').DialogPointerEventsCase,
+  DialogScopedCase: () => require('./DialogScopedCase').DialogScopedCase,
+  DialogSheetAdaptCase: () => require('./DialogSheetAdaptCase').DialogSheetAdaptCase,
+  Example: () => require('./Example').Example,
+  ExitCompletionCase: () => require('./ExitCompletionCase').ExitCompletionCase,
+  FocusVisibleButton: () => require('./FocusVisibleButton').FocusVisibleButton,
+  FocusVisibleButtonPointer: () =>
+    require('./FocusVisibleButtonPointer').FocusVisibleButtonPointer,
+  FocusVisibleButtonWithFocusStyle: () =>
+    require('./FocusVisibleButtonWithFocusStyle').FocusVisibleButtonWithFocusStyle,
+  FontTokensInVariants: () => require('./FontTokensInVariants').FontTokensInVariants,
+  GroupHoverMobile: () => require('./GroupHoverMobile').GroupHoverMobile,
+  GroupPressInVariant: () => require('./GroupPressInVariant').GroupPressInVariant,
+  GroupPseudoVariantOverride: () =>
+    require('./GroupPseudoVariantOverride').GroupPseudoVariantOverride,
+  GroupPressNative: () => require('./GroupPressNative').GroupPressNative,
+  GroupPressTransitionMatrix: () =>
+    require('./GroupPressTransitionMatrix').GroupPressTransitionMatrix,
+  GroupProp: () => require('./GroupProp').GroupProp,
+  MediaQueryGtMd: () => require('./MediaQueryGtMd').MediaQueryGtMd,
+  MediaQueriesV5: () => require('./MediaQueriesV5').MediaQueriesV5,
+  MenuAccessibilityCase: () => require('./MenuAccessibilityCase').MenuAccessibilityCase,
+  MenuAsChildPositionCase: () =>
+    require('./MenuAsChildPositionCase').MenuAsChildPositionCase,
+  MenuHighlightCase: () => require('./MenuHighlightCase').MenuHighlightCase,
+  MenuRadioGroupCase: () => require('./MenuRadioGroupCase').MenuRadioGroupCase,
+  MenuSubCase: () => require('./MenuSubCase').MenuSubCase,
+  MenuSubLeftCase: () => require('./MenuSubLeftCase').MenuSubLeftCase,
+  NativePortalTest: () => require('./NativePortalTest').NativePortalTest,
+  GroupUseCases: () => require('./GroupUseCases').GroupUseCases,
+  ImageTokenStyle: () => require('./ImageTokenStyle').ImageTokenStyle,
+  ThemedListItem: () => require('./ListItem').ThemedListItem,
+  NewInputBasic: () => require('./NewInputBasic').NewInputBasic,
+  NewInputEvents: () => require('./NewInputEvents').NewInputEvents,
+  OverlayStyled: () => require('./OverlayStyled').OverlayStyled,
+  PlaceholderTextColor: () => require('./PlaceholderTextColor').PlaceholderTextColor,
+  PointerEventsCase: () => require('./PointerEventsCase').PointerEventsCase,
+  PopoverCase: () => require('./PopoverCase').PopoverCase,
+  PopoverContentStyledPlusAnimations: () =>
+    require('./PopoverContentStyledPlusAnimations').PopoverContentStyledPlusAnimations,
+  PopoverFocusScopeCase: () => require('./PopoverFocusScopeCase').PopoverFocusScopeCase,
+  PopoverScopedCase: () => require('./PopoverScopedCase').PopoverScopedCase,
+  PopoverTriggerIsolationCase: () =>
+    require('./PopoverTriggerIsolationCase').PopoverTriggerIsolationCase,
+  PressStyleNative: () => require('./PressStyleNative').PressStyleNative,
+  PressStyleScrollStuck: () => require('./PressStyleScrollStuck').PressStyleScrollStuck,
+  PseudoStyleMerge: () => require('./PseudoStyleMerge').PseudoStyleMerge,
+  PseudoTransitionCase: () => require('./PseudoTransitionCase').PseudoTransitionCase,
+  RenderPropCase: () => require('./RenderPropCase').RenderPropCase,
+  ScrollViewRefCase: () => require('./ScrollViewRefCase').ScrollViewRefCase,
+  SecondPage: () => require('./SecondPage').SecondPage,
+  SelectAndroidOnPress: () => require('./SelectAndroidOnPress').SelectAndroidOnPress,
+  SelectFocusScopeCase: () => require('./SelectFocusScopeCase').SelectFocusScopeCase,
+  SelectRemount: () => require('./SelectRemount').SelectRemount,
+  Shadows: () => require('./Shadows').Shadows,
+  ShorthandVariables: () => require('./ShorthandVariables').ShorthandVariables,
+  SheetAnimationCase: () => require('./SheetAnimationCase').SheetAnimationCase,
+  SheetDragCase: () => require('./SheetDragCase').SheetDragCase,
+  SheetDragResistCase: () => require('./SheetDragResistCase').SheetDragResistCase,
+  SheetKeyboardDragCase: () => require('./SheetKeyboardDragCase').SheetKeyboardDragCase,
+  SheetKeyboardFitContentCase: () =>
+    require('./SheetKeyboardFitContentCase').SheetKeyboardFitContentCase,
+  KeyboardControllerTest: () =>
+    require('./KeyboardControllerTest').KeyboardControllerTest,
+  SheetScrollableDrag: () => require('./SheetScrollableDrag').SheetScrollableDrag,
+  SheetScrollLockCase: () => require('./SheetScrollLockCase').SheetScrollLockCase,
+  SheetSnapPointsFitCase: () =>
+    require('./SheetSnapPointsFitCase').SheetSnapPointsFitCase,
+  SheetPressRegressionCase: () =>
+    require('./SheetPressRegressionCase').SheetPressRegressionCase,
+  SlowThemeReRender: () => require('./SlowThemeReRender').SlowThemeReRender,
+  SpinnerCustomColors: () => require('./SpinnerCustomColors').SpinnerCustomColors,
+  StackZIndex: () => require('./StackZIndex').StackZIndex,
+  StyledAnchor: () => require('./StyledAnchor').StyledAnchor,
+  StyledButtonAnimationAuto: () =>
+    require('./StyledButtonAnimationAuto').StyledButtonAnimationAuto,
+  StyledButtonTheme: () => require('./StyledButtonTheme').StyledButtonTheme,
+  StyledButtonVariantPseudo: () =>
+    require('./StyledButtonVariantPseudo').StyledButtonVariantPseudo,
+  StyledButtonVariantPseudoMerge: () =>
+    require('./StyledButtonVariantPseudoMerge').StyledButtonVariantPseudoMerge,
+  StyledCheckboxTheme: () => require('./StyledCheckboxTheme').StyledCheckboxTheme,
+  StyledContextColor: () => require('./StyledContextColor').StyledContextColor,
+  StyledContextTokens: () => require('./StyledContextTokens').StyledContextTokens,
+  StyledHOCNamed: () => require('./StyledHOCNamed').StyledHOCNamed,
+  StyledIconColor: () => require('./StyledIconColor').StyledIconColor,
+  StyledInputFocusStyle: () => require('./StyledInputFocusStyle').StyledInputFocusStyle,
+  StyledInputOnFocus: () => require('./StyledInputOnFocus').StyledInputOnFocus,
+  StyledMediaQueryMerge: () => require('./StyledMediaQueryMerge').StyledMediaQueryMerge,
+  StyledOverridePsuedo: () => require('./StyledOverridePsuedo').StyledOverridePsuedo,
+  StyledRNW: () => require('./StyledRNW').StyledRNW,
+  StyledStyleableInputOnFocus: () =>
+    require('./StyledStyleableInputOnFocus').StyledStyleableInputOnFocus,
+  StyledStyleableInputVariant: () =>
+    require('./StyledStyleableInputVariant').StyledStyleableInputVariant,
+  StyledStyledStyleableInputOnFocus: () =>
+    require('./StyledStyledStyleableInputOnFocus').StyledStyledStyleableInputOnFocus,
+  StyledVariantTextColor: () =>
+    require('./StyledVariantTextColor').StyledVariantTextColor,
+  StyledViewOnFocus: () => require('./StyledViewOnFocus').StyledViewOnFocus,
+  StylePlatform: () => require('./StylePlatform').StylePlatform,
+  StyleProp: () => require('./StyleProp').StyleProp,
+  TabsOnInteraction: () => require('./TabsOnInteraction').TabsOnInteraction,
+  TextNestedInheritance: () => require('./TextNestedInheritance').TextNestedInheritance,
+  ThemeChange: () => require('./ThemeChange').ThemeChange,
+  ThemeChangeBasic: () => require('./ThemeChangeBasic').ThemeChangeBasic,
+  ThemeComponentResolution: () =>
+    require('./ThemeComponentResolution').ThemeComponentResolution,
+  ThemeMutation: () => require('./ThemeMutation').ThemeMutation,
+  ThemeNested: () => require('./ThemeNested').ThemeNested,
+  ThemeReset: () => require('./ThemeReset').ThemeReset,
+  ThemeShallowCase: () => require('./ThemeShallowCase').ThemeShallowCase,
+  ToastMultipleCase: () => require('./ToastMultipleCase').ToastMultipleCase,
+  ToastNativeBurntCase: () => require('./ToastNativeBurntCase').ToastNativeBurntCase,
+  ToggleGroupActiveProps: () =>
+    require('./ToggleGroupActiveProps').ToggleGroupActiveProps,
+  TooltipAnimationCase: () => require('./TooltipAnimationCase').TooltipAnimationCase,
+  TooltipCase: () => require('./TooltipCase').TooltipCase,
+  TooltipGroupCase: () => require('./TooltipGroupCase').TooltipGroupCase,
+  TooltipPositionJumpCase: () =>
+    require('./TooltipPositionJumpCase').TooltipPositionJumpCase,
+  TooltipTriggerInlineCase: () =>
+    require('./TooltipTriggerInlineCase').TooltipTriggerInlineCase,
+  TransformMediaQueryMerge: () =>
+    require('./TransformMediaQueryMerge').TransformMediaQueryMerge,
+  UseCases: () => require('./UseCases').UseCases,
+  UseTheme: () => require('./UseTheme').UseTheme,
+  V5ThemeBuilderOutput: () => require('./V5ThemeBuilderOutput').V5ThemeBuilderOutput,
+  VariantFontFamily: () => require('./VariantFontFamily').VariantFontFamily,
+  VariantsOrder: () => require('./VariantsOrder').VariantsOrder,
+  ZIndex: () => require('./ZIndex').ZIndex,
+  NestedPressExclusive: () => require('./NestedPressExclusive').NestedPressExclusive,
+}
+
+export const useCases: Record<string, ComponentType<any>> = {}
+for (const key of Object.keys(loaders)) {
+  Object.defineProperty(useCases, key, {
+    enumerable: true,
+    configurable: true,
+    get: () => loaders[key](),
+  })
+}

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -1,197 +1,270 @@
-// web-only exports - excludes native-only dependencies like:
-// - react-native-keyboard-controller
-// - react-native-actions-sheet
-// - react-native-teleport
+// web-only usecase registry (lazy). excludes native-only deps
+// (react-native-keyboard-controller, react-native-actions-sheet, react-native-teleport).
+// AUTO-SHAPED lazy registry: each usecase module is required (and therefore
+// evaluated) only when its component is first accessed, not when this index loads.
+// Object.keys(useCases) lists names without evaluating any usecase (getters are not
+// invoked by Object.keys); useCases[name] evaluates just that one. This avoids the
+// per-launch eval of every usecase that made Detox app relaunches slow.
+import type { ComponentType } from 'react'
 
-export { AnimatedByProp } from './AnimatedByProp'
-export { AnimatePresenceEnterExitCase } from './AnimatePresenceEnterExitCase'
-export { AnimatePresenceExitTest } from './AnimatePresenceExitTest'
-export { AnimationComprehensiveCase } from './AnimationComprehensiveCase'
-export { RawAnimatedValueCase } from './RawAnimatedValueCase'
-export { AnimationsWithMediaQueriesCase } from './AnimationsWithMediaQueriesCase'
-export { ThemeMediaAnimationCase } from './ThemeMediaAnimationCase'
-export { Benchmark } from './Benchmark'
-export { ButtonCircular } from './ButtonCircular'
-export { ButtonCustom } from './ButtonCustom'
-export { ButtonIconColor } from './ButtonIconColor'
-export { ButtonInverse } from './ButtonInverse'
-export { ButtonUnstyled } from './ButtonUnstyled'
-export { CheckboxDisabledOnPress } from './CheckboxDisabledOnPress'
-export { ClickDuringEnterCase } from './ClickDuringEnterCase'
-export { CodeExamplesInput } from './CodeExamplesInput'
-export { ColorTokenFallback } from './ColorTokenFallback'
-export { CompilerExtraction } from './CompilerExtraction'
-export { CompilerTernaryActive } from './CompilerTernaryActive'
-export { ComplexVariants } from './ComplexVariants'
-export { CrashAdaptSheet } from './CrashAdaptSheet'
-export { CustomStyledAnimatedPopover } from './CustomStyledAnimatedPopover'
-export { CustomStyledAnimatedTooltip } from './CustomStyledAnimatedTooltip'
-export { DriverDisableAnimationPropsCase } from './DriverDisableAnimationPropsCase'
-export { DOMNodeAPIs } from './DOMNodeAPIs'
-export { DialogFocusScopeCase } from './DialogFocusScopeCase'
-export { DialogFocusScopeDebug } from './DialogFocusScopeDebug'
-export { DialogNestedCase } from './DialogNestedCase'
-export { DismissLayerStackingCase } from './DismissLayerStackingCase'
-export { DialogOpenControlled } from './DialogOpenControlled'
-export { DialogPointerEventsCase } from './DialogPointerEventsCase'
-export { DialogScopedCase } from './DialogScopedCase'
-export { DialogSheetAdaptCase } from './DialogSheetAdaptCase'
-export { DialogSheetAdaptResizeCase } from './DialogSheetAdaptResizeCase'
-export { DialogSheetAdaptUnmountCase } from './DialogSheetAdaptUnmountCase'
-export { Example } from './Example'
-export { ExitCompletionCase } from './ExitCompletionCase'
-export { FocusVisibleButton } from './FocusVisibleButton'
-export { FocusVisibleButtonPointer } from './FocusVisibleButtonPointer'
-export { FocusVisibleButtonWithFocusStyle } from './FocusVisibleButtonWithFocusStyle'
-export { FontTokensInVariants } from './FontTokensInVariants'
-export { FocusWithinCase } from './FocusWithinCase'
-export { FormButtonTypeCase } from './FormButtonTypeCase'
-export { GroupHoverMobile } from './GroupHoverMobile'
-export { GroupPressInVariant } from './GroupPressInVariant'
-export { GroupPseudoVariantOverride } from './GroupPseudoVariantOverride'
-export { GroupPressNative } from './GroupPressNative'
-export { GroupPressTransitionMatrix } from './GroupPressTransitionMatrix'
-export { GroupProp } from './GroupProp'
-export { GlobalScopedTriggerIsolationCase } from './GlobalScopedTriggerIsolationCase'
-export { MediaQueryGtMd } from './MediaQueryGtMd'
-export { MediaQueriesV5 } from './MediaQueriesV5'
-export { MenuAboveDialogCase } from './MenuAboveDialogCase'
-export { MenuAnimatePositionCase } from './MenuAnimatePositionCase'
-export { MenuAnimatePositionToggleCase } from './MenuAnimatePositionToggleCase'
-export { MenuAccessibilityCase } from './MenuAccessibilityCase'
-export { MenuItemFocusCase } from './MenuItemFocusCase'
-export { MenuArrowAnimatePresenceCase } from './MenuArrowAnimatePresenceCase'
-export { MenuAsChildPositionCase } from './MenuAsChildPositionCase'
-export { MenuAutoResizeCase } from './MenuAutoResizeCase'
-export { MenuFocusLeaveCase } from './MenuFocusLeaveCase'
-export { MenuHighlightCase } from './MenuHighlightCase'
-export { MenuMultiTriggerCase } from './MenuMultiTriggerCase'
-export { MenuItemPseudoOverrideCase } from './MenuItemPseudoOverrideCase'
-export { MenuBottomCase } from './MenuBottomCase'
-export { MenuOverflowCase } from './MenuOverflowCase'
-export { MenuDismissOnScrollCase } from './MenuDismissOnScrollCase'
-export { MenuRadioGroupCase } from './MenuRadioGroupCase'
-export { MenuSubCase } from './MenuSubCase'
-export { MenuSubNestedPositionCase } from './MenuSubNestedPositionCase'
-export { MenuSubLeftCase } from './MenuSubLeftCase'
-export { MultiDriverAnimation } from './MultiDriverAnimation'
-export { MenuSubStyledCase } from './MenuSubStyledCase'
-export { MenuThemeCase } from './MenuThemeCase'
-export { MenuUnstyledCase } from './MenuUnstyledCase'
-export { GroupUseCases } from './GroupUseCases'
-export { HeightMediaQueryOverrideCase } from './HeightMediaQueryOverrideCase'
-export { ImageTokenStyle } from './ImageTokenStyle'
-export { InputAutoFocusAfterMenuCase } from './InputAutoFocusAfterMenuCase'
-export { InputAutoFocusStyledCase } from './InputAutoFocusStyledCase'
-export { ThemedListItem } from './ListItem'
-export { NewInputBasic } from './NewInputBasic'
-export { OpacityModifierCase } from './OpacityModifierCase'
-export { OnLayoutCase } from './OnLayoutCase'
-export { OnLayoutScaleCase } from './OnLayoutScaleCase'
-export { OnLayoutStressCase } from './OnLayoutStressCase'
-export { NewInputEvents } from './NewInputEvents'
-export { OverlayStyled } from './OverlayStyled'
-export { ParagraphSpanFontInheritance } from './ParagraphSpanFontInheritance'
-export { PlaceholderTextColor } from './PlaceholderTextColor'
-export { PointerEventsCase } from './PointerEventsCase'
-export { ProgressFirstPaint } from './ProgressFirstPaint'
-export { PopoverAdaptSheetUnmountCase } from './PopoverAdaptSheetUnmountCase'
-export { PopoverAndMenuMultiTriggerCase } from './PopoverAndMenuMultiTriggerCase'
-export { PopoverCase, PopoverAnimatePositionCase } from './PopoverCase'
-export {
-  PopoverHoverableDelayCase,
-  PopoverHoverableRestMsCase,
-  PopoverHoverableExitAnimCase,
-  PopoverHoverableSafePolygonCase,
-} from './PopoverHoverableCase'
-export { PopoverHoverableDisableClickCase } from './PopoverHoverableDisableClickCase'
-export { PopoverHoverableScopedCase } from './PopoverHoverableScopedCase'
-export { PopoverHoverableRapidCase } from './PopoverHoverableRapidCase'
-export { PopoverContentStyledPlusAnimations } from './PopoverContentStyledPlusAnimations'
-export { PopoverFocusScopeCase } from './PopoverFocusScopeCase'
-export { PopoverScopedCase } from './PopoverScopedCase'
-export { PopoverTriggerIsolationCase } from './PopoverTriggerIsolationCase'
-export { PressStyleNative } from './PressStyleNative'
-export { PressStyleScrollStuck } from './PressStyleScrollStuck'
-export { PseudoStyleMerge } from './PseudoStyleMerge'
-export { PseudoTransitionCase } from './PseudoTransitionCase'
-export { RemoveScrollCase } from './RemoveScrollCase'
-export { RenderPropCase } from './RenderPropCase'
-export { ScrollViewRefCase } from './ScrollViewRefCase'
-export { SecondPage } from './SecondPage'
-export { SelectAndroidOnPress } from './SelectAndroidOnPress'
-export { SelectFocusScopeCase } from './SelectFocusScopeCase'
-export { SelectRemount } from './SelectRemount'
-export { Shadows } from './Shadows'
-export { ShorthandVariables } from './ShorthandVariables'
-export { SheetAnimationCase } from './SheetAnimationCase'
-export { SheetOnAnimationCompleteCase } from './SheetOnAnimationCompleteCase'
-export { SheetDragCase } from './SheetDragCase'
-export { SheetDragResistCase } from './SheetDragResistCase.web'
-export { SheetScrollableDrag } from './SheetScrollableDrag'
-export { SheetScrollLockCase } from './SheetScrollLockCase'
-export { SheetSnapPointsFitCase } from './SheetSnapPointsFitCase'
-export { SheetWebKeyboardCase } from './SheetWebKeyboardCase'
-export { SheetWebKeyboardAutoFocusCase } from './SheetWebKeyboardAutoFocusCase'
-export { SlowThemeReRender } from './SlowThemeReRender'
-export { SpinnerCustomColors } from './SpinnerCustomColors'
-export { StackZIndex } from './StackZIndex'
-export { StyledAnchor } from './StyledAnchor'
-export { StyledHtmlCase } from './StyledHtmlCase'
-export { StyledButtonAnimationAuto } from './StyledButtonAnimationAuto'
-export { StyledButtonTheme } from './StyledButtonTheme'
-export { StyledButtonVariantPseudo } from './StyledButtonVariantPseudo'
-export { StyledButtonVariantPseudoMerge } from './StyledButtonVariantPseudoMerge'
-export { StyledCheckboxTheme } from './StyledCheckboxTheme'
-export { StyledContextColor } from './StyledContextColor'
-export { StyledContextTokens } from './StyledContextTokens'
-export { StyledHOCNamed } from './StyledHOCNamed'
-export { StyledIconColor } from './StyledIconColor'
-export { StyledInputFocusStyle } from './StyledInputFocusStyle'
-export { StyledInputOnFocus } from './StyledInputOnFocus'
-export { StyledMediaQueryMerge } from './StyledMediaQueryMerge'
-export { StyledOverridePsuedo } from './StyledOverridePsuedo'
-export { StyledRNW } from './StyledRNW'
-export { StyledStyleableInputOnFocus } from './StyledStyleableInputOnFocus'
-export { StyledStyleableInputVariant } from './StyledStyleableInputVariant'
-export { StyledStyledStyleableInputOnFocus } from './StyledStyledStyleableInputOnFocus'
-export { StyledVariantTextColor } from './StyledVariantTextColor'
-export { StyledViewOnFocus } from './StyledViewOnFocus'
-export { StressPage } from './StressPage'
-export { StyleCompatCase } from './StyleCompatCase'
-export { StylePlatform } from './StylePlatform'
-export { StyleProp } from './StyleProp'
-export { TabsOnInteraction } from './TabsOnInteraction'
-export { TextNestedInheritance } from './TextNestedInheritance'
-export { TabHoverAnimationCase } from './TabHoverAnimationCase'
-export { ThemeChange } from './ThemeChange'
-export { ThemeConditionalName } from './ThemeConditionalName'
-export { ThemeChangeBasic } from './ThemeChangeBasic'
-export { ThemeComponentResolution } from './ThemeComponentResolution'
-export { ThemeMutation } from './ThemeMutation'
-export { ThemeNested } from './ThemeNested'
-export { ThemeReset } from './ThemeReset'
-export { ThemeShallowCase } from './ThemeShallowCase'
-// ToastCase removed - uses legacy v1 API
-export { ToastAboveDialogCase } from './ToastAboveDialogCase'
-export { ToastMultipleCase } from './ToastMultipleCase'
-export { ToastNativeNotificationCase } from './ToastNativeNotificationCase'
-export { ToggleGroupActiveProps } from './ToggleGroupActiveProps'
-export { ToggleGroupXGroupCase } from './ToggleGroupXGroupCase'
-export { TooltipAnimationCase } from './TooltipAnimationCase'
-export { TooltipCase } from './TooltipCase'
-export { TooltipGlobalPatternCase } from './TooltipGlobalPatternCase'
-export { TooltipGroupCase } from './TooltipGroupCase'
-export { TooltipPositionJumpCase } from './TooltipPositionJumpCase'
-export { TooltipTriggerInlineCase } from './TooltipTriggerInlineCase'
-export { TooltipMultiTriggerCase } from './TooltipMultiTriggerCase'
-export { TransformMediaQueryMerge } from './TransformMediaQueryMerge'
-export { UseCases } from './UseCases'
-export { NumberOfLinesFontStyles } from './NumberOfLinesFontStyles'
-export { NumberOfLinesMediaQuery } from './NumberOfLinesMediaQuery'
-export { UseTheme } from './UseTheme'
-export { V5ThemeBuilderOutput } from './V5ThemeBuilderOutput'
-export { VariantFontFamily } from './VariantFontFamily'
-export { VariantsOrder } from './VariantsOrder'
-export { ZIndex } from './ZIndex'
-export { NestedPressExclusive } from './NestedPressExclusive'
+const loaders: Record<string, () => ComponentType<any>> = {
+  AnimatedByProp: () => require('./AnimatedByProp').AnimatedByProp,
+  AnimatePresenceEnterExitCase: () =>
+    require('./AnimatePresenceEnterExitCase').AnimatePresenceEnterExitCase,
+  AnimatePresenceExitTest: () =>
+    require('./AnimatePresenceExitTest').AnimatePresenceExitTest,
+  AnimationComprehensiveCase: () =>
+    require('./AnimationComprehensiveCase').AnimationComprehensiveCase,
+  RawAnimatedValueCase: () => require('./RawAnimatedValueCase').RawAnimatedValueCase,
+  AnimationsWithMediaQueriesCase: () =>
+    require('./AnimationsWithMediaQueriesCase').AnimationsWithMediaQueriesCase,
+  ThemeMediaAnimationCase: () =>
+    require('./ThemeMediaAnimationCase').ThemeMediaAnimationCase,
+  Benchmark: () => require('./Benchmark').Benchmark,
+  ButtonCircular: () => require('./ButtonCircular').ButtonCircular,
+  ButtonCustom: () => require('./ButtonCustom').ButtonCustom,
+  ButtonIconColor: () => require('./ButtonIconColor').ButtonIconColor,
+  ButtonInverse: () => require('./ButtonInverse').ButtonInverse,
+  ButtonUnstyled: () => require('./ButtonUnstyled').ButtonUnstyled,
+  CheckboxDisabledOnPress: () =>
+    require('./CheckboxDisabledOnPress').CheckboxDisabledOnPress,
+  ClickDuringEnterCase: () => require('./ClickDuringEnterCase').ClickDuringEnterCase,
+  CodeExamplesInput: () => require('./CodeExamplesInput').CodeExamplesInput,
+  ColorTokenFallback: () => require('./ColorTokenFallback').ColorTokenFallback,
+  CompilerExtraction: () => require('./CompilerExtraction').CompilerExtraction,
+  CompilerTernaryActive: () => require('./CompilerTernaryActive').CompilerTernaryActive,
+  ComplexVariants: () => require('./ComplexVariants').ComplexVariants,
+  CrashAdaptSheet: () => require('./CrashAdaptSheet').CrashAdaptSheet,
+  CustomStyledAnimatedPopover: () =>
+    require('./CustomStyledAnimatedPopover').CustomStyledAnimatedPopover,
+  CustomStyledAnimatedTooltip: () =>
+    require('./CustomStyledAnimatedTooltip').CustomStyledAnimatedTooltip,
+  DriverDisableAnimationPropsCase: () =>
+    require('./DriverDisableAnimationPropsCase').DriverDisableAnimationPropsCase,
+  DOMNodeAPIs: () => require('./DOMNodeAPIs').DOMNodeAPIs,
+  DialogFocusScopeCase: () => require('./DialogFocusScopeCase').DialogFocusScopeCase,
+  DialogFocusScopeDebug: () => require('./DialogFocusScopeDebug').DialogFocusScopeDebug,
+  DialogNestedCase: () => require('./DialogNestedCase').DialogNestedCase,
+  DismissLayerStackingCase: () =>
+    require('./DismissLayerStackingCase').DismissLayerStackingCase,
+  DialogOpenControlled: () => require('./DialogOpenControlled').DialogOpenControlled,
+  DialogPointerEventsCase: () =>
+    require('./DialogPointerEventsCase').DialogPointerEventsCase,
+  DialogScopedCase: () => require('./DialogScopedCase').DialogScopedCase,
+  DialogSheetAdaptCase: () => require('./DialogSheetAdaptCase').DialogSheetAdaptCase,
+  DialogSheetAdaptResizeCase: () =>
+    require('./DialogSheetAdaptResizeCase').DialogSheetAdaptResizeCase,
+  DialogSheetAdaptUnmountCase: () =>
+    require('./DialogSheetAdaptUnmountCase').DialogSheetAdaptUnmountCase,
+  Example: () => require('./Example').Example,
+  ExitCompletionCase: () => require('./ExitCompletionCase').ExitCompletionCase,
+  FocusVisibleButton: () => require('./FocusVisibleButton').FocusVisibleButton,
+  FocusVisibleButtonPointer: () =>
+    require('./FocusVisibleButtonPointer').FocusVisibleButtonPointer,
+  FocusVisibleButtonWithFocusStyle: () =>
+    require('./FocusVisibleButtonWithFocusStyle').FocusVisibleButtonWithFocusStyle,
+  FontTokensInVariants: () => require('./FontTokensInVariants').FontTokensInVariants,
+  FocusWithinCase: () => require('./FocusWithinCase').FocusWithinCase,
+  FormButtonTypeCase: () => require('./FormButtonTypeCase').FormButtonTypeCase,
+  GroupHoverMobile: () => require('./GroupHoverMobile').GroupHoverMobile,
+  GroupPressInVariant: () => require('./GroupPressInVariant').GroupPressInVariant,
+  GroupPseudoVariantOverride: () =>
+    require('./GroupPseudoVariantOverride').GroupPseudoVariantOverride,
+  GroupPressNative: () => require('./GroupPressNative').GroupPressNative,
+  GroupPressTransitionMatrix: () =>
+    require('./GroupPressTransitionMatrix').GroupPressTransitionMatrix,
+  GroupProp: () => require('./GroupProp').GroupProp,
+  GlobalScopedTriggerIsolationCase: () =>
+    require('./GlobalScopedTriggerIsolationCase').GlobalScopedTriggerIsolationCase,
+  MediaQueryGtMd: () => require('./MediaQueryGtMd').MediaQueryGtMd,
+  MediaQueriesV5: () => require('./MediaQueriesV5').MediaQueriesV5,
+  MenuAboveDialogCase: () => require('./MenuAboveDialogCase').MenuAboveDialogCase,
+  MenuAnimatePositionCase: () =>
+    require('./MenuAnimatePositionCase').MenuAnimatePositionCase,
+  MenuAnimatePositionToggleCase: () =>
+    require('./MenuAnimatePositionToggleCase').MenuAnimatePositionToggleCase,
+  MenuAccessibilityCase: () => require('./MenuAccessibilityCase').MenuAccessibilityCase,
+  MenuItemFocusCase: () => require('./MenuItemFocusCase').MenuItemFocusCase,
+  MenuArrowAnimatePresenceCase: () =>
+    require('./MenuArrowAnimatePresenceCase').MenuArrowAnimatePresenceCase,
+  MenuAsChildPositionCase: () =>
+    require('./MenuAsChildPositionCase').MenuAsChildPositionCase,
+  MenuAutoResizeCase: () => require('./MenuAutoResizeCase').MenuAutoResizeCase,
+  MenuFocusLeaveCase: () => require('./MenuFocusLeaveCase').MenuFocusLeaveCase,
+  MenuHighlightCase: () => require('./MenuHighlightCase').MenuHighlightCase,
+  MenuMultiTriggerCase: () => require('./MenuMultiTriggerCase').MenuMultiTriggerCase,
+  MenuItemPseudoOverrideCase: () =>
+    require('./MenuItemPseudoOverrideCase').MenuItemPseudoOverrideCase,
+  MenuBottomCase: () => require('./MenuBottomCase').MenuBottomCase,
+  MenuOverflowCase: () => require('./MenuOverflowCase').MenuOverflowCase,
+  MenuDismissOnScrollCase: () =>
+    require('./MenuDismissOnScrollCase').MenuDismissOnScrollCase,
+  MenuRadioGroupCase: () => require('./MenuRadioGroupCase').MenuRadioGroupCase,
+  MenuSubCase: () => require('./MenuSubCase').MenuSubCase,
+  MenuSubNestedPositionCase: () =>
+    require('./MenuSubNestedPositionCase').MenuSubNestedPositionCase,
+  MenuSubLeftCase: () => require('./MenuSubLeftCase').MenuSubLeftCase,
+  MultiDriverAnimation: () => require('./MultiDriverAnimation').MultiDriverAnimation,
+  MenuSubStyledCase: () => require('./MenuSubStyledCase').MenuSubStyledCase,
+  MenuThemeCase: () => require('./MenuThemeCase').MenuThemeCase,
+  MenuUnstyledCase: () => require('./MenuUnstyledCase').MenuUnstyledCase,
+  GroupUseCases: () => require('./GroupUseCases').GroupUseCases,
+  HeightMediaQueryOverrideCase: () =>
+    require('./HeightMediaQueryOverrideCase').HeightMediaQueryOverrideCase,
+  ImageTokenStyle: () => require('./ImageTokenStyle').ImageTokenStyle,
+  InputAutoFocusAfterMenuCase: () =>
+    require('./InputAutoFocusAfterMenuCase').InputAutoFocusAfterMenuCase,
+  InputAutoFocusStyledCase: () =>
+    require('./InputAutoFocusStyledCase').InputAutoFocusStyledCase,
+  ThemedListItem: () => require('./ListItem').ThemedListItem,
+  NewInputBasic: () => require('./NewInputBasic').NewInputBasic,
+  OpacityModifierCase: () => require('./OpacityModifierCase').OpacityModifierCase,
+  OnLayoutCase: () => require('./OnLayoutCase').OnLayoutCase,
+  OnLayoutScaleCase: () => require('./OnLayoutScaleCase').OnLayoutScaleCase,
+  OnLayoutStressCase: () => require('./OnLayoutStressCase').OnLayoutStressCase,
+  NewInputEvents: () => require('./NewInputEvents').NewInputEvents,
+  OverlayStyled: () => require('./OverlayStyled').OverlayStyled,
+  ParagraphSpanFontInheritance: () =>
+    require('./ParagraphSpanFontInheritance').ParagraphSpanFontInheritance,
+  PlaceholderTextColor: () => require('./PlaceholderTextColor').PlaceholderTextColor,
+  PointerEventsCase: () => require('./PointerEventsCase').PointerEventsCase,
+  ProgressFirstPaint: () => require('./ProgressFirstPaint').ProgressFirstPaint,
+  PopoverAdaptSheetUnmountCase: () =>
+    require('./PopoverAdaptSheetUnmountCase').PopoverAdaptSheetUnmountCase,
+  PopoverAndMenuMultiTriggerCase: () =>
+    require('./PopoverAndMenuMultiTriggerCase').PopoverAndMenuMultiTriggerCase,
+  PopoverCase: () => require('./PopoverCase').PopoverCase,
+  PopoverAnimatePositionCase: () => require('./PopoverCase').PopoverAnimatePositionCase,
+  PopoverHoverableDelayCase: () =>
+    require('./PopoverHoverableCase').PopoverHoverableDelayCase,
+  PopoverHoverableRestMsCase: () =>
+    require('./PopoverHoverableCase').PopoverHoverableRestMsCase,
+  PopoverHoverableExitAnimCase: () =>
+    require('./PopoverHoverableCase').PopoverHoverableExitAnimCase,
+  PopoverHoverableSafePolygonCase: () =>
+    require('./PopoverHoverableCase').PopoverHoverableSafePolygonCase,
+  PopoverHoverableDisableClickCase: () =>
+    require('./PopoverHoverableDisableClickCase').PopoverHoverableDisableClickCase,
+  PopoverHoverableScopedCase: () =>
+    require('./PopoverHoverableScopedCase').PopoverHoverableScopedCase,
+  PopoverHoverableRapidCase: () =>
+    require('./PopoverHoverableRapidCase').PopoverHoverableRapidCase,
+  PopoverContentStyledPlusAnimations: () =>
+    require('./PopoverContentStyledPlusAnimations').PopoverContentStyledPlusAnimations,
+  PopoverFocusScopeCase: () => require('./PopoverFocusScopeCase').PopoverFocusScopeCase,
+  PopoverScopedCase: () => require('./PopoverScopedCase').PopoverScopedCase,
+  PopoverTriggerIsolationCase: () =>
+    require('./PopoverTriggerIsolationCase').PopoverTriggerIsolationCase,
+  PressStyleNative: () => require('./PressStyleNative').PressStyleNative,
+  PressStyleScrollStuck: () => require('./PressStyleScrollStuck').PressStyleScrollStuck,
+  PseudoStyleMerge: () => require('./PseudoStyleMerge').PseudoStyleMerge,
+  PseudoTransitionCase: () => require('./PseudoTransitionCase').PseudoTransitionCase,
+  RemoveScrollCase: () => require('./RemoveScrollCase').RemoveScrollCase,
+  RenderPropCase: () => require('./RenderPropCase').RenderPropCase,
+  ScrollViewRefCase: () => require('./ScrollViewRefCase').ScrollViewRefCase,
+  SecondPage: () => require('./SecondPage').SecondPage,
+  SelectAndroidOnPress: () => require('./SelectAndroidOnPress').SelectAndroidOnPress,
+  SelectFocusScopeCase: () => require('./SelectFocusScopeCase').SelectFocusScopeCase,
+  SelectRemount: () => require('./SelectRemount').SelectRemount,
+  Shadows: () => require('./Shadows').Shadows,
+  ShorthandVariables: () => require('./ShorthandVariables').ShorthandVariables,
+  SheetAnimationCase: () => require('./SheetAnimationCase').SheetAnimationCase,
+  SheetOnAnimationCompleteCase: () =>
+    require('./SheetOnAnimationCompleteCase').SheetOnAnimationCompleteCase,
+  SheetDragCase: () => require('./SheetDragCase').SheetDragCase,
+  SheetDragResistCase: () => require('./SheetDragResistCase.web').SheetDragResistCase,
+  SheetScrollableDrag: () => require('./SheetScrollableDrag').SheetScrollableDrag,
+  SheetScrollLockCase: () => require('./SheetScrollLockCase').SheetScrollLockCase,
+  SheetSnapPointsFitCase: () =>
+    require('./SheetSnapPointsFitCase').SheetSnapPointsFitCase,
+  SheetWebKeyboardCase: () => require('./SheetWebKeyboardCase').SheetWebKeyboardCase,
+  SheetWebKeyboardAutoFocusCase: () =>
+    require('./SheetWebKeyboardAutoFocusCase').SheetWebKeyboardAutoFocusCase,
+  SlowThemeReRender: () => require('./SlowThemeReRender').SlowThemeReRender,
+  SpinnerCustomColors: () => require('./SpinnerCustomColors').SpinnerCustomColors,
+  StackZIndex: () => require('./StackZIndex').StackZIndex,
+  StyledAnchor: () => require('./StyledAnchor').StyledAnchor,
+  StyledHtmlCase: () => require('./StyledHtmlCase').StyledHtmlCase,
+  StyledButtonAnimationAuto: () =>
+    require('./StyledButtonAnimationAuto').StyledButtonAnimationAuto,
+  StyledButtonTheme: () => require('./StyledButtonTheme').StyledButtonTheme,
+  StyledButtonVariantPseudo: () =>
+    require('./StyledButtonVariantPseudo').StyledButtonVariantPseudo,
+  StyledButtonVariantPseudoMerge: () =>
+    require('./StyledButtonVariantPseudoMerge').StyledButtonVariantPseudoMerge,
+  StyledCheckboxTheme: () => require('./StyledCheckboxTheme').StyledCheckboxTheme,
+  StyledContextColor: () => require('./StyledContextColor').StyledContextColor,
+  StyledContextTokens: () => require('./StyledContextTokens').StyledContextTokens,
+  StyledHOCNamed: () => require('./StyledHOCNamed').StyledHOCNamed,
+  StyledIconColor: () => require('./StyledIconColor').StyledIconColor,
+  StyledInputFocusStyle: () => require('./StyledInputFocusStyle').StyledInputFocusStyle,
+  StyledInputOnFocus: () => require('./StyledInputOnFocus').StyledInputOnFocus,
+  StyledMediaQueryMerge: () => require('./StyledMediaQueryMerge').StyledMediaQueryMerge,
+  StyledOverridePsuedo: () => require('./StyledOverridePsuedo').StyledOverridePsuedo,
+  StyledRNW: () => require('./StyledRNW').StyledRNW,
+  StyledStyleableInputOnFocus: () =>
+    require('./StyledStyleableInputOnFocus').StyledStyleableInputOnFocus,
+  StyledStyleableInputVariant: () =>
+    require('./StyledStyleableInputVariant').StyledStyleableInputVariant,
+  StyledStyledStyleableInputOnFocus: () =>
+    require('./StyledStyledStyleableInputOnFocus').StyledStyledStyleableInputOnFocus,
+  StyledVariantTextColor: () =>
+    require('./StyledVariantTextColor').StyledVariantTextColor,
+  StyledViewOnFocus: () => require('./StyledViewOnFocus').StyledViewOnFocus,
+  StressPage: () => require('./StressPage').StressPage,
+  StyleCompatCase: () => require('./StyleCompatCase').StyleCompatCase,
+  StylePlatform: () => require('./StylePlatform').StylePlatform,
+  StyleProp: () => require('./StyleProp').StyleProp,
+  TabsOnInteraction: () => require('./TabsOnInteraction').TabsOnInteraction,
+  TextNestedInheritance: () => require('./TextNestedInheritance').TextNestedInheritance,
+  TabHoverAnimationCase: () => require('./TabHoverAnimationCase').TabHoverAnimationCase,
+  ThemeChange: () => require('./ThemeChange').ThemeChange,
+  ThemeConditionalName: () => require('./ThemeConditionalName').ThemeConditionalName,
+  ThemeChangeBasic: () => require('./ThemeChangeBasic').ThemeChangeBasic,
+  ThemeComponentResolution: () =>
+    require('./ThemeComponentResolution').ThemeComponentResolution,
+  ThemeMutation: () => require('./ThemeMutation').ThemeMutation,
+  ThemeNested: () => require('./ThemeNested').ThemeNested,
+  ThemeReset: () => require('./ThemeReset').ThemeReset,
+  ThemeShallowCase: () => require('./ThemeShallowCase').ThemeShallowCase,
+  ToastAboveDialogCase: () => require('./ToastAboveDialogCase').ToastAboveDialogCase,
+  ToastMultipleCase: () => require('./ToastMultipleCase').ToastMultipleCase,
+  ToastNativeNotificationCase: () =>
+    require('./ToastNativeNotificationCase').ToastNativeNotificationCase,
+  ToggleGroupActiveProps: () =>
+    require('./ToggleGroupActiveProps').ToggleGroupActiveProps,
+  ToggleGroupXGroupCase: () => require('./ToggleGroupXGroupCase').ToggleGroupXGroupCase,
+  TooltipAnimationCase: () => require('./TooltipAnimationCase').TooltipAnimationCase,
+  TooltipCase: () => require('./TooltipCase').TooltipCase,
+  TooltipGlobalPatternCase: () =>
+    require('./TooltipGlobalPatternCase').TooltipGlobalPatternCase,
+  TooltipGroupCase: () => require('./TooltipGroupCase').TooltipGroupCase,
+  TooltipPositionJumpCase: () =>
+    require('./TooltipPositionJumpCase').TooltipPositionJumpCase,
+  TooltipTriggerInlineCase: () =>
+    require('./TooltipTriggerInlineCase').TooltipTriggerInlineCase,
+  TooltipMultiTriggerCase: () =>
+    require('./TooltipMultiTriggerCase').TooltipMultiTriggerCase,
+  TransformMediaQueryMerge: () =>
+    require('./TransformMediaQueryMerge').TransformMediaQueryMerge,
+  UseCases: () => require('./UseCases').UseCases,
+  NumberOfLinesFontStyles: () =>
+    require('./NumberOfLinesFontStyles').NumberOfLinesFontStyles,
+  NumberOfLinesMediaQuery: () =>
+    require('./NumberOfLinesMediaQuery').NumberOfLinesMediaQuery,
+  UseTheme: () => require('./UseTheme').UseTheme,
+  V5ThemeBuilderOutput: () => require('./V5ThemeBuilderOutput').V5ThemeBuilderOutput,
+  VariantFontFamily: () => require('./VariantFontFamily').VariantFontFamily,
+  VariantsOrder: () => require('./VariantsOrder').VariantsOrder,
+  ZIndex: () => require('./ZIndex').ZIndex,
+  NestedPressExclusive: () => require('./NestedPressExclusive').NestedPressExclusive,
+}
+
+export const useCases: Record<string, ComponentType<any>> = {}
+for (const key of Object.keys(loaders)) {
+  Object.defineProperty(useCases, key, {
+    enumerable: true,
+    configurable: true,
+    get: () => loaders[key](),
+  })
+}


### PR DESCRIPTION
Detox iOS speed + reliability work (split out from the combined branch; sheet-library fixes are in #4020).

## What
Every kitchen-sink e2e test now launches **straight into its use case** (`directUseCase` / deep-link remount) instead of `safeReloadApp()` + `navigateToTestCase()` (relaunch → home → quick-nav tap, ~60-90s/test). Plus:
- Lazy-load usecases registry so each launch evals only the navigated case (not all ~190).
- `CompilerExtraction`'s in-test `npx tamagui build` (2-27min, variable) isolated on its own shard; remaining files bin-packed by measured time, with the heavy anchors (`noRngh`, `SheetScrollableDrag`, `PressStyleNative`) on separate shards.
- launch/connect flake recovery + circuit-breaker; `App.native.tsx` directUseCase host.

## Measured (per-file, vs old)
MediaQueryGtMd 215→54s · TabsOnInteraction 277→60s · SelectAndroidOnPress 977→256s · SheetScrollableDrag 1463→732s · CompilerExtraction's build dominates its shard.

On a **healthy runner draw** the 4 shards land ~13-28min (all ≤30); shard 2 hit 22min even on a bad draw.

## Honest caveat
Per-shard wall time still has heavy **iOS Detox infra variance** — launch/connect hangs (~28min) and cold-Metro-bundle (2.6-22min) randomly inflate a shard to 40min+ (same matrix measured 13/28.7/26.4/33.4 one run, 42/22/40/41 the next). Guaranteeing ≤30 every run (and a 3-shard collapse) needs further infra work: pre-warm/cache the Metro bundle, cache the `@tamagui` build output, harden the launch/connect retry. This PR is the conversion + matrix foundation that those build on.