### PR TITLE
site: stop inlining live server secrets into the dist/api build

### DIFF
--- a/code/tamagui.dev/app/api/github/sponsor+api.ts
+++ b/code/tamagui.dev/app/api/github/sponsor+api.ts
@@ -1,9 +1,10 @@
 import crypto from 'crypto'
 import { apiRoute } from '~/features/api/apiRoute'
+import { serverEnv } from '~/features/api/serverEnv'
 import { supabaseAdmin } from '~/features/auth/supabaseAdmin'
 
 export default apiRoute(async (req) => {
-  if (!process.env.GITHUB_SPONSOR_WEBHOOK_SECRET) {
+  if (!serverEnv('GITHUB_SPONSOR_WEBHOOK_SECRET')) {
     throw new Error('GITHUB_SPONSOR_WEBHOOK_SECRET env var is not set')
   }
 
@@ -13,7 +14,7 @@ export default apiRoute(async (req) => {
   }
 
   const body = await req.text()
-  const hmac = crypto.createHmac('sha256', process.env.GITHUB_SPONSOR_WEBHOOK_SECRET!)
+  const hmac = crypto.createHmac('sha256', serverEnv('GITHUB_SPONSOR_WEBHOOK_SECRET')!)
   hmac.update(body)
   const expectedSignature = `sha256=${hmac.digest('hex')}`
 

--- a/code/tamagui.dev/app/api/start-chat+api.tsx
+++ b/code/tamagui.dev/app/api/start-chat+api.tsx
@@ -1,6 +1,7 @@
 import type { Endpoint } from 'one'
 import { ensureAccess } from '~/features/api/ensureAccess'
 import { ensureAuth } from '~/features/api/ensureAuth'
+import { serverEnv } from '~/features/api/serverEnv'
 
 export const POST: Endpoint = async (req) => {
   const { user } = await ensureAuth({ req })
@@ -19,7 +20,7 @@ export const POST: Endpoint = async (req) => {
   const requestBody = {
     action: 'add',
     email,
-    key: process.env.TAMAGUI_PRO_SECRET,
+    key: serverEnv('TAMAGUI_PRO_SECRET'),
   }
 
   const response = await fetch('https://start.chat/api/tamagui-pro', {

--- a/code/tamagui.dev/app/api/stripe/webhook+api.ts
+++ b/code/tamagui.dev/app/api/stripe/webhook+api.ts
@@ -2,6 +2,7 @@ import type Stripe from 'stripe'
 import * as v from 'valibot'
 import { apiRoute } from '~/features/api/apiRoute'
 import { getQuery } from '~/features/api/getQuery'
+import { serverEnv } from '~/features/api/serverEnv'
 import { readBodyBuffer } from '~/features/api/readBodyBuffer'
 import { unclaimSubscription } from '~/features/api/unclaimProduct'
 import {
@@ -25,7 +26,7 @@ import { stripe } from '~/features/stripe/stripe'
 import { supabaseAdmin } from '~/features/auth/supabaseAdmin'
 import { STRIPE_PRODUCTS } from '~/features/stripe/products'
 
-const endpointSecret = process.env.STRIPE_SIGNING_SIGNATURE_SECRET
+const endpointSecret = serverEnv('STRIPE_SIGNING_SIGNATURE_SECRET')
 
 const Schema = v.object({
   referral: v.optional(v.string()),

--- a/code/tamagui.dev/app/api/theme/generate+api.ts
+++ b/code/tamagui.dev/app/api/theme/generate+api.ts
@@ -4,6 +4,7 @@ import slugify from '@sindresorhus/slugify'
 import { generateText } from 'ai'
 import { z } from 'zod'
 import { apiRoute } from '~/features/api/apiRoute'
+import { serverEnv } from '~/features/api/serverEnv'
 import { ensureAccess } from '~/features/api/ensureAccess'
 import { ensureAuth } from '~/features/api/ensureAuth'
 import { readBodyJSON } from '~/features/api/readBodyJSON'
@@ -11,7 +12,7 @@ import { supabaseAdmin } from '~/features/auth/supabaseAdmin'
 import type { ThemeSuiteItemData } from '~/features/studio/theme/types'
 
 const openrouter = createOpenRouter({
-  apiKey: process.env.OPENROUTER_API_KEY,
+  apiKey: serverEnv('OPENROUTER_API_KEY'),
 })
 
 const modelChain = [

--- a/code/tamagui.dev/features/api/serverEnv.ts
+++ b/code/tamagui.dev/features/api/serverEnv.ts
@@ -1,0 +1,10 @@
+// read a server-only secret at runtime.
+//
+// the production server build (`one build`) inlines `process.env.X` references
+// as literal strings into dist/api when X is set at build time -- which bakes
+// live secrets (service_role key, sk_live, the GitHub PAT, ...) into the
+// deployed artifact at rest. the dynamic property access here can't be matched
+// by that static `process.env.X` replacement, so the value stays a real runtime
+// env lookup and never lands in the bundle. always read server secrets through
+// this, never `process.env.SECRET` directly.
+export const serverEnv = (key: string): string | undefined => process.env[key]

--- a/code/tamagui.dev/features/auth/supabaseAdmin.ts
+++ b/code/tamagui.dev/features/auth/supabaseAdmin.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import type Stripe from 'stripe'
+import { serverEnv } from '../api/serverEnv'
 import { sendProductPurchaseEmail } from '~/features/email/helpers'
 import { stripe } from '~/features/stripe/stripe'
 import type { Price, Product } from '~/features/stripe/types'
@@ -8,7 +9,7 @@ import { STRIPE_PRODUCTS } from '../stripe/products'
 import type { Database } from '../supabase/types'
 
 const SUPA_URL = import.meta.env.NEXT_PUBLIC_SUPABASE_URL || 'http://localhost:54321'
-const SUPA_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
+const SUPA_KEY = serverEnv('SUPABASE_SERVICE_ROLE_KEY') || ''
 
 // Note: supabaseAdmin uses the SERVICE_ROLE_KEY which you must only use in a secure server-side context
 // as it has admin priviliges and overwrites RLS policies!

--- a/code/tamagui.dev/features/discord/helpers.ts
+++ b/code/tamagui.dev/features/discord/helpers.ts
@@ -1,3 +1,5 @@
+import { serverEnv } from '../api/serverEnv'
+
 export const TAKEOUT_ROLE_ID = '1131082605052301403'
 export const TAMAGUI_DISCORD_GUILD_ID = '909986013848412191'
 export const TAKEOUT_GROUP_ID = '1131249991256657950' // group id
@@ -9,7 +11,7 @@ export const getDiscordClient = async () => {
   const { REST } = await import('@discordjs/rest')
   const { WebSocketManager } = await import('@discordjs/ws')
 
-  const token = process.env.DISCORD_BOT_TOKEN!
+  const token = serverEnv('DISCORD_BOT_TOKEN')!
 
   const rest = new REST({ version: '10' }).setToken(token)
 

--- a/code/tamagui.dev/features/email/helpers.ts
+++ b/code/tamagui.dev/features/email/helpers.ts
@@ -1,7 +1,8 @@
 // @ts-ignore
 import * as postmark from 'postmark'
+import { serverEnv } from '../api/serverEnv'
 
-const serverToken = process.env.POSTMARK_SERVER_TOKEN!
+const serverToken = serverEnv('POSTMARK_SERVER_TOKEN')!
 
 if (process.env.NODE_ENV === 'production') {
   if (!serverToken) {

--- a/code/tamagui.dev/features/github/helpers.ts
+++ b/code/tamagui.dev/features/github/helpers.ts
@@ -1,3 +1,5 @@
+import { serverEnv } from '../api/serverEnv'
+
 export type GithubSponsorshipStatus =
   | {
       hasSponsorAccess: false
@@ -32,7 +34,7 @@ export type GithubAccessStatus = {
   orgs: GithubSponsorshipStatus[]
 }
 // sponsor checks reuse the admin token (the old read-only GITHUB_TOKEN was retired)
-const GITHUB_ADMIN_TOKEN = process.env.GITHUB_ADMIN_TOKEN
+const GITHUB_ADMIN_TOKEN = serverEnv('GITHUB_ADMIN_TOKEN')
 
 // whitelisting uniswap org for feedback
 const whitelistOrgs = {

--- a/code/tamagui.dev/features/github/octokit.ts
+++ b/code/tamagui.dev/features/github/octokit.ts
@@ -1,10 +1,11 @@
 import fetch from 'node-fetch'
+import { serverEnv } from '../api/serverEnv'
 
 export const getOctokit = async () => {
   const { Octokit } = await import('octokit')
 
   return new Octokit({
-    auth: process.env.GITHUB_ADMIN_TOKEN,
+    auth: serverEnv('GITHUB_ADMIN_TOKEN'),
     request: {
       fetch,
     },

--- a/code/tamagui.dev/features/stripe/stripe.ts
+++ b/code/tamagui.dev/features/stripe/stripe.ts
@@ -1,11 +1,12 @@
 import Stripe from 'stripe'
+import { serverEnv } from '../api/serverEnv'
 
 const isTestMode =
   process.env.STRIPE_TEST_MODE === 'true' || process.env.NODE_ENV === 'development'
 
 const secretKey = isTestMode
-  ? process.env.STRIPE_SECRET_KEY_TEST
-  : process.env.STRIPE_SECRET_KEY
+  ? serverEnv('STRIPE_SECRET_KEY_TEST')
+  : serverEnv('STRIPE_SECRET_KEY')
 
 export const stripe = new Stripe(secretKey!, {
   // https://github.com/stripe/stripe-node#configuration


### PR DESCRIPTION
Closes audit H-1 (secrets). The production server build (`one build`) inlines `process.env.X` as a literal string into `dist/api` whenever X is set at build time — which baked the live **Supabase service_role key, Stripe `sk_live`, the GitHub admin PAT, and the OpenRouter key** into the deployed artifact at rest (not a public leak — dist is gitignored, client bundle is clean — but a large blast radius on the Railway build host/image).

Fix: read every server-only secret through a new `serverEnv(key)` helper that does a dynamic `process.env[key]` lookup. The build's static `process.env.X` replacement can't match the computed access, so the value stays a real runtime lookup and never lands in the bundle. Runtime behavior is identical (`process.env[k]` === `process.env.K`). Converted all server secrets (service_role, sk_live/test, PAT ×2, OpenRouter, Stripe webhook signing secret, sponsor webhook secret, Discord, Postmark, pro secret).

**Validated:** rebuilt `dist/api` and confirmed zero `service_role` / `sk_live` / `github_pat` / `sk-or-v1` literals remain (only the intended public `anon` key), and the chunks now read `process.env[...]`. tsc + oxlint clean.

⚠️ **Rotation still required (user action):** the four secrets above already sat in plaintext in every previously-built artifact, so rotate them after this deploys — Supabase service_role, Stripe `sk_live`, GitHub admin PAT, OpenRouter key.