### PR TITLE
fix(core): drop "unset" style value on native instead of crashing

### DIFF
--- a/code/core/core-test/getSplitStyles.native.test.tsx
+++ b/code/core/core-test/getSplitStyles.native.test.tsx
@@ -318,6 +318,20 @@ describe('getSplitStyles', () => {
       expect(resultStr).toContain('blue')
     }
   })
+
+  test('drops "unset" on native instead of passing it to RN style', () => {
+    // React Native rejects CSS-wide keywords — aspectRatio throws on "unset".
+    // propMapper should drop "unset" so the prop falls back to its default.
+    expect(() =>
+      getSplitStylesFor({ aspectRatio: 'unset', backgroundColor: 'unset' })
+    ).not.toThrow()
+    const { style } = getSplitStylesFor({
+      aspectRatio: 'unset',
+      backgroundColor: 'unset',
+    })
+    expect(style?.aspectRatio).toBeUndefined()
+    expect(style?.backgroundColor).toBeUndefined()
+  })
 })
 
 describe.skip('getSplitStyles - pseudo prop merging', () => {

--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -43,6 +43,14 @@ export const propMapper: PropMapper = (key, value, styleState, disabled, map) =>
   const { conf, styleProps, staticConfig } = styleState
   const { variants } = staticConfig
 
+  // "unset" is a CSS-wide keyword: valid CSS on web, but React Native
+  // style props reject it (e.g. aspectRatio throws "must be a number, a
+  // ratio string or `auto`"). Drop it on native so the prop falls back to
+  // its initial value instead of crashing.
+  if (process.env.TAMAGUI_TARGET === 'native' && value === 'unset') {
+    return
+  }
+
   if (!styleProps.noExpand) {
     if (variants && key in variants) {
       const variantValue = resolveVariants(key, value, styleProps, styleState, '')


### PR DESCRIPTION
## Description

The undocumented `unset` style value was removed in 86d0cfe9 (`chore: remove undocumented unset style value`). Style prop types still accept CSS-wide keywords, and on **web** `unset` is valid CSS, so `aspectRatio="unset"` / `backgroundColor="unset"` render fine. On **native**, `propMapper` now passes `unset` straight to the React Native style and RN throws on strict props:

```tsx
<View aspectRatio="unset" />
// → aspectRatio must either be a number, a ratio string or `auto`. You passed: unset
```

So a value the web side accepts is a hard redbox on native — a web/native parity gap rather than intended behavior.

## Solution

Guarded by `process.env.TAMAGUI_TARGET === 'native'`, `propMapper` drops a prop whose value is `"unset"`, so it falls back to the property's initial value — the same result `unset` produces on web. Web is unchanged. This isn't restoring the removed `unset` feature, only stopping native from crashing on a value the web types still accept.

**Open question:** the other CSS-wide keywords (`initial`, `inherit`, `revert`, `revert-layer`) are likewise invalid in RN style props. I scoped this to `unset` to match the reported crash — happy to widen the guard to the full set if you'd prefer.

## Test plan

Added to `code/core/core-test/getSplitStyles.native.test.tsx`: asserts `aspectRatio: 'unset'` / `backgroundColor: 'unset'` no longer throw and are dropped from the resolved native style.
