### PR TITLE
fix(build): deterministically specify .native.js for native ESM imports

### DIFF
--- a/code/packages/build/tamagui-build.js
+++ b/code/packages/build/tamagui-build.js
@@ -1387,6 +1387,7 @@ async function esbuildWriteIfChanged(
                 {
                   esExtensionDefault: platform === 'native' ? '.native.js' : '.mjs',
                   esExtensions: platform === 'native' ? ['.js'] : ['.mjs'],
+                  tryExtensions: platform === 'native' ? ['.native.js', '.js'] : ['.js'],
                 },
               ],
             ].filter(Boolean),


### PR DESCRIPTION
## Summary

`@tamagui/build` intermittently emits **bare relative imports in native ESM output** for any package that has a hand-authored `.native.ts` platform split. The bad output looks like:

```js
// dist/esm/index.native.js  (WRONG)
import { getWindowSize, subscribe } from "./helpers";        // should be "./helpers.native.js"
```

Under Metro's package-exports resolution (the Expo SDK 56 default, `unstable_enablePackageExports: true`) with a `"type": "module"` package, that bare `./helpers` resolves to the **web** sibling (`helpers.mjs`) on native. For `@tamagui/use-window-dimensions` the web helper reads `window.document.documentElement`, so it crashes at startup on React Native:

```
TypeError: Cannot read property 'documentElement' of undefined
```

It is **non-deterministic** — the same source compiles correctly most of the time and incorrectly sometimes, which is why a given published version may or may not be affected. `use-window-dimensions@2.3.1` shipped broken; `2.2.0` shipped fine; the source is byte-identical between them.

## Root cause — a build-time race

`esbuildWriteIfChanged` runs `babel-plugin-fully-specified` to add extensions. It decides whether to append an extension by checking the filesystem, but only passes `esExtensions` — not `tryExtensions` — so the existence check defaults to `['.js']`:

```js
{
  esExtensionDefault: platform === 'native' ? '.native.js' : '.mjs',
  esExtensions:       platform === 'native' ? ['.js']      : ['.mjs'],
  // tryExtensions defaults to ['.js']
}
```

For a platform-split module, the **native** pass writes its output as `helpers.native.js` (and deliberately skips the plain `helpers.js` — "if native exists, avoid outputting non-native"). So the `existsSync(helpers.js)` check never matches the native pass's own output. It only passes if the **web** pass has already written `helpers.js` into the shared `dist/esm` dir.

The four esbuild passes (cjs/esm × web/native) run concurrently in a single `Promise.all`, all writing to the same dir. So whether `helpers.js` exists when the native pass runs its check is a race between the native and web passes:

- web pass wins → `helpers.js` present → `./helpers.native.js` ✅
- native pass wins → bare `./helpers` ❌

Single-source modules (no `.native.ts`) are affected too — e.g. `./initialValue` was only resolving correctly because it relied on the web pass's `initialValue.js`.

### Reproduction (deterministic demonstration of the race)

Building `@tamagui/use-window-dimensions` from a clean checkout, 12 identical runs:

```
12 clean builds → 4 BROKEN (bare ./helpers) / 8 correct (./helpers.native.js)
```

(esbuild version makes no difference — reproduced on both 0.27.4 and 0.28.1.)

## The fix

Make the native pass look for its **own** output (`*.native.js`, written and awaited before the specify step — exactly what the "write first so we can find them" comment intends) instead of the racing web pass's `.js`:

```js
tryExtensions: platform === 'native' ? ['.native.js', '.js'] : ['.js'],
```

This makes resolution self-contained and deterministic regardless of pass ordering, without sacrificing the parallel build.

### Verification

With the fix, 12 identical builds → **12/12 correct**, and all targets resolve properly:

```
native esm → import ... from "./helpers.native.js"
web    esm → import ... from "./helpers.mjs"
cjs native → require("./helpers.native.js")
```

It also makes the previously-lucky single-source imports (e.g. `./initialValue`) deterministic.

## Impact

Any consumer on Metro package-exports resolution a build that landed on the wrong side of the race. The crash surfaced via `@tamagui/use-window-dimensions`, but the same latent race affects every platform-split module across `@tamagui/*` (incl. `@tamagui/core`, `@tamagui/web`); they happen to win the race in current published artifacts.
