### PR TITLE
site: record post-deploy supabase migration (og-storage lockdown + search_path)

### DIFF
--- a/code/tamagui.dev/supabase/migrations/20260630000003_storage_upload_lockdown_and_search_path.sql
+++ b/code/tamagui.dev/supabase/migrations/20260630000003_storage_upload_lockdown_and_search_path.sql
@@ -1,0 +1,23 @@
+-- security incident remediation, part 3 (2026-06-30) -- POST-DEPLOY
+--
+-- apply ONLY after the PR that switches theme/open-graph+api.tsx to the service
+-- role is live. before that, the OG route uploads with the anon client and
+-- relies on the public "Theme Image Upload" INSERT policy; dropping it earlier
+-- would make OG-image cache writes fail (non-fatal, but avoidable).
+
+-- H2: the theme-og-images storage bucket allowed ANY holder of the public anon
+-- key to upload arbitrary files into tamagui's CDN bucket (the "Theme Image
+-- Upload" policy was `to public with check (bucket_id = 'theme-og-images')`,
+-- no auth, no mime/size limit). open-graph now uploads via the service role
+-- (which bypasses storage RLS), so drop the public INSERT policy and constrain
+-- the bucket to small PNGs. the bucket stays public-READ so OG cards still load.
+drop policy if exists "Theme Image Upload" on storage.objects;
+update storage.buckets
+  set allowed_mime_types = array['image/png'],
+      file_size_limit = 2097152  -- 2 MB
+  where id = 'theme-og-images';
+
+-- M1: pin search_path on the SECURITY DEFINER signup trigger so a shadowing
+-- object planted earlier in the path can't hijack it. all references inside the
+-- function are already schema-qualified (public.users), so '' is safe.
+alter function public.handle_new_user() set search_path = '';


### PR DESCRIPTION
Captures the post-deploy half of the 2026-06-30 RLS remediation as a version-controlled migration (it previously lived only in an ephemeral scratchpad). **Already applied to prod and verified** after PR #4054 deployed:

- **H2** — the \`theme-og-images\` storage bucket let anyone with the public anon key upload arbitrary files to the CDN. Dropped the public \`"Theme Image Upload"\` INSERT policy and constrained the bucket to \`image/png\` / 2 MB (still public-READ so OG cards load). \`open-graph\` uploads via the service role, so legit uploads are unaffected. Verified: anon upload now returns \`403 new row violates row-level security policy\`.
- **M1** — pinned \`search_path = ''\` on the \`SECURITY DEFINER\` \`handle_new_user\` signup trigger.

The H1 theme-read lockdown ships in PR #4054's migration \`20260630000002\`. This migration is post-deploy (apply after the service-role \`open-graph\` change is live).

Note: prod's \`supabase_migrations.schema_migrations\` history is empty — these migrations were applied via direct SQL, so the migrations folder is a record, not an auto-applied source.