### PR TITLE
test: update webpack styleExpansions snapshot for inset atomic expansion

### DIFF
--- a/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
@@ -228,13 +228,13 @@ exports[`webpack-tests > 8. styleExpansions 1`] = `
         class="_dsp_contents  font_body"
       >
         <div
-          class="is_View _fd-column _pos-relative _inset-0px"
+          class="is_View _fd-column _pos-relative _t-0px _r-0px _b-0px _l-0px"
         >
           <div
             class="is_View _fd-column _bg-red"
           >
             <div
-              class="is_View _fd-column _pos-relative _inset-0px _bg-white _col-blue"
+              class="is_View _fd-column _pos-relative _t-0px _r-0px _b-0px _l-0px _bg-white _col-blue"
             />
           </div>
         </div>


### PR DESCRIPTION
## What

Regenerates the stale `webpack.test.tsx > 8. styleExpansions` snapshot. After 7fcf4cdd31 (`fix(core): expand inset and block-axis logical props on web for atomic CSS correctness`), `inset: 0` / `fullscreen` now emits four atomic classes (`_t-0px _r-0px _b-0px _l-0px`) instead of a single `_inset-0px`. The snapshot wasn't regenerated, so the **Checks** job has been failing on `main` ever since.

## Diff

```
-class="is_View _fd-column _pos-relative _inset-0px"
+class="is_View _fd-column _pos-relative _t-0px _r-0px _b-0px _l-0px"
```

Verified locally: `bun run test:webpack` → 18 passed. Diff is exactly the inset expansion, nothing else.

Unblocks a green `main` for the patch release.