### PR TITLE
fix(sheet): tune mobile sheets and overshoot cover

### DIFF
--- a/code/kitchen-sink/src/usecases/SheetSnapPointsFitCase.tsx
+++ b/code/kitchen-sink/src/usecases/SheetSnapPointsFitCase.tsx
@@ -1,5 +1,21 @@
 import { useState } from 'react'
-import { Adapt, Button, Dialog, Paragraph, Sheet, View, YStack } from 'tamagui'
+import {
+  Adapt,
+  Button,
+  Dialog,
+  Paragraph,
+  Sheet,
+  useWindowDimensions,
+  View,
+  YStack,
+} from 'tamagui'
+
+const sheetTopRadius = {
+  borderTopLeftRadius: 33,
+  borderTopRightRadius: 33,
+  borderBottomRightRadius: 0,
+  borderBottomLeftRadius: 0,
+} as const
 
 /**
  * Test case for Sheet with snapPointsMode="fit" adapted from Dialog
@@ -16,7 +32,141 @@ export function SheetSnapPointsFitCase() {
       <DynamicContentSheet />
       <ScrollViewInFitSheet />
       <TallScrollViewInFitSheet />
+      <Tall3pcDialogAdaptSheet />
     </YStack>
+  )
+}
+
+/**
+ * mirrors the real-world 3PunchConvo "filter by event" composition: a dialog that
+ * adapts to a fit-mode sheet on xs, whose frame owns the fallback background and
+ * wraps the sheet scrollview with absolute decorative layers, a maxHeight,
+ * moveOnKeyboardChange enabled, and content taller than the screen.
+ *
+ * the sheet must size to capped content and scroll. it must not collapse to a
+ * sliver anchored at the bottom edge. regression guard for fit-mode sizing through
+ * the dialog adapt teleport, absolute layers, and consumer maxHeight path.
+ *
+ * note the body below is a plain content-sized stack. a `flex={1}` child here would
+ * collapse the whole sheet: in fit mode the sheet sizes to content, so flex:1
+ * (flex-basis 0) contributes nothing to the intrinsic height and the sheet measures
+ * to ~just the title. that was the original 3pc bug.
+ */
+function Tall3pcDialogAdaptSheet() {
+  const dimensions = useWindowDimensions()
+  const resolvedMaxHeight = Math.round(dimensions.height * 0.86)
+
+  return (
+    <Dialog modal>
+      <Dialog.Trigger asChild>
+        <Button data-testid="repro-3pc-trigger">
+          Open 3pc-style Dialog sheet (tall)
+        </Button>
+      </Dialog.Trigger>
+
+      <Adapt when="xs" platform="web">
+        <Sheet
+          transition="medium"
+          zIndex={250000}
+          modal
+          snapPointsMode="fit"
+          dismissOnSnapToBottom
+          moveOnKeyboardChange
+        >
+          <Sheet.Overlay
+            data-testid="repro-3pc-overlay"
+            bg="$color5"
+            opacity={0.5}
+            enterStyle={{ opacity: 0 }}
+            exitStyle={{ opacity: 0 }}
+          />
+          <Sheet.Frame
+            data-testid="repro-3pc-frame"
+            borderRadius={32}
+            borderBottomRightRadius={0}
+            borderBottomLeftRadius={0}
+            bg="$color2"
+            overflow="hidden"
+          >
+            <YStack
+              {...sheetTopRadius}
+              position="absolute"
+              inset={0}
+              bg="$color12"
+              opacity={0.15}
+              borderWidth={2}
+              borderBottomWidth={0}
+              borderColor="$borderColor"
+            />
+            <View
+              {...sheetTopRadius}
+              position="absolute"
+              inset={0}
+              bg="$color2"
+              opacity={0.5}
+            />
+            <YStack
+              {...sheetTopRadius}
+              position="absolute"
+              inset={0}
+              opacity={0.25}
+              borderWidth={1}
+              borderBottomWidth={0}
+              borderColor="$color12"
+            />
+
+            <Sheet.ScrollView
+              data-testid="repro-3pc-scrollview"
+              maxHeight={resolvedMaxHeight}
+              keyboardShouldPersistTaps="handled"
+            >
+              <YStack gap="$3" padding="$4">
+                <Adapt.Contents />
+              </YStack>
+            </Sheet.ScrollView>
+          </Sheet.Frame>
+        </Sheet>
+      </Adapt>
+
+      <Dialog.Portal>
+        <Dialog.Overlay
+          key="overlay"
+          transition="quick"
+          bg="$color"
+          opacity={0.5}
+          enterStyle={{ opacity: 0 }}
+          exitStyle={{ opacity: 0 }}
+        />
+        <Dialog.Content
+          bordered
+          elevate
+          key="content"
+          transition="quick"
+          enterStyle={{ x: 0, y: -20, opacity: 0, scale: 0.9 }}
+          exitStyle={{ x: 0, y: 10, opacity: 0, scale: 0.95 }}
+          width={400}
+          padding="$6"
+          gap="$4"
+        >
+          <Dialog.Title>Events</Dialog.Title>
+          {/* plain content-sized stack, not flex={1} (see note above) */}
+          <YStack gap="$3" paddingVertical="$2">
+            {Array.from({ length: 40 }).map((_, i) => (
+              <View
+                key={i}
+                data-testid={`repro-3pc-item-${i}`}
+                padding="$3"
+                borderRadius="$3"
+                bg="$background"
+                minHeight={60}
+              >
+                <Paragraph>Event {i + 1} - Fight night card</Paragraph>
+              </View>
+            ))}
+          </YStack>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog>
   )
 }
 

--- a/code/kitchen-sink/tests/SheetSnapPointsFit.animated.test.tsx
+++ b/code/kitchen-sink/tests/SheetSnapPointsFit.animated.test.tsx
@@ -351,6 +351,95 @@ test.describe('Sheet.ScrollView inside snapPointsMode="fit"', () => {
   })
 })
 
+test.describe('Sheet fit-mode through Dialog.Adapt (3pc filter-by-event style)', () => {
+  // mirrors the real 3PunchConvo "filter by event" sheet: a dialog adapting to a
+  // fit-mode sheet on xs, frame with absolute background layers, scrollview given an
+  // explicit consumer maxHeight, moveOnKeyboardChange, content taller than screen.
+  // regression: a flex:1 body collapsed the fit sheet to ~just the title height, so it
+  // hung as a sliver at the bottom edge. with a content-sized body it must fill to the
+  // capped height and scroll.
+  test('tall dialog sheet fills to capped height and scrolls, does not collapse', async ({
+    page,
+  }) => {
+    // xs (maxWidth 660) triggers the dialog sheet adaptation
+    await page.setViewportSize({ width: 400, height: 800 })
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(300)
+
+    const trigger = page.getByTestId('repro-3pc-trigger')
+    const frame = page.getByTestId('repro-3pc-frame')
+    const scrollview = page.getByTestId('repro-3pc-scrollview')
+
+    await expect(trigger).toBeVisible()
+    await trigger.click()
+
+    // the adapted sheet, not the dialog, must render. frame/scrollview only exist
+    // in the Adapt branch, so their visibility confirms we got the sheet.
+    await expect(frame).toBeVisible({ timeout: 5000 })
+    await expect(scrollview).toBeVisible()
+    // let the open spring fully settle (spring drivers take longer than css)
+    await page.waitForTimeout(900)
+
+    const svBox = await scrollview.boundingBox()
+    const viewport = page.viewportSize()
+    expect(svBox).toBeTruthy()
+    expect(viewport).toBeTruthy()
+
+    // regression: must not collapse to a sliver (was ~100px). fills most of the
+    // viewport, capped at the consumer maxHeight (0.86 * height).
+    expect(svBox!.height).toBeGreaterThan(viewport!.height * 0.6)
+    expect(svBox!.height).toBeLessThanOrEqual(Math.round(viewport!.height * 0.86) + 12)
+
+    // and it is actually shown on-screen (not hanging below / off the viewport).
+    // boundingBox stays driver-agnostic; toBeInViewport tolerates sub-pixel
+    // spring settling that a strict bottom-edge pixel check would flake on.
+    await expect(scrollview).toBeInViewport({ ratio: 0.95 })
+
+    const cover = await frame.evaluate((frameEl) => {
+      const frameBox = frameEl.getBoundingClientRect()
+      const covers = Array.from(document.querySelectorAll('[data-sheet-cover]')).map(
+        (el) => {
+          const box = el.getBoundingClientRect()
+          return {
+            backgroundColor: getComputedStyle(el).backgroundColor,
+            height: box.height,
+            topDelta: Math.abs(box.top - frameBox.bottom),
+          }
+        }
+      )
+
+      return (
+        covers.find(
+          (candidate) =>
+            candidate.topDelta <= 2 &&
+            candidate.height >= window.innerHeight &&
+            candidate.backgroundColor !== 'rgba(0, 0, 0, 0)' &&
+            candidate.backgroundColor !== 'transparent'
+        ) ?? null
+      )
+    })
+    expect(cover).toBeTruthy()
+
+    // content is taller than the cap, so it should scroll.
+    const scrolled = await scrollview.evaluate((el) => {
+      let target: Element | null = el
+      while (target && target.scrollHeight <= target.clientHeight) {
+        target = target.firstElementChild
+      }
+      if (!target) return { ok: false, sh: 0, ch: 0 }
+      target.scrollTop = target.scrollHeight
+      return {
+        ok: target.scrollTop > 0,
+        sh: target.scrollHeight,
+        ch: target.clientHeight,
+      }
+    })
+    expect(scrolled.sh).toBeGreaterThan(scrolled.ch)
+    expect(scrolled.ok).toBe(true)
+  })
+})
+
 test.describe('Adapted Dialog Sheet', () => {
   // TODO: This test is flaky in CI - the adaptation may not trigger reliably at 500px
   // The core functionality is tested by other Sheet tests

--- a/code/tamagui.dev/data/docs/components/sheet/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/sheet/2.0.0.mdx
@@ -172,6 +172,16 @@ Displays behind Frame. Extends [YStack](/docs/components/stacks).
 
 Contains the content. Extends [YStack](/docs/components/stacks).
 
+<PropsTable
+  data={[
+    {
+      name: 'disableHideBottomOverflow',
+      type: 'boolean',
+      description: `Disables the default cloned frame cover below the sheet. Leave it omitted or false when a spring can overshoot on open; the cover prevents page content from showing through below the sheet. If your frame uses decorative absolute layers, put the fallback background on Sheet.Frame so the cloned cover can occlude the bottom too.`,
+    },
+  ]}
+/>
+
 ### Sheet.Handle
 
 Shows a handle above the frame by default. On tap, it will cycle between

--- a/code/tamagui.dev/features/site/header/Header.tsx
+++ b/code/tamagui.dev/features/site/header/Header.tsx
@@ -413,7 +413,7 @@ export const HeaderLinksPopover = (props: PopoverProps) => {
       </SlidingPopoverContext.Provider>
 
       <Adapt platform="touch" when="sm">
-        <Sheet transition={'quicker'} zIndex={100000000} modal dismissOnSnapToBottom>
+        <Sheet transition="medium" zIndex={100000000} modal dismissOnSnapToBottom>
           <Sheet.Frame>
             <Sheet.ScrollView showsVerticalScrollIndicator={false}>
               <Adapt.Contents />

--- a/code/tamagui.dev/features/site/header/UpgradeToProPopover.tsx
+++ b/code/tamagui.dev/features/site/header/UpgradeToProPopover.tsx
@@ -77,7 +77,7 @@ export const UpgradeToProPopover = (props: PopoverProps) => {
       </Popover.Anchor>
 
       <Adapt platform="touch" when="maxMd">
-        <Sheet zIndex={100000000} modal dismissOnSnapToBottom>
+        <Sheet zIndex={100000000} modal dismissOnSnapToBottom transition="medium">
           <Sheet.Frame>
             <Sheet.ScrollView>
               <Adapt.Contents />

--- a/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
+++ b/code/tamagui.dev/features/site/purchase/NewPurchaseModal.tsx
@@ -297,7 +297,7 @@ export function PurchaseModalContents() {
         }}
       >
         <Dialog.Adapt when="maxMd">
-          <Sheet modal transition="quick">
+          <Sheet modal dismissOnSnapToBottom transition="medium">
             <Sheet.Frame bg="$color1" p={0} flex={1}>
               <Sheet.ScrollView flex={1}>
                 <Dialog.Adapt.Contents />

--- a/code/ui/sheet/src/SheetImplementationCustom.tsx
+++ b/code/ui/sheet/src/SheetImplementationCustom.tsx
@@ -27,6 +27,7 @@ import { GestureSheetProvider } from './GestureSheetContext'
 import { resisted } from './helpers'
 import { getKeyboardOccludedHeight } from './keyboardAvoidance'
 import {
+  getMaxViewportHeight,
   getStableLayoutViewportHeight,
   getWebKeyboardHeight,
   MIN_KEYBOARD_HEIGHT,
@@ -385,8 +386,17 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
       // use effScreenSize (the frozen anchor space the positions were built in) for
       // the off-screen/close target too, so a close while the keyboard is still up
       // animates fully out instead of to a mismatched live screenSize.
+      //
+      // web: clear the maximum the viewport can ever reveal, not just the current
+      // layout viewport. iOS Safari retracts its chrome on scroll and exposes area
+      // below the current viewport, so a sheet parked at effScreenSize would peek
+      // back in as the page scrolls. getMaxViewportHeight floors the target past
+      // anything Safari can expose.
+      const closeTarget = isWeb
+        ? Math.max(effScreenSize, getMaxViewportHeight())
+        : effScreenSize
       let toValue =
-        isHidden || position === -1 ? effScreenSize : activePositions[position]
+        isHidden || position === -1 ? closeTarget : activePositions[position]
 
       if (at.current === toValue) return
 

--- a/code/ui/sheet/src/createSheet.tsx
+++ b/code/ui/sheet/src/createSheet.tsx
@@ -1,5 +1,5 @@
 import { useComposedRefs } from '@tamagui/compose-refs'
-import { useIsomorphicLayoutEffect } from '@tamagui/constants'
+import { isWeb, useIsomorphicLayoutEffect } from '@tamagui/constants'
 import type {
   GetProps,
   ViewProps,
@@ -25,6 +25,7 @@ import { SheetScrollView } from './SheetScrollView'
 import type { SheetProps, SheetScopedProps } from './types'
 import { useSheetController } from './useSheetController'
 import { useSheetOffscreenSize } from './useSheetOffscreenSize'
+import { getMaxViewportHeight } from './webViewport'
 
 type SharedSheetProps = {
   open?: boolean
@@ -136,9 +137,9 @@ export function createSheet<
 
   type ExtraFrameProps = {
     /**
-     * By default the sheet adds a view below its bottom that extends down another 50%,
-     * this is useful if your Sheet has a spring animation that bounces "past" the top when
-     * opening, preventing it from showing the content underneath.
+     * by default the sheet adds a view below its bottom that extends past the
+     * largest visible viewport height. this covers spring overshoot when opening
+     * so page content never shows through below the sheet.
      */
     disableHideBottomOverflow?: boolean
 
@@ -225,14 +226,25 @@ export function createSheet<
             <Frame
               {...props}
               componentName="SheetCover"
+              data-sheet-cover=""
               children={null}
               // Don't inherit testID - this is a visual helper element
               testID={undefined}
               id={undefined}
               position="absolute"
-              bottom="-100%"
+              // anchor the cover's top at the sheet's bottom edge (top: 100% of the
+              // container), then extend it downward. on web extend it past the
+              // largest viewport safari can reveal as its chrome retracts, so the
+              // sheet background covers the bottom instead of revealing the page.
+              // native keeps frameSize.
+              top="100%"
               zIndex={-1}
-              height={context.frameSize}
+              height={
+                isWeb
+                  ? Math.max(context.frameSize, getMaxViewportHeight())
+                  : context.frameSize
+              }
+              maxHeight={isWeb ? 'none' : undefined}
               left={0}
               right={0}
               borderWidth={0}

--- a/code/ui/sheet/src/webViewport.ts
+++ b/code/ui/sheet/src/webViewport.ts
@@ -41,6 +41,35 @@ export function getStableLayoutViewportHeight(): number {
 }
 
 /**
+ * the largest the visible viewport can ever become on this device.
+ *
+ * iOS Safari grows the visible area as its top/bottom chrome (URL bar, toolbar,
+ * the dynamic bottom safe area) retracts on scroll, so the current layout
+ * viewport — document.documentElement.clientHeight — is not an upper bound: the
+ * chrome can collapse and reveal area BELOW it. A sheet whose hidden/below-fold
+ * region is sized against the current viewport then peeks back into view as the
+ * page scrolls and Safari reveals more.
+ *
+ * So we track a session high-water mark across every measured viewport signal,
+ * floored at the device screen height, so we never under-shoot even before any
+ * chrome collapse has been observed. Used to push hidden/minimized sheet content
+ * fully past the maximum the viewport could ever expose.
+ */
+let _maxViewportHeight = 0
+export function getMaxViewportHeight(): number {
+  if (typeof window === 'undefined') return 0
+  const ch = typeof document !== 'undefined' ? document.documentElement?.clientHeight : 0
+  _maxViewportHeight = Math.max(
+    _maxViewportHeight,
+    ch || 0,
+    window.innerHeight || 0,
+    window.visualViewport?.height || 0,
+    window.screen?.height || 0
+  )
+  return _maxViewportHeight
+}
+
+/**
  * Soft-keyboard height = the occluded region between the (stable) layout
  * viewport bottom and the visual viewport bottom.
  */

--- a/code/ui/sheet/types/createSheet.d.ts
+++ b/code/ui/sheet/types/createSheet.d.ts
@@ -46,9 +46,9 @@ export declare function createSheet<H extends TamaguiComponent | SheetStyledComp
     Controlled: FunctionComponent<Omit<SheetProps, "open" | "onOpenChange"> & RefAttributes<RNView>> & {
         Frame: ForwardRefExoticComponent<SheetScopedProps<Omit<GetProps<F>, keyof {
             /**
-             * By default the sheet adds a view below its bottom that extends down another 50%,
-             * this is useful if your Sheet has a spring animation that bounces "past" the top when
-             * opening, preventing it from showing the content underneath.
+             * by default the sheet adds a view below its bottom that extends past the
+             * largest visible viewport height. this covers spring overshoot when opening
+             * so page content never shows through below the sheet.
              */
             disableHideBottomOverflow?: boolean;
             /**
@@ -59,9 +59,9 @@ export declare function createSheet<H extends TamaguiComponent | SheetStyledComp
             adjustPaddingForOffscreenContent?: boolean;
         }> & {
             /**
-             * By default the sheet adds a view below its bottom that extends down another 50%,
-             * this is useful if your Sheet has a spring animation that bounces "past" the top when
-             * opening, preventing it from showing the content underneath.
+             * by default the sheet adds a view below its bottom that extends past the
+             * largest visible viewport height. this covers spring overshoot when opening
+             * so page content never shows through below the sheet.
              */
             disableHideBottomOverflow?: boolean;
             /**
@@ -119,9 +119,9 @@ export declare function createSheet<H extends TamaguiComponent | SheetStyledComp
     };
     Frame: ForwardRefExoticComponent<SheetScopedProps<Omit<GetProps<F>, keyof {
         /**
-         * By default the sheet adds a view below its bottom that extends down another 50%,
-         * this is useful if your Sheet has a spring animation that bounces "past" the top when
-         * opening, preventing it from showing the content underneath.
+         * by default the sheet adds a view below its bottom that extends past the
+         * largest visible viewport height. this covers spring overshoot when opening
+         * so page content never shows through below the sheet.
          */
         disableHideBottomOverflow?: boolean;
         /**
@@ -132,9 +132,9 @@ export declare function createSheet<H extends TamaguiComponent | SheetStyledComp
         adjustPaddingForOffscreenContent?: boolean;
     }> & {
         /**
-         * By default the sheet adds a view below its bottom that extends down another 50%,
-         * this is useful if your Sheet has a spring animation that bounces "past" the top when
-         * opening, preventing it from showing the content underneath.
+         * by default the sheet adds a view below its bottom that extends past the
+         * largest visible viewport height. this covers spring overshoot when opening
+         * so page content never shows through below the sheet.
          */
         disableHideBottomOverflow?: boolean;
         /**

--- a/code/ui/sheet/types/webViewport.d.ts
+++ b/code/ui/sheet/types/webViewport.d.ts
@@ -22,6 +22,7 @@ export declare function isEditableElement(el: Element | null): boolean;
  * visualViewport), so it stays constant while the keyboard animates in/out.
  */
 export declare function getStableLayoutViewportHeight(): number;
+export declare function getMaxViewportHeight(): number;
 /**
  * Soft-keyboard height = the occluded region between the (stable) layout
  * viewport bottom and the visual viewport bottom.


### PR DESCRIPTION
## Summary

- slow the tamagui.dev mobile menu and Pro adapted sheets to `transition="medium"`
- restore swipe-to-dismiss on the mobile Pro purchase sheet with `dismissOnSnapToBottom`
- extend the web sheet bottom cover past the max visible viewport and prevent maxHeight from clamping it, so spring overshoot stays occluded
- add a 3pc-style Dialog.Adapt kitchen-sink repro/test and document the background-cover pattern for `disableHideBottomOverflow`

## Tests

- `bun run build` in `code/ui/sheet`
- `./node_modules/.bin/turbo run build --filter=@tamagui/kitchen-sink... --concurrency=8` to prepare the clean worktree package graph
- `PORT=9012 NODE_ENV=test TAMAGUI_TEST_ANIMATION_DRIVER=motion node -r esbuild-register ../../node_modules/.bin/playwright test --config ./playwright.config.ts tests/SheetSnapPointsFit.animated.test.tsx --project=animated-motion` (13 passed, 1 skipped)
- `bun run build:prod` in `code/tamagui.dev` (passes; existing non-fatal extractor/chunk warnings and dummy Postmark token scan warning)
- Playwright mobile flow against `http://localhost:8082/`: main menu sheet opens, Pro sheet opens, downward touch drag closes it; screenshots saved to `/tmp/tamagui-dev-worktree-main-menu-open.png`, `/tmp/tamagui-dev-worktree-pro-sheet-open.png`, `/tmp/tamagui-dev-worktree-pro-sheet-after-drag.png`
