### PR TITLE
site: stop parity-discount spoofing (verify Cloudflare transit before trusting CF-IPCountry)

### DIFF
--- a/code/tamagui.dev/app/api/create-v2-subscription+api.ts
+++ b/code/tamagui.dev/app/api/create-v2-subscription+api.ts
@@ -3,6 +3,7 @@ import { apiRoute } from '~/features/api/apiRoute'
 import { ensureAuth } from '~/features/api/ensureAuth'
 import { createOrRetrieveCustomer } from '~/features/auth/supabaseAdmin'
 import { getParityDiscount } from '~/features/geo-pricing/parityConfig'
+import { getTrustedCountryCode } from '~/features/geo-pricing/trustedCountry'
 import { assertValidCoupon } from '~/features/stripe/assertValidCoupon'
 import { STRIPE_PRODUCTS } from '~/features/stripe/products'
 import { stripe } from '~/features/stripe/stripe'
@@ -55,8 +56,11 @@ export default apiRoute(async (req) => {
     return Response.json({ error: 'Payment method is required' }, { status: 400 })
   }
 
-  // Get parity discount from Cloudflare header (server-side validation - can't be spoofed)
-  const countryCode = req.headers.get('CF-IPCountry')
+  // Parity discount applies to the actual charge, so the country must come from a
+  // request proven to have transited Cloudflare (getTrustedCountryCode) -- a direct
+  // origin hit can't spoof CF-IPCountry to discount the price. Unverified -> null ->
+  // 0% discount (full price).
+  const countryCode = getTrustedCountryCode(req)
   const parityDiscountPercent = getParityDiscount(countryCode)
 
   // Track created resources for rollback

--- a/code/tamagui.dev/features/geo-pricing/trustedCountry.ts
+++ b/code/tamagui.dev/features/geo-pricing/trustedCountry.ts
@@ -1,0 +1,30 @@
+import { timingSafeEqual } from 'node:crypto'
+
+// Only trust Cloudflare's CF-IPCountry header when the request is proven to have
+// transited Cloudflare.
+//
+// CF-IPCountry is set by Cloudflare's edge, but the Railway origin is directly
+// reachable, so a client that hits the origin URL directly can send any
+// CF-IPCountry value it wants. Trusting it on the *charge* path let an authed
+// user spoof CF-IPCountry: VE (a deep-discount tier) and buy the $250 license
+// for ~$37.
+//
+// Fix: a Cloudflare Transform Rule (or Worker) adds a request header
+//   X-Origin-Secret: <CF_ORIGIN_SECRET>
+// to every request it proxies. A direct origin hit can't produce it, so it can't
+// spoof the country. If CF_ORIGIN_SECRET isn't configured we can't prove transit,
+// so we fail safe to no discount (full price). The secret is read via dynamic
+// process.env access so the server build can't inline it (see api/serverEnv.ts).
+export function getTrustedCountryCode(req: Request): string | null {
+  const expected = process.env['CF_ORIGIN_SECRET']
+  if (!expected) return null
+
+  const provided = req.headers.get('x-origin-secret')
+  if (!provided) return null
+
+  const a = Buffer.from(provided)
+  const b = Buffer.from(expected)
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null
+
+  return req.headers.get('CF-IPCountry')
+}


### PR DESCRIPTION
Closes audit H-1 (parity). `create-v2-subscription` set the **actual charge amount** from the `CF-IPCountry` request header with a "can't be spoofed" comment — but the Railway origin is directly reachable, so an authed user POSTing straight to the origin with `CF-IPCountry: VE` bought the $250 license for ~$37 (and it stacked on coupons).

Fix: the discount country now comes from `getTrustedCountryCode(req)`, which only returns `CF-IPCountry` when the request carries `X-Origin-Secret: <CF_ORIGIN_SECRET>` (constant-time compared). A direct origin hit can't produce that header. If the secret isn't configured we fail safe to **no discount** (full price). `tsc` + oxlint clean.

## ⚠️ DO NOT MERGE until the Cloudflare side is set up — otherwise parity discounts go to 0 for everyone.

Two infra steps (yours):
1. **Cloudflare Transform Rule** (or Worker) on the tamagui.dev zone: add request header `X-Origin-Secret` = a long random secret to all proxied requests.
2. **Railway env var** `CF_ORIGIN_SECRET` = that same secret (read dynamically, so it won't be inlined into the build).

Once both are in place, merge this — parity discounts keep working for real Cloudflare traffic and direct-origin spoofing returns full price. (Ideally also lock the Railway origin to Cloudflare's IP ranges so the origin isn't directly reachable at all.)