### PR TITLE
fix(sheet): freeze native fit sheet viewport when keyboard opens

### DIFF
--- a/code/kitchen-sink/e2e/SheetKeyboardFitContent.test.ts
+++ b/code/kitchen-sink/e2e/SheetKeyboardFitContent.test.ts
@@ -1,5 +1,6 @@
 import { by, device, element, expect, waitFor } from 'detox'
 import { safeLaunchApp, withSync } from './utils/detox'
+import { remountDirectUseCase } from './utils/navigation'
 
 const isAndroid = () => device.getPlatform() === 'android'
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
@@ -12,6 +13,15 @@ describe('SheetKeyboardFitContent', () => {
       launchArgs: { directUseCase: 'SheetKeyboardFitContentCase' },
     })
     await waitForSheetKeyboardFitContent()
+  })
+
+  // remount per test (launch once, deep-link remount) so a failed attempt that
+  // leaves the sheet open can't occlude the trigger on the jest retry - without
+  // this, any real failure cascades into a misleading "trigger not hittable".
+  beforeEach(async () => {
+    if (isAndroid()) return
+    await remountDirectUseCase('sheet-kb-fit-screen')
+    await device.disableSynchronization()
   })
 
   it('keeps fit Sheet.ScrollView stable through keyboard open, close, and scroll', async () => {

--- a/code/ui/sheet/src/SheetImplementationCustom.tsx
+++ b/code/ui/sheet/src/SheetImplementationCustom.tsx
@@ -207,6 +207,26 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
     // height would mismatch).
     const isWebKbSheet = isWeb && hasFit && moveOnKeyboardChange
 
+    // NATIVE keyboard frame freeze. native fit sheets feed keyboardOccludedHeight
+    // into the ScrollView as scrollable tail padding so content can clear the
+    // keyboard. but that padding grows the fit content, which grows the frame,
+    // which grows the occluded height — a feedback loop that balloons the sheet
+    // to the full-screen cap. web breaks the loop by freezing geometry against
+    // effScreenSize; native has no such freeze, so we pin the ScrollView to the
+    // frame height measured while the keyboard was closed (preKeyboardFrameSize)
+    // via keyboardStableFrameHeight below. unlike web, the native keyboard is an
+    // overlay that never shrinks the measured screen, so screenSize stays live.
+    const isNativeKbFitSheet = !isWeb && hasFit && Boolean(moveOnKeyboardChange)
+
+    // snapshot the fit frame height while the keyboard is closed, so the pin above
+    // holds the pre-keyboard viewport rather than a mid-feedback-loop value.
+    const preKeyboardFrameSize = React.useRef(0)
+    React.useEffect(() => {
+      if (isNativeKbFitSheet && open && !isKeyboardVisible && frameSize > 0) {
+        preKeyboardFrameSize.current = frameSize
+      }
+    }, [isNativeKbFitSheet, open, isKeyboardVisible, frameSize])
+
     // the space the snap positions are built against. WEB: the stable layout
     // viewport (document.documentElement.clientHeight), which the soft keyboard
     // never shrinks (unlike the measured screenSize / visualViewport). NATIVE:
@@ -307,7 +327,11 @@ export const SheetImplementationCustom = React.forwardRef<View, SheetProps>(
     // smaller; this override keeps it at the full height so the frame translates
     // with the keyboard but never resizes. 0 = no override (use the consumer maxHeight).
     const keyboardStableFrameHeight =
-      isWebKbSheet && isKeyboardVisible && frameSize > 0 ? frameSize : 0
+      isWebKbSheet && isKeyboardVisible && frameSize > 0
+        ? frameSize
+        : isNativeKbFitSheet && isKeyboardVisible && preKeyboardFrameSize.current > 0
+          ? preKeyboardFrameSize.current
+          : 0
 
     const { useAnimatedNumber, useAnimatedNumberStyle } = animationDriver
     const AnimatedView = (animationDriver.View ?? TamaguiView) as typeof Animated.View


### PR DESCRIPTION
## Problem

iOS Detox shard 4/4 was red on `SheetKeyboardFitContent.test.ts` (keeping main's Native Tests workflow red for multiple runs). Two distinct issues, both reproduced locally on the sim:

### 1. Native fit viewport feedback loop (the real bug)
`feat(sheet): preserve fit scroll viewport on keyboard` pinned the fit ScrollView height only on **web** (`isWebKbSheet = isWeb && hasFit && moveOnKeyboardChange`). On native there was no pin, so when the keyboard opened, the `keyboardOccludedHeight` tail-padding grew the fit content → grew the frame → grew the occluded height → more padding… a runaway loop that ballooned the sheet to the full-screen cap.

Runtime trace from the sim:
```
kbVis=false: frameSize=651 occluded=0
kbVis=true:  frameSize=651 occluded=166  ← padding(166) added
             frameSize=817 occluded=332  ← content→frame→occluded grew
             frameSize=852 occluded=367  ← hit screen cap → reads 852 (expected 651)
```

**Fix:** snapshot the fit frame height while the keyboard is closed (`preKeyboardFrameSize`) and pin the native ScrollView to it when the keyboard opens, mirroring the web freeze. The web path is unchanged (the new branch is gated `!isWeb`).

### 2. Missing test isolation (the misleading error)
The test lacked the `beforeEach(remountDirectUseCase(...))` every sibling Sheet test has. When the real assertion failed and left the sheet open, the jest retry couldn't tap the now-occluded trigger and reported a confusing "trigger not hittable" error, masking the actual failure. Added the per-test remount (launch-once + deep-link remount, no relaunch flake).

## Validation (local iOS sim)
- Reproduced `expected 651, got 852`, then **green** after the fix (single attempt, no cascade)
- Sheet unit tests 15/15 · tsc clean · oxlint + oxfmt clean
- **Web sheet keyboard tests 13/13 pass** — no web regression