### PR TITLE
ci: fix Detox applesimutils install (Homebrew untrusted-tap)

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -141,6 +141,9 @@ jobs:
 
       - name: Install tooling
         if: env.SKIP_IOS_TESTS != 'true'
+        env:
+          # homebrew now refuses third-party taps non-interactively; allow wix/brew (applesimutils)
+          HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
         run: |
           npm install -g detox-cli &
           detox_pid=$!

--- a/next.md
+++ b/next.md
@@ -383,6 +383,8 @@ $gtSm: false,
 
   - we may want Sheet to have its own removeScroll in this case
 
+- adapt nested-ScrollView problem: when a Dialog adapts to a Sheet, the Sheet already wraps contents in Sheet.ScrollView, so any inner ScrollView the consumer renders (e.g. DialogBody's `scrollable`) double-nests and content overscrolls while the sheet drags. right now dialog.tsx hand-detects `$xs` and skips its own ScrollView - that's a leaky workaround. need something better: either Adapt automatically unwraps/flattens a redundant ScrollView when adapting, or a documented pattern (e.g. a context flag the adapted child reads to know "a Sheet.ScrollView already owns scrolling, don't add one")
+
 - AnimatePresence should just work if you change the enterStyle exitStyle dynamically in the render, no need for custom we can capture the props
 
 - popover transform origin


### PR DESCRIPTION
## Problem

All 4 iOS Detox shards have failed on the last 3 `main` runs (since 2026-06-26) at the tooling-install step:

```
##[error]Refusing to load formula wix/brew/applesimutils from untrusted tap wix/brew.
##[error]Process completed with exit code 1.
```

This is a Homebrew policy change — it now refuses to load formulae from third-party taps non-interactively. Not caused by any pushed code (the failing commits include doc-only pushes like `next.md`).

## Fix

Set `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` on the `Install tooling` step so `brew tap wix/brew` / `brew install applesimutils` work non-interactively.

The `brew trust --formula` alternative has a version-dependent `Invalid usage` CLI bug ([Homebrew/brew#22685](https://github.com/homebrew/brew/issues/22685)), so the env var is the reliable single-path fix.