### PR TITLE
fix(select): resolve Select.Viewport elevate variant so it stops leaking to the DOM

### DIFF
--- a/code/core/core-test/selectViewportElevate.web.test.tsx
+++ b/code/core/core-test/selectViewportElevate.web.test.tsx
@@ -1,0 +1,70 @@
+process.env.TAMAGUI_TARGET = 'web'
+
+import { SelectViewportFrame } from '../../ui/select/src/SelectViewport'
+import { beforeAll, describe, expect, test } from 'vitest'
+
+import config from '../config-default'
+import {
+  StyleObjectProperty,
+  StyleObjectValue,
+  createTamagui,
+  getConfig,
+} from '../web/src'
+import { simplifiedGetSplitStyles } from './utils'
+
+let lightTheme: any
+
+beforeAll(() => {
+  // @ts-ignore
+  createTamagui(config.getDefaultTamaguiConfig())
+  lightTheme = getConfig().themes.light
+})
+
+function findRuleValue(rulesToInsert: Record<string, any>, property: string): any {
+  for (const rule of Object.values(rulesToInsert)) {
+    if (rule[StyleObjectProperty] === property) {
+      return rule[StyleObjectValue]
+    }
+  }
+  return undefined
+}
+
+// Regression for #3952: the styled() `unstyled: false` variant emits
+// `elevate: true`. Because SelectViewportFrame extends YStack (which has no
+// `elevate` variant), that value used to leak to the DOM as elevate="true"
+// (React "non-boolean attribute" warning) and the shadow was never applied.
+describe('Select.Viewport elevate resolution (#3952)', () => {
+  test('does not leak `elevate` to the DOM (styled default)', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      SelectViewportFrame,
+      { unstyled: false },
+      { theme: lightTheme, themeName: 'light' }
+    )
+    expect(viewProps.elevate).toBeUndefined()
+  })
+
+  test('resolves `elevate` to a boxShadow style', () => {
+    // SelectViewport always renders the frame with a `size` (size={itemContext.size}),
+    // which getElevation uses to compute the shadow offset/radius. A shadowColor is
+    // supplied so the offset/radius collapse into a concrete boxShadow rule on web
+    // (the default test theme has no shadowColor of its own).
+    const { rulesToInsert } = simplifiedGetSplitStyles(
+      SelectViewportFrame,
+      { unstyled: false, size: '$2', shadowColor: 'red' },
+      { theme: lightTheme, themeName: 'light' }
+    )
+    // If elevate never resolved (the #3952 bug), there would be no boxShadow rule
+    // at all. The geometry (0px 8px 16px) comes straight from getElevation('$2').
+    const boxShadow = findRuleValue(rulesToInsert, 'boxShadow')
+    expect(boxShadow).toBe('0px 8px 16px red')
+  })
+
+  test('does not leak `elevate` when unstyled', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      SelectViewportFrame,
+      { unstyled: true },
+      { theme: lightTheme, themeName: 'light' }
+    )
+    expect(viewProps.elevate).toBeUndefined()
+  })
+})

--- a/code/ui/select/src/SelectViewport.tsx
+++ b/code/ui/select/src/SelectViewport.tsx
@@ -4,7 +4,7 @@ import { useComposedRefs } from '@tamagui/compose-refs'
 import { isWeb, useIsomorphicLayoutEffect } from '@tamagui/constants'
 import { styled } from '@tamagui/core'
 import { needsPortalRepropagation } from '@tamagui/portal'
-import { YStack } from '@tamagui/stacks'
+import { YStack, getElevation } from '@tamagui/stacks'
 import { startTransition } from '@tamagui/start-transition'
 import * as React from 'react'
 import { VIEWPORT_NAME } from './constants'
@@ -31,6 +31,16 @@ export const SelectViewportFrame = styled(YStack, {
         bordered: true,
         userSelect: 'none',
         outlineWidth: 0,
+      },
+    },
+
+    // YStack has no `elevate` variant, so `elevate: true` emitted by the
+    // `unstyled: false` variant above would otherwise leak to the DOM instead
+    // of resolving to shadow styles. Define it here (matching ThemeableStack)
+    // so it expands through getElevation using the frame's `size`.
+    elevate: {
+      true: (_: boolean, extras: any) => {
+        return getElevation(extras.props['size'], extras) as any
       },
     },
 


### PR DESCRIPTION
Fixes #3952.

`SelectViewportFrame` extends `YStack`, which has no `elevate` variant. Its `unstyled: false` variant emits `elevate: true`, but because `YStack` cannot expand it, the value fell through to the DOM as `elevate="true"`. On web/Next.js that triggers React's "Received `true` for a non-boolean attribute `elevate`" warning on every open, and the elevation shadow was never applied (`getElevation` never ran).

This adds an `elevate` variant directly to `SelectViewportFrame` so the value resolves to shadow styles, the same way `ThemeableStack` and `SizableStack` wire it up. It mirrors the variant-cascade fixes from rc.20/rc.21 (`animatedBy`, `marginLeft`, `unstyled`).

After the change, `elevate` no longer reaches the DOM and the viewport gets its box-shadow.

I added a regression test in `code/core/core-test/selectViewportElevate.web.test.tsx` that runs the frame through `getSplitStyles` and checks:
- `elevate` is not present on the resulting view props (styled and unstyled)
- the resolved styles include the expected `boxShadow`

Tests pass, and `bun run turbo run build --filter=@tamagui/select` builds clean (types included). Lint and format pass on the changed files.

Note: while here I noticed `bordered: true` from the same `unstyled: false` block leaks to the DOM in the same way. I left that out to keep this PR focused on #3952, but happy to follow up on it.
