### PR TITLE
fix(bento-get): redact access tokens in CLI DEBUG logs

### DIFF
--- a/code/packages/bento-get/src/app/AuthGuard.tsx
+++ b/code/packages/bento-get/src/app/AuthGuard.tsx
@@ -1,7 +1,7 @@
 import { Alert } from '@inkjs/ui'
 import { Box } from 'ink'
 import React from 'react'
-import { debugLog } from '../commands/index.js'
+import { debugLog, redact } from '../commands/index.js'
 import { AppContext } from '../data/AppContext.js'
 import { useInstallComponent } from '../hooks/useInstallComponent.js'
 
@@ -16,7 +16,7 @@ export const AuthGuard = ({ children }: { children: React.ReactNode }) => {
       setAccessToken(token)
       setIsLoggedIn(true)
       debugLog('Token found, setting isLoggedIn to true')
-      debugLog({ token })
+      debugLog({ token: redact(token) })
     } else {
       setIsLoggedIn(false)
     }

--- a/code/packages/bento-get/src/commands/index.tsx
+++ b/code/packages/bento-get/src/commands/index.tsx
@@ -26,6 +26,13 @@ export const debugLog = (...args: any[]) => {
   if (process.env.DEBUG === 'true') console.log(...args)
 }
 
+// redact a secret (access token) for debug output so DEBUG=true logs / CI logs
+// can't leak the full bearer — show only a short prefix + length
+export const redact = (s: unknown): string =>
+  typeof s === 'string' && s.length > 8
+    ? `${s.slice(0, 6)}…(${s.length} chars)`
+    : '<redacted>'
+
 function BentoGet() {
   const navigate = useNavigate()
   const location = useLocation()
@@ -105,7 +112,7 @@ function BentoGet() {
       setAccessToken(token as string)
       setIsLoggedIn(true)
       debugLog('Token found, setting isLoggedIn to true')
-      debugLog({ token })
+      debugLog({ token: redact(token) })
     } else {
       setIsLoggedIn(false)
     }

--- a/code/packages/bento-get/src/hooks/useFetchComponent.tsx
+++ b/code/packages/bento-get/src/hooks/useFetchComponent.tsx
@@ -3,7 +3,7 @@ import querystring from 'node:querystring'
 import React from 'react'
 import useSWR from 'swr'
 import { AppContext } from '../data/AppContext.js'
-import { debugLog } from '../commands/index.js'
+import { debugLog, redact } from '../commands/index.js'
 
 export const useFetchComponent = () => {
   const { installState, accessToken, tokenStore, setIsLoggedIn, setAccessToken } =
@@ -11,7 +11,7 @@ export const useFetchComponent = () => {
 
   const fetcher = async (url: string) => {
     debugLog('fetcher', url)
-    debugLog({ accessToken })
+    debugLog({ accessToken: redact(accessToken) })
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     }

--- a/code/packages/bento-get/src/screens/CodeAuthScreen.tsx
+++ b/code/packages/bento-get/src/screens/CodeAuthScreen.tsx
@@ -7,7 +7,7 @@ import { useContext, useState } from 'react'
 import { createClient } from '@supabase/supabase-js'
 import Spinner from 'ink-spinner'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { debugLog } from '../commands/index.js'
+import { debugLog, redact } from '../commands/index.js'
 import { PUBLIC_SUPABASE_ANON_KEY, PUBLIC_SUPABASE_URL } from '../constants.js'
 import { AppContext } from '../data/AppContext.js'
 
@@ -24,8 +24,8 @@ export const CodeAuthScreen = () => {
 
   const handleInputChange = async (value: string) => {
     debugLog('----\nauth input change ----\n', {
-      value,
-      at: appContext.accessToken,
+      value: redact(value),
+      at: redact(appContext.accessToken),
     })
 
     if (!location.pathname.includes('/auth/')) return
@@ -46,7 +46,7 @@ export const CodeAuthScreen = () => {
       appContext.setIsLoggedIn(true)
       appContext.tokenStore.set('accessToken', value)
       appContext.tokenStore.onDidChange('accessToken', (newValue) => {
-        debugLog('tokenStore changed', newValue)
+        debugLog('tokenStore changed', redact(newValue))
       })
       debugLog('navigating to install-confirm', { fileName })
       navigate(`/install-confirm/${fileName}`)


### PR DESCRIPTION
Closes audit M-3 (secrets). The Bento CLI logged the full Supabase access token to stdout under `DEBUG=true` (`debugLog({ token })`, `{ accessToken }`, the pasted auth input, and tokenStore changes) — so the bearer landed in terminal scrollback / CI logs. Added a `redact()` helper (prefix + length only) and applied it at all five token-log sites. Build + oxlint clean.

Note: this is the published `bento-get` CLI, so it needs a **bento-get npm release** to reach CLI users (merging to main does not publish). The deeper token-model hardening (H-2: the CLI uses the full account JWT as its credential) is a larger coordinated server+CLI change tracked separately.