### PR TITLE
site: harden api surface (CORS, error bodies, theme-history scoping, install-bot ownership, impersonate escaping)

### DIFF
--- a/code/tamagui.dev/.gitignore
+++ b/code/tamagui.dev/.gitignore
@@ -1,3 +1,8 @@
+# secrets — never commit (.env holds live service_role / sk_live / PAT)
+.env
+.env.*
+!.env.example
+
 bento-output
 helpers/dist/
 

--- a/code/tamagui.dev/app/api/admin/impersonate+api.ts
+++ b/code/tamagui.dev/app/api/admin/impersonate+api.ts
@@ -4,6 +4,11 @@ import { isAdminEmail } from '~/features/api/isAdmin'
 import { readBodyJSON } from '~/features/api/readBodyJSON'
 import { supabaseAdmin } from '~/features/auth/supabaseAdmin'
 
+// escape for HTML text context (the impersonated user's email is DB-controlled
+// and gets rendered into the admin's own browser, so a malformed email must not
+// execute as markup in that high-value session)
+const escapeHtml = (s: string) => s.replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`)
+
 /**
  * Generate impersonation link for admin to view a user's account
  * Admin-only endpoint
@@ -88,7 +93,7 @@ export default apiRoute(async (req) => {
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 </head>
 <body>
-  <p>Impersonating user ${targetUser.email}...</p>
+  <p>Impersonating user ${escapeHtml(targetUser.email)}...</p>
   <p style="color: red; font-weight: bold;">ADMIN IMPERSONATION MODE</p>
   <p id="status">Verifying...</p>
   <script>
@@ -96,13 +101,13 @@ export default apiRoute(async (req) => {
       const statusEl = document.getElementById('status');
       try {
         const supabase = window.supabase.createClient(
-          '${process.env.NEXT_PUBLIC_SUPABASE_URL}',
-          '${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}'
+          ${JSON.stringify(process.env.NEXT_PUBLIC_SUPABASE_URL ?? '')},
+          ${JSON.stringify(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '')}
         );
 
         // verify the OTP token
         const { data, error } = await supabase.auth.verifyOtp({
-          token_hash: '${token}',
+          token_hash: ${JSON.stringify(token)},
           type: 'magiclink'
         });
 

--- a/code/tamagui.dev/app/api/github/install-bot+api.ts
+++ b/code/tamagui.dev/app/api/github/install-bot+api.ts
@@ -3,7 +3,7 @@ import { ensureAuth } from '~/features/api/ensureAuth'
 import { supabaseAdmin } from '~/features/auth/supabaseAdmin'
 
 export default apiRoute(async (req) => {
-  await ensureAuth({ req })
+  const { user } = await ensureAuth({ req })
 
   const url = new URL(req.url)
   const subscriptionItemId = url.searchParams.get('subscription_item_id')
@@ -15,6 +15,28 @@ export default apiRoute(async (req) => {
         status: 400,
       }
     )
+  }
+
+  // verify the caller owns this subscription item via its subscription before
+  // inserting an installation row for it (mirrors github/bot-setup)
+  const { data: subItem } = await supabaseAdmin
+    .from('subscription_items')
+    .select('subscription_id')
+    .eq('id', subscriptionItemId)
+    .single()
+
+  if (!subItem) {
+    return Response.json({ message: 'subscription item not found' }, { status: 404 })
+  }
+
+  const { data: sub } = await supabaseAdmin
+    .from('subscriptions')
+    .select('user_id')
+    .eq('id', subItem.subscription_id)
+    .single()
+
+  if (!sub || sub.user_id !== user.id) {
+    return Response.json({ message: 'subscription item not found' }, { status: 404 })
   }
 
   const { data } = await supabaseAdmin

--- a/code/tamagui.dev/app/api/theme/histories+api.tsx
+++ b/code/tamagui.dev/app/api/theme/histories+api.tsx
@@ -5,34 +5,20 @@ import { supabaseAdmin } from '~/features/auth/supabaseAdmin'
 export default apiRoute(async (req) => {
   const { user } = await ensureAuth({ req })
   const url = new URL(req.url)
-  const searchQuery = url.searchParams.get('q')
-  const userId = url.searchParams.get('uid')
   const id = url.searchParams.get('id')
 
+  // a single theme from the caller's own history (scoped to user_id so one user
+  // can't read another's themes/prompts by guessing an id). public sharing of a
+  // theme by id goes through getTheme/theme-share, not this history endpoint.
   if (id) {
     const { data, error } = await supabaseAdmin
       .from('theme_histories')
       .select('theme_data, search_query')
       .eq('id', Number(id))
+      .eq('user_id', user.id)
 
     if (error) {
-      return Response.json({ error: error.message }, { status: 500 })
-    }
-
-    return Response.json(data)
-  }
-
-  // Get specific theme
-  if (searchQuery && userId) {
-    const { data, error } = await supabaseAdmin
-      .from('theme_histories')
-      .select('theme_data, search_query')
-      .eq('user_id', userId)
-      .eq('search_query', searchQuery)
-      .single()
-
-    if (error) {
-      return Response.json({ error: error.message }, { status: 500 })
+      return Response.json({ error: 'Failed to load theme' }, { status: 500 })
     }
 
     return Response.json(data)
@@ -46,7 +32,7 @@ export default apiRoute(async (req) => {
     .limit(30)
 
   if (error) {
-    return Response.json({ error: error.message }, { status: 500 })
+    return Response.json({ error: 'Failed to load themes' }, { status: 500 })
   }
 
   return Response.json({ histories: data })

--- a/code/tamagui.dev/features/api/ClientError.ts
+++ b/code/tamagui.dev/features/api/ClientError.ts
@@ -1,0 +1,12 @@
+// a user-facing error. apiRoute returns its message + status to the client, so
+// throw this for validation / business errors the caller is meant to see (e.g.
+// "This coupon has expired"). Plain Errors are treated as internal and return a
+// generic 500 with no detail leaked.
+export class ClientError extends Error {
+  status: number
+  constructor(message: string, status = 400) {
+    super(message)
+    this.name = 'ClientError'
+    this.status = status
+  }
+}

--- a/code/tamagui.dev/features/api/apiRoute.ts
+++ b/code/tamagui.dev/features/api/apiRoute.ts
@@ -1,6 +1,7 @@
 import type { PostgrestError } from '@supabase/supabase-js'
 import type { Endpoint } from 'one'
 import { isResponse } from 'one'
+import { ClientError } from './ClientError'
 
 export function apiRoute(handler: Endpoint) {
   return (async (req) => {
@@ -18,27 +19,22 @@ export function apiRoute(handler: Endpoint) {
 
       return out
     } catch (err) {
-      // not an error
+      // a Response thrown by the handler is an intentional result, not an error
       if (isResponse(err)) {
         return err
       }
 
+      // a ClientError is a user-facing message the caller is meant to see
+      if (err instanceof ClientError) {
+        return Response.json({ error: err.message }, { status: err.status })
+      }
+
+      // anything else is internal: log the detail server-side, return a generic
+      // body so we don't leak Postgres/Stripe/internal messages to the client
       const message = err instanceof Error ? err.message : `${err}`
+      console.trace(`Error in apiRoute ${req.url}: ${message}`, err)
 
-      // log errors with traces for debugging in prod
-      console.trace(`Error in apiRoute (caught response) ${req.url}: ${message}`, err)
-
-      return new Response(
-        JSON.stringify({
-          error: message,
-        }),
-        {
-          status: 500,
-          headers: {
-            'content-type': 'application/json',
-          },
-        }
-      )
+      return Response.json({ error: 'Internal server error' }, { status: 500 })
     }
   }) satisfies Endpoint
 }

--- a/code/tamagui.dev/features/api/cors.ts
+++ b/code/tamagui.dev/features/api/cors.ts
@@ -12,13 +12,28 @@ export const setupCors = (req: Request) => {
   }
 }
 
+// exact local dev origins (the desktop/dev app on :1421) — matched verbatim so
+// attacker hosts like http://evil-localhost:1421 can't slip past a suffix check.
+const DEV_ORIGINS = new Set(['http://localhost:1421', 'http://127.0.0.1:1421'])
+
 function isValidOrigin(origin?: string | null): origin is string {
+  if (typeof origin !== 'string') return false
+  if (DEV_ORIGINS.has(origin)) return true
+  // prod: require a real https origin on tamagui.dev / stripe.com (or a subdomain).
+  // parse so the scheme is checked and the host is compared exactly (host carries
+  // any port), so e.g. http://… and eviltamagui.dev are both rejected.
+  let url: URL
+  try {
+    url = new URL(origin)
+  } catch {
+    return false
+  }
+  if (url.protocol !== 'https:') return false
+  const { host } = url
   return (
-    typeof origin === 'string' &&
-    (origin === 'tamagui.dev' ||
-      origin.endsWith('.tamagui.dev') ||
-      origin === 'stripe.com' ||
-      origin.endsWith('.stripe.com') ||
-      origin.endsWith('localhost:1421'))
+    host === 'tamagui.dev' ||
+    host.endsWith('.tamagui.dev') ||
+    host === 'stripe.com' ||
+    host.endsWith('.stripe.com')
   )
 }

--- a/code/tamagui.dev/features/stripe/assertValidCoupon.ts
+++ b/code/tamagui.dev/features/stripe/assertValidCoupon.ts
@@ -1,3 +1,4 @@
+import { ClientError } from '../api/ClientError'
 import { stripe } from './stripe'
 
 /**
@@ -14,24 +15,24 @@ export async function assertValidCoupon(couponId: string, productId: string) {
   try {
     coupon = await stripe.coupons.retrieve(couponId)
   } catch {
-    throw new Error('Invalid coupon code')
+    throw new ClientError('Invalid coupon code')
   }
 
   if (!coupon.valid) {
-    throw new Error('This coupon is no longer valid')
+    throw new ClientError('This coupon is no longer valid')
   }
 
   if (coupon.redeem_by && coupon.redeem_by < Math.floor(Date.now() / 1000)) {
-    throw new Error('This coupon has expired')
+    throw new ClientError('This coupon has expired')
   }
 
   if (coupon.max_redemptions != null && coupon.times_redeemed >= coupon.max_redemptions) {
-    throw new Error('This coupon has reached its usage limit')
+    throw new ClientError('This coupon has reached its usage limit')
   }
 
   // if the coupon is restricted to specific products, the charged product must be one of them
   const restrictedProducts = coupon.applies_to?.products
   if (restrictedProducts?.length && !restrictedProducts.includes(productId)) {
-    throw new Error('This coupon is not valid for this product')
+    throw new ClientError('This coupon is not valid for this product')
   }
 }


### PR DESCRIPTION
Closes the remaining lower-severity findings from the 2026-06-30 security audit (tamagui.dev only):

- **CORS** (`features/api/cors.ts`): `isValidOrigin` now matches exact dev origins and parses prod origins (https + exact host on tamagui.dev/stripe.com or a subdomain). Removes the `endsWith('localhost:1421')` suffix match that accepted `http://evil-localhost:1421`, plus the dead schemeless `=== 'tamagui.dev'` branches.
- **Error leakage** (`features/api/apiRoute.ts` + new `ClientError`): the catch-all 500 no longer echoes raw internal/Postgres/Stripe messages. Handlers throw `ClientError` for messages the user is meant to see; `assertValidCoupon` now does, so coupon UX is unchanged while everything else returns a generic body.
- **Theme-history scoping** (`app/api/theme/histories+api.tsx`): the `id` branch is now scoped to `user_id`, and the unused attacker-controlled `uid`+`q` branch is removed — one user can no longer read another's themes/prompts. Public theme sharing still flows through getTheme.
- **install-bot ownership** (`app/api/github/install-bot+api.ts`): verifies the caller owns the subscription item (via its subscription) before inserting an `app_installations` row (mirrors bot-setup).
- **Impersonate XSS** (`app/api/admin/impersonate+api.ts`): HTML-escapes the impersonated email and JSON-encodes the url/anon-key/OTP token into the script context.
- **.gitignore**: ignore `.env`/`.env.*` so the live-secret file can't be accidentally committed.

Validated: `tsc --noEmit` clean, oxlint clean, oxfmt clean.