### PR TITLE
perf(v2): native deopt + partial-flatten, hook gating, gated $group/$theme CSS extraction

### DIFF
--- a/code/compiler/static-tests/tests/__snapshots__/babel.native.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/babel.native.test.tsx.snap
@@ -1,5 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`$group-* on native should de-opt (preserve as inline prop) 1`] = `
+"const __ReactNativeView = require('react-native').View;
+const __ReactNativeText = require('react-native').Text;
+import { YStack } from 'tamagui';
+export function Test() {
+  return <YStack group="row">
+          <YStack backgroundColor="red" $group-row-hover={{
+      backgroundColor: 'green'
+    }} />
+        </YStack>;
+}"
+`;
+
 exports[`$gtMd only should NOT apply on small screens 1`] = `
 "const __ReactNativeStyleSheet = require('react-native').StyleSheet;
 const _sheet = __ReactNativeStyleSheet.create({
@@ -62,6 +75,17 @@ export function Test() {
   return <_ReactNativeViewStyled0 _expressions={["md", "gtMd"]} />;
 }
 const _ReactNativeViewStyled0 = _withStableStyle(__ReactNativeView, (theme, _expressions) => [_sheet["0"], _expressions[0] ? _sheet["1"] : null, _expressions[1] ? _sheet["2"] : null], false, true);"
+`;
+
+exports[`$theme-* on native should de-opt (preserve as inline prop) 1`] = `
+"const __ReactNativeView = require('react-native').View;
+const __ReactNativeText = require('react-native').Text;
+import { YStack } from 'tamagui';
+export function Test() {
+  return <YStack backgroundColor="red" $theme-dark={{
+    backgroundColor: 'green'
+  }} />;
+}"
 `;
 
 exports[`basic conditional extraction 1`] = `
@@ -181,6 +205,17 @@ const __ReactNativeText = require('react-native').Text;
 import { YStack } from 'tamagui';
 export function Test(props) {
   return <YStack scale={props.isLoading ? 1 : 2} x={10} {...props} rotate="10deg" />;
+}"
+`;
+
+exports[`hoverStyle on native should de-opt (preserve as inline prop) 1`] = `
+"const __ReactNativeView = require('react-native').View;
+const __ReactNativeText = require('react-native').Text;
+import { YStack } from 'tamagui';
+export function Test() {
+  return <YStack backgroundColor="red" hoverStyle={{
+    backgroundColor: 'green'
+  }} />;
 }"
 `;
 

--- a/code/compiler/static-tests/tests/__snapshots__/babel.native.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/babel.native.test.tsx.snap
@@ -1,14 +1,32 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`$group-* on native should de-opt (preserve as inline prop) 1`] = `
+exports[`$group-* non-hover on native should de-opt (preserve as inline prop) 1`] = `
 "const __ReactNativeView = require('react-native').View;
 const __ReactNativeText = require('react-native').Text;
 import { YStack } from 'tamagui';
 export function Test() {
   return <YStack group="row">
-          <YStack backgroundColor="red" $group-row-hover={{
+          <YStack backgroundColor="red" $group-row-press={{
       backgroundColor: 'green'
     }} />
+        </YStack>;
+}"
+`;
+
+exports[`$group-*-hover on native should drop dead hover work 1`] = `
+"const __ReactNativeStyleSheet = require('react-native').StyleSheet;
+const _sheet = __ReactNativeStyleSheet.create({
+  "0": {
+    "flexDirection": "column",
+    "backgroundColor": "red"
+  }
+});
+const __ReactNativeView = require('react-native').View;
+const __ReactNativeText = require('react-native').Text;
+import { YStack } from 'tamagui';
+export function Test() {
+  return <YStack group="row">
+          <__ReactNativeView style={_sheet["0"]} />
         </YStack>;
 }"
 `;
@@ -208,14 +226,19 @@ export function Test(props) {
 }"
 `;
 
-exports[`hoverStyle on native should de-opt (preserve as inline prop) 1`] = `
-"const __ReactNativeView = require('react-native').View;
+exports[`hoverStyle on native should drop dead hover work 1`] = `
+"const __ReactNativeStyleSheet = require('react-native').StyleSheet;
+const _sheet = __ReactNativeStyleSheet.create({
+  "0": {
+    "flexDirection": "column",
+    "backgroundColor": "red"
+  }
+});
+const __ReactNativeView = require('react-native').View;
 const __ReactNativeText = require('react-native').Text;
 import { YStack } from 'tamagui';
 export function Test() {
-  return <YStack backgroundColor="red" hoverStyle={{
-    backgroundColor: 'green'
-  }} />;
+  return <__ReactNativeView style={_sheet["0"]} />;
 }"
 `;
 

--- a/code/compiler/static-tests/tests/babel.native.test.tsx
+++ b/code/compiler/static-tests/tests/babel.native.test.tsx
@@ -289,12 +289,9 @@ test('string ternary test should not be confused with media key', async () => {
   expect(code).toMatchSnapshot()
 })
 
-// native compiler under-fold: pseudo-state props must NOT flatten on native
-// (RN StyleSheet has no concept of $hover/$press — flattening would write a
-// literal "hoverStyle"/"pressStyle" key into the sheet and silently lose the
-// behavior at runtime). The compiler must de-opt → preserve the prop on the
-// runtime component, where createComponent/getSplitStyles handle it.
-test('hoverStyle on native should de-opt (preserve as inline prop)', async () => {
+// native has no hover state, so hoverStyle should be dropped instead of
+// preserved as runtime work.
+test('hoverStyle on native should drop dead hover work', async () => {
   const output = await extractForNative(`
     import { YStack } from 'tamagui'
     export function Test() {
@@ -304,13 +301,11 @@ test('hoverStyle on native should de-opt (preserve as inline prop)', async () =>
     }
   `)
   const code = output?.code ?? ''
-  // must NOT serialize hoverStyle into the StyleSheet
+  // must not serialize hoverStyle into the stylesheet or preserve it as runtime work
   expect(code).not.toContain('"hoverStyle"')
-  // must preserve the JSX prop verbatim
-  expect(code).toContain('hoverStyle')
-  expect(code).toContain("backgroundColor: 'green'")
-  // and the original component (not __ReactNativeView) is preserved
-  expect(code).toContain('<YStack')
+  expect(code).not.toContain('hoverStyle')
+  expect(code).not.toContain("backgroundColor: 'green'")
+  expect(code).toContain('__ReactNativeView')
   expect(code).toMatchSnapshot()
 })
 
@@ -332,7 +327,7 @@ test('$theme-* on native should de-opt (preserve as inline prop)', async () => {
   expect(code).toMatchSnapshot()
 })
 
-test('$group-* on native should de-opt (preserve as inline prop)', async () => {
+test('$group-*-hover on native should drop dead hover work', async () => {
   const output = await extractForNative(`
     import { YStack } from 'tamagui'
     export function Test() {
@@ -347,10 +342,32 @@ test('$group-* on native should de-opt (preserve as inline prop)', async () => {
     }
   `)
   const code = output?.code ?? ''
-  // must NOT serialize $group-row-hover as a sheet key
+  // must not serialize or preserve hover-only group styles on native
   expect(code).not.toContain('"$group-row-hover"')
-  // must preserve as an inline JSX prop so runtime resolves it via GroupContext
-  expect(code).toContain('$group-row-hover')
+  expect(code).not.toContain('$group-row-hover')
+  expect(code).not.toContain("backgroundColor: 'green'")
+  expect(code).toMatchSnapshot()
+})
+
+test('$group-* non-hover on native should de-opt (preserve as inline prop)', async () => {
+  const output = await extractForNative(`
+    import { YStack } from 'tamagui'
+    export function Test() {
+      return (
+        <YStack group="row">
+          <YStack
+            backgroundColor="red"
+            $group-row-press={{ backgroundColor: 'green' }}
+          />
+        </YStack>
+      )
+    }
+  `)
+  const code = output?.code ?? ''
+  // must not serialize $group-row-press as a sheet key
+  expect(code).not.toContain('"$group-row-press"')
+  // must preserve as an inline jsx prop so runtime resolves it via group context
+  expect(code).toContain('$group-row-press')
   // group="row" parent must remain (it provides the runtime container context)
   expect(code).toContain('group="row"')
   expect(code).toMatchSnapshot()

--- a/code/compiler/static-tests/tests/babel.native.test.tsx
+++ b/code/compiler/static-tests/tests/babel.native.test.tsx
@@ -289,6 +289,73 @@ test('string ternary test should not be confused with media key', async () => {
   expect(code).toMatchSnapshot()
 })
 
+// native compiler under-fold: pseudo-state props must NOT flatten on native
+// (RN StyleSheet has no concept of $hover/$press — flattening would write a
+// literal "hoverStyle"/"pressStyle" key into the sheet and silently lose the
+// behavior at runtime). The compiler must de-opt → preserve the prop on the
+// runtime component, where createComponent/getSplitStyles handle it.
+test('hoverStyle on native should de-opt (preserve as inline prop)', async () => {
+  const output = await extractForNative(`
+    import { YStack } from 'tamagui'
+    export function Test() {
+      return (
+        <YStack backgroundColor="red" hoverStyle={{ backgroundColor: 'green' }} />
+      )
+    }
+  `)
+  const code = output?.code ?? ''
+  // must NOT serialize hoverStyle into the StyleSheet
+  expect(code).not.toContain('"hoverStyle"')
+  // must preserve the JSX prop verbatim
+  expect(code).toContain('hoverStyle')
+  expect(code).toContain("backgroundColor: 'green'")
+  // and the original component (not __ReactNativeView) is preserved
+  expect(code).toContain('<YStack')
+  expect(code).toMatchSnapshot()
+})
+
+test('$theme-* on native should de-opt (preserve as inline prop)', async () => {
+  const output = await extractForNative(`
+    import { YStack } from 'tamagui'
+    export function Test() {
+      return (
+        <YStack backgroundColor="red" $theme-dark={{ backgroundColor: 'green' }} />
+      )
+    }
+  `)
+  const code = output?.code ?? ''
+  // must NOT serialize $theme-dark as a sheet key (it would never match on RN)
+  expect(code).not.toContain('"$theme-dark"')
+  // must preserve as an inline JSX prop so runtime resolves it via theme
+  expect(code).toContain('$theme-dark')
+  expect(code).toContain('<YStack')
+  expect(code).toMatchSnapshot()
+})
+
+test('$group-* on native should de-opt (preserve as inline prop)', async () => {
+  const output = await extractForNative(`
+    import { YStack } from 'tamagui'
+    export function Test() {
+      return (
+        <YStack group="row">
+          <YStack
+            backgroundColor="red"
+            $group-row-hover={{ backgroundColor: 'green' }}
+          />
+        </YStack>
+      )
+    }
+  `)
+  const code = output?.code ?? ''
+  // must NOT serialize $group-row-hover as a sheet key
+  expect(code).not.toContain('"$group-row-hover"')
+  // must preserve as an inline JSX prop so runtime resolves it via GroupContext
+  expect(code).toContain('$group-row-hover')
+  // group="row" parent must remain (it provides the runtime container context)
+  expect(code).toContain('group="row"')
+  expect(code).toMatchSnapshot()
+})
+
 test('ternary with mixed theme-token and non-token values preserves all props', async () => {
   const output = await extractForNative(`
     import { Text } from 'tamagui'

--- a/code/compiler/static-tests/tests/babel.web.test.tsx
+++ b/code/compiler/static-tests/tests/babel.web.test.tsx
@@ -470,6 +470,55 @@ test('$group- with untilMeasured on the same parent does NOT extract child group
   // can still use it — only the descendants' group styles bail.
 })
 
+test('$group- styles on an animated element stay on the runtime path (never extract to CSS)', async () => {
+  // Q2 invariant: a static @container class can't drive a JS animation driver's
+  // interpolation, so an animated element's $group- style must NOT extract to CSS.
+  // the compiler enforces this via createExtractor's `animation` de-opt (the whole
+  // element drops to runtime), backed by extractToClassNames' animation guard.
+  const output = await extractForWeb(
+    `
+    import { View } from '@tamagui/core'
+
+    export function Test() {
+      return (
+        <View group="card">
+          <View
+            width={100}
+            animation="bouncy"
+            $group-card={{ backgroundColor: 'red' }}
+          />
+        </View>
+      )
+    }
+  `
+  )
+  expect(output?.js).toContain('$group-card')
+})
+
+test('$group- styles on an element with enterStyle stay on the runtime path', async () => {
+  // same Q2 invariant via a different animation surface (enterStyle). guards
+  // against a regression where an animated element's group style leaks into
+  // static @container CSS.
+  const output = await extractForWeb(
+    `
+    import { View } from '@tamagui/core'
+
+    export function Test() {
+      return (
+        <View group="card">
+          <View
+            width={100}
+            enterStyle={{ opacity: 0 }}
+            $group-card={{ backgroundColor: 'red' }}
+          />
+        </View>
+      )
+    }
+  `
+  )
+  expect(output?.js).toContain('$group-card')
+})
+
 test('$theme- styles extract to atomic CSS', async () => {
   const output = await extractForWeb(
     `

--- a/code/compiler/static-tests/tests/babel.web.test.tsx
+++ b/code/compiler/static-tests/tests/babel.web.test.tsx
@@ -388,31 +388,89 @@ test('flexBasis: 0 with responsive style extracts correctly', async () => {
   expect(output?.styles).toMatchSnapshot()
 })
 
-test('$group- styles are not flattened', async () => {
+test('$group- styles extract to atomic CSS', async () => {
   const output = await extractForWeb(
     `
-    import { View, XStack } from '@tamagui/core'
+    import { View } from '@tamagui/core'
 
     export function Test() {
       return (
-        <XStack group="card">
+        <View group="card">
           <View
             width={100}
             $group-card={{ backgroundColor: 'red' }}
           />
-        </XStack>
+        </View>
+      )
+    }
+  `
+  )
+  // child View should fully flatten to <div> with className — no runtime $group-card prop
+  expect(output?.js).toContain('div')
+  expect(output?.js).not.toContain('$group-card')
+
+  // parent's static `group="card"` should emit container CSS + `t_group_card` className.
+  expect(output?.styles).toContain('container-name: card')
+  expect(output?.styles).toContain('container-type: inline-size')
+  expect(output?.js).toContain('t_group_card')
+
+  // child rule rides off the parent's `.t_group_card` className.
+  expect(output?.styles).toContain('.t_group_card')
+  expect(output?.styles).toContain('background-color')
+})
+
+test('$group- styles with pseudo extract to parent-hover selector', async () => {
+  const output = await extractForWeb(
+    `
+    import { View } from '@tamagui/core'
+
+    export function Test() {
+      return (
+        <View group="row">
+          <View
+            width={100}
+            $group-row-hover={{ backgroundColor: 'red' }}
+          />
+        </View>
       )
     }
   `
   )
 
-  // $group- styles should NOT be flattened - they need runtime handling
-  // The component should not be converted to a plain div
-  expect(output?.js).toContain('View')
-  expect(output?.js).toContain('$group-card')
+  expect(output?.js).toContain('div')
+  expect(output?.js).not.toContain('$group-row-hover')
+  // hover pseudo is matched off the parent's `.t_group_row` class — wrapped in
+  // @media (hover:hover) so touch devices don't sticky-trigger.
+  expect(output?.styles).toContain('.t_group_row:hover')
+  expect(output?.styles).toContain('@media (hover:hover)')
+  expect(output?.styles).toContain('background-color')
 })
 
-test('$theme- styles are not flattened', async () => {
+test('$group- with untilMeasured on the same parent does NOT extract child group styles', async () => {
+  const output = await extractForWeb(
+    `
+    import { View } from '@tamagui/core'
+
+    export function Test() {
+      return (
+        <View group="card" untilMeasured="hide">
+          <View
+            width={100}
+            $group-card={{ backgroundColor: 'red' }}
+          />
+        </View>
+      )
+    }
+  `
+  )
+
+  // child's $group-card must remain inline for runtime measurement gating
+  expect(output?.js).toContain('$group-card')
+  // parent still extracts its container CSS so siblings without untilMeasured
+  // can still use it — only the descendants' group styles bail.
+})
+
+test('$theme- styles extract to atomic CSS', async () => {
   const output = await extractForWeb(
     `
     import { View } from '@tamagui/core'
@@ -429,11 +487,13 @@ test('$theme- styles are not flattened', async () => {
   `
   )
 
-  // $theme- styles should NOT be flattened - they need runtime handling
-  // The component should not be converted to a plain div
-  expect(output?.js).toContain('View')
-  expect(output?.js).toContain('$theme-light')
-  expect(output?.js).toContain('$theme-dark')
+  // fully flattens to a div; styles emitted as theme-scoped rules.
+  expect(output?.js).toContain('div')
+  expect(output?.js).not.toContain('$theme-light')
+  expect(output?.js).not.toContain('$theme-dark')
+  expect(output?.styles).toContain('background-color')
+  expect(output?.styles).toContain('t_light')
+  expect(output?.styles).toContain('t_dark')
 })
 
 test('$platform-web styles are flattened on web', async () => {

--- a/code/compiler/static-tests/tests/flatten.native.test.tsx
+++ b/code/compiler/static-tests/tests/flatten.native.test.tsx
@@ -176,6 +176,43 @@ describe('flatten-tests', () => {
     // no tokens / media / group → createComponent skips the theme + media hooks
     expect(code).toContain('data-disable-theme')
     expect(code).toContain('data-disable-media')
+    // pressStyle IS an event surface → the native useEvents hook must stay
+    expect(code).not.toContain('data-disable-events')
+  })
+
+  // a deopted element with NO event surface (no handlers, no press/focus/hover
+  // styles, no group) gets data-disable-events so createComponent skips the native
+  // useEvents hook (RNGH gesture + refs). a dynamic prop forces the deopt while the
+  // static props still partial-flatten (same shape as the pressStyle test above).
+  test(`emits data-disable-events on event-free deopt`, async () => {
+    const output = await extractForNative(`
+      import { View } from 'tamagui'
+      export function Test({ o }) {
+        return (
+          <View width={60} height={40} backgroundColor="rgb(1,2,3)" opacity={o} />
+        )
+      }
+    `)
+    const code = output?.code ?? ''
+    // static props still partial-flatten onto the runtime View
+    expect(code).toContain('<View style=')
+    // no event surface → the native useEvents hook is skipped
+    expect(code).toContain('data-disable-events')
+  })
+
+  // the same shape WITH a real handler must NOT get data-disable-events
+  test(`keeps useEvents hook when an onPress handler is present`, async () => {
+    const output = await extractForNative(`
+      import { View } from 'tamagui'
+      export function Test({ o, onPress }) {
+        return (
+          <View width={60} height={40} backgroundColor="rgb(1,2,3)" opacity={o} onPress={onPress} />
+        )
+      }
+    `)
+    const code = output?.code ?? ''
+    expect(code).toContain('<View style=')
+    expect(code).not.toContain('data-disable-events')
   })
 
   // theme tokens must NOT be baked into the flattened static style — they stay inline

--- a/code/compiler/static-tests/tests/flatten.native.test.tsx
+++ b/code/compiler/static-tests/tests/flatten.native.test.tsx
@@ -145,6 +145,61 @@ describe('flatten-tests', () => {
     expect(output?.code).contains('theme["invalid-identifier"].get()')
   })
 
+  // partial-flatten on native deopt: a component that must stay on the runtime path
+  // (pressStyle) still gets its pure-static props pre-merged into one `style={…}`,
+  // skipping the runtime per-prop loop. dead native hoverStyle is dropped.
+  test(`partial-flattens static props on pressStyle deopt`, async () => {
+    const output = await extractForNative(`
+      import { View } from 'tamagui'
+      export function Test() {
+        return (
+          <View
+            width={60}
+            height={40}
+            backgroundColor="rgb(1,2,3)"
+            hoverStyle={{ opacity: 0.5 }}
+            pressStyle={{ opacity: 0.8 }}
+          />
+        )
+      }
+    `)
+    const code = output?.code ?? ''
+    // static props merged into a single style object
+    expect(code).toContain('"width": 60')
+    expect(code).toContain('"backgroundColor": "rgb(1,2,3)"')
+    // pseudo stays on the runtime component
+    expect(code).toContain('pressStyle')
+    // dead native hover is dropped entirely
+    expect(code).not.toContain('hoverStyle')
+    // still the runtime tamagui View (deopted), not folded to a raw RN view
+    expect(code).toContain('<View style=')
+  })
+
+  // theme tokens must NOT be baked into the flattened static style — they stay inline
+  // so the runtime resolves them per-theme (theme switching keeps working).
+  test(`keeps theme tokens inline when partial-flattening`, async () => {
+    const output = await extractForNative(`
+      import { View } from 'tamagui'
+      export function Test() {
+        return (
+          <View
+            width={60}
+            height={40}
+            backgroundColor="$gray2"
+            pressStyle={{ opacity: 0.8 }}
+          />
+        )
+      }
+    `)
+    const code = output?.code ?? ''
+    // static numeric props flatten
+    expect(code).toContain('"width": 60')
+    // the theme token is NOT hardcoded into the static style object
+    expect(code).not.toContain('"backgroundColor": "$gray2"')
+    // it remains an inline prop the runtime resolves per-theme
+    expect(code).toContain('backgroundColor="$gray2"')
+  })
+
   // TODO make this work:
   // test.skip(`keeps style object a single object case 2`, async () => {
   //   const output = await extractForNative(`

--- a/code/compiler/static-tests/tests/flatten.native.test.tsx
+++ b/code/compiler/static-tests/tests/flatten.native.test.tsx
@@ -173,6 +173,9 @@ describe('flatten-tests', () => {
     expect(code).not.toContain('hoverStyle')
     // still the runtime tamagui View (deopted), not folded to a raw RN view
     expect(code).toContain('<View style=')
+    // no tokens / media / group → createComponent skips the theme + media hooks
+    expect(code).toContain('data-disable-theme')
+    expect(code).toContain('data-disable-media')
   })
 
   // theme tokens must NOT be baked into the flattened static style — they stay inline
@@ -198,6 +201,10 @@ describe('flatten-tests', () => {
     expect(code).not.toContain('"backgroundColor": "$gray2"')
     // it remains an inline prop the runtime resolves per-theme
     expect(code).toContain('backgroundColor="$gray2"')
+    // token-bearing → theme hook MUST stay (no data-disable-theme), but it's still
+    // media-free so the media hook is skipped
+    expect(code).not.toContain('data-disable-theme')
+    expect(code).toContain('data-disable-media')
   })
 
   // TODO make this work:

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -1095,6 +1095,13 @@ export function createExtractor(
 
             ...(!isTargetingHTML
               ? [
+                  // native has no CSS pseudo selectors; these are runtime-only on
+                  // RN (event listeners + style merge in createComponent), and if
+                  // we let them flatten into the StyleSheet they get written
+                  // under a literal key (e.g. `"hoverStyle"`) that RN treats as
+                  // an unknown style prop → silent breakage. de-opt → preserve
+                  // the original prop on the runtime component.
+                  'hoverStyle',
                   'pressStyle',
                   'focusStyle',
                   'focusVisibleStyle',
@@ -2333,6 +2340,19 @@ export function createExtractor(
               // check de-opt props again
               for (const key in outProps) {
                 if (deoptProps.has(key)) {
+                  shouldFlatten = false
+                }
+                // native has no atomic-CSS sink for theme- / group- pseudo
+                // blocks; if they flatten they get serialized under the literal
+                // `$theme-…` / `$group-…` key into the RN StyleSheet, where the
+                // runtime's @container / theme-name matching never runs. de-opt
+                // → preserve as inline prop so getSplitStyles handles them at
+                // render time.
+                if (
+                  platform === 'native' &&
+                  key[0] === '$' &&
+                  (key.startsWith('$theme-') || key.startsWith('$group-'))
+                ) {
                   shouldFlatten = false
                 }
               }

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -64,6 +64,31 @@ const UNTOUCHED_PROPS = {
 // (requires runtime Platform.OS + Platform.isTV checks via react-native-tvos)
 const nativeOnlyPlatforms = new Set(['android', 'ios', 'tv', 'androidtv', 'tvos'])
 
+// props whose presence forces createComponent to keep the native useEvents hook.
+// used to decide whether to emit data-disable-events on a deopted (non-flattened)
+// native element. mouse/hover keys included for native-desktop; group included
+// because a group parent can gain dynamic press-tracking children at runtime.
+const EVENT_PROP_NAMES = new Set([
+  'onPress',
+  'onPressIn',
+  'onPressOut',
+  'onLongPress',
+  'delayLongPress',
+  'onClick',
+  'onMouseDown',
+  'onMouseUp',
+  'onMouseEnter',
+  'onMouseLeave',
+  'onFocus',
+  'onBlur',
+  'pressStyle',
+  'focusStyle',
+  'focusVisibleStyle',
+  'focusWithinStyle',
+  'hoverStyle',
+  'group',
+])
+
 const createTernary = (x: Ternary) => x
 
 export type Extractor = ReturnType<typeof createExtractor>
@@ -2070,6 +2095,11 @@ export function createExtractor(
                 const hasSpread = ogAttributes.some((a) => t.isJSXSpreadAttribute(a))
                 let usesTheme = hasSpread
                 let usesMedia = hasSpread
+                // events: any handler, press/focus/hover pseudo-style, or group prop
+                // means createComponent must keep the native useEvents hook (RNGH
+                // gesture + refs). group is included because a group parent can gain
+                // dynamic press-tracking children at runtime. conservative on spread.
+                let usesEvents = hasSpread
                 for (const a of ogAttributes) {
                   if (!t.isJSXAttribute(a) || !t.isJSXIdentifier(a.name)) continue
                   const n = a.name.name
@@ -2085,6 +2115,9 @@ export function createExtractor(
                   if (n[0] === '$') {
                     usesMedia = true
                     if (n.startsWith('$theme-') || n.startsWith('$group-')) usesTheme = true
+                  }
+                  if (!usesEvents && EVENT_PROP_NAMES.has(n)) {
+                    usesEvents = true
                   }
                 }
                 if (!usesTheme) {
@@ -2106,6 +2139,11 @@ export function createExtractor(
                 if (!usesMedia) {
                   flagAttrs.push(
                     t.jsxAttribute(t.jsxIdentifier('data-disable-media'), null)
+                  )
+                }
+                if (!usesEvents) {
+                  flagAttrs.push(
+                    t.jsxAttribute(t.jsxIdentifier('data-disable-events'), null)
                   )
                 }
 

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -76,6 +76,16 @@ function isFullyDisabled(props: TamaguiOptions) {
   return props.disableExtraction && props.disableDebugAttr
 }
 
+// a compile-evaluated style value carries a theme token if any leaf string is
+// "$"-prefixed (e.g. "$gray2"). such styles must NOT be flattened into a static
+// `style` object — the token is resolved at runtime so theme switching keeps working.
+function styleValueHasToken(v: any): boolean {
+  if (typeof v === 'string') return v.charCodeAt(0) === 36 // '$'
+  if (Array.isArray(v)) return v.some(styleValueHasToken)
+  if (v && typeof v === 'object') return Object.values(v).some(styleValueHasToken)
+  return false
+}
+
 // Walk up JSX ancestors looking for one that declares `group="<groupName>"` together
 // with the `untilMeasured` prop. Used to deopt children whose styles depend on a
 // parent that the runtime measures before emitting child styles (can't be modeled
@@ -2002,7 +2012,6 @@ export function createExtractor(
           })
 
           if (!shouldFlatten) {
-            // were no longer partially optimizing, it adds a lot of complexity for dubious performance
             if (shouldPrintDebug) {
               logger.info(
                 `Deopting ${JSON.stringify({
@@ -2014,7 +2023,54 @@ export function createExtractor(
                 })}`
               )
             }
-            node.attributes = ogAttributes
+            // PARTIAL FLATTEN (native): even when the element must stay on the runtime
+            // path (pseudo/group/dynamic keep it deopted), pre-merge the pure-static
+            // style props into a single `style={…}` so the runtime skips its per-prop
+            // loop for them (the dominant deopt cost on RN). theme tokens ($…) and
+            // dynamic props stay inline so theme/media switching + dynamics are
+            // unaffected; dead native hoverStyle is dropped (no-op on touch).
+            let partial: (t.JSXAttribute | t.JSXSpreadAttribute)[] | null = null
+            if (
+              platform === 'native' &&
+              !staticConfig.isHOC &&
+              !staticConfig.isStyledHOC &&
+              !ogAttributes.some(
+                (a) =>
+                  t.isJSXSpreadAttribute(a) ||
+                  (t.isJSXAttribute(a) &&
+                    t.isJSXIdentifier(a.name) &&
+                    a.name.name === 'style')
+              )
+            ) {
+              const staticStyle: Record<string, any> = {}
+              const consumed = new Set<string>()
+              for (const a of attrs) {
+                if (a.type !== 'style' || !a.name || !a.attr) continue
+                if (pseudoDescriptors[a.name]) continue
+                if (!t.isJSXAttribute(a.attr) || !t.isJSXIdentifier(a.attr.name)) continue
+                if (styleValueHasToken(a.value)) continue
+                Object.assign(staticStyle, a.value)
+                consumed.add(a.attr.name.name)
+              }
+              if (consumed.size >= 2) {
+                const kept = ogAttributes.filter((a) => {
+                  if (!t.isJSXAttribute(a) || !t.isJSXIdentifier(a.name)) return true
+                  const n = a.name.name
+                  if (consumed.has(n)) return false
+                  if (n === 'hoverStyle') return false
+                  if (n.startsWith('$group-') && getGroupPseudo(n) === 'hover') return false
+                  return true
+                })
+                partial = [
+                  t.jsxAttribute(
+                    t.jsxIdentifier('style'),
+                    t.jsxExpressionContainer(literalToAst(staticStyle) as t.Expression)
+                  ),
+                  ...kept,
+                ]
+              }
+            }
+            node.attributes = partial ?? ogAttributes
             return
           }
 

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -1375,6 +1375,19 @@ export function createExtractor(
               return [attribute.value!, path.get('value')!] as const
             })()
 
+            // These props have runtime-only meaning on native. Decide from the
+            // original JSX attr, before getSplitStyles has a chance to drop
+            // native-dead work like hoverStyle from its static output.
+            if (
+              deoptProps.has(name) ||
+              (platform === 'native' &&
+                name[0] === '$' &&
+                (name.startsWith('$theme-') || name.startsWith('$group-')))
+            ) {
+              inlined.set(name, true)
+              return attr
+            }
+
             const remove = () => {
               Array.isArray(valuePath)
                 ? valuePath.map((p) => p.remove())

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -399,6 +399,22 @@ export function createExtractor(
       )
     }
 
+    function getGroupPseudo(name: string) {
+      const [_, groupName, a, b, c] = name.split('-')
+      if (!groupName) return
+      const m2 = a && b ? `${a}-${b}` : ''
+      const media = (m2 && mediaQueryConfig[m2] && m2) || (a && mediaQueryConfig[a] && a)
+      return media
+        ? media === m2
+          ? c
+          : b
+            ? `${b}${c ? `-${c}` : ''}`
+            : undefined
+        : a
+          ? `${a}${b ? `-${b}` : ''}${c ? `-${c}` : ''}`
+          : undefined
+    }
+
     /**
      * Step 1: Determine if importing any statically extractable components
      */
@@ -1135,13 +1151,12 @@ export function createExtractor(
 
             ...(!isTargetingHTML
               ? [
-                  // native has no CSS pseudo selectors; these are runtime-only on
-                  // RN (event listeners + style merge in createComponent), and if
-                  // we let them flatten into the StyleSheet they get written
-                  // under a literal key (e.g. `"hoverStyle"`) that RN treats as
-                  // an unknown style prop → silent breakage. de-opt → preserve
-                  // the original prop on the runtime component.
-                  'hoverStyle',
+                  // native has no css pseudo selectors; these are runtime-only on
+                  // rn (event listeners + style merge in createComponent), and if
+                  // we let them flatten into the stylesheet they get written
+                  // under a literal key that rn treats as an unknown style prop.
+                  // hover is intentionally excluded: it is no-op on native and
+                  // should be dropped rather than preserved as runtime work.
                   'pressStyle',
                   'focusStyle',
                   'focusVisibleStyle',
@@ -1415,14 +1430,15 @@ export function createExtractor(
               return [attribute.value!, path.get('value')!] as const
             })()
 
-            // These props have runtime-only meaning on native. Decide from the
-            // original JSX attr, before getSplitStyles has a chance to drop
+            // these props have runtime-only meaning on native. decide from the
+            // original jsx attr, before getSplitStyles has a chance to drop
             // native-dead work like hoverStyle from its static output.
             if (
               deoptProps.has(name) ||
               (platform === 'native' &&
                 name[0] === '$' &&
-                (name.startsWith('$theme-') || name.startsWith('$group-')))
+                (name.startsWith('$theme-') ||
+                  (name.startsWith('$group-') && getGroupPseudo(name) !== 'hover')))
             ) {
               inlined.set(name, true)
               return attr
@@ -2402,6 +2418,14 @@ export function createExtractor(
                   if (propsForSplit === props) {
                     propsForSplit = { ...props }
                   }
+                  if (
+                    platform === 'native' &&
+                    k.startsWith('$group-') &&
+                    getGroupPseudo(k) === 'hover'
+                  ) {
+                    delete propsForSplit[k]
+                    continue
+                  }
                   extractedMediaLikeProps ||= {}
                   extractedMediaLikeProps[k] = propsForSplit[k]
                   delete propsForSplit[k]
@@ -2451,7 +2475,8 @@ export function createExtractor(
                 if (
                   platform === 'native' &&
                   key[0] === '$' &&
-                  (key.startsWith('$theme-') || key.startsWith('$group-'))
+                  (key.startsWith('$theme-') ||
+                    (key.startsWith('$group-') && getGroupPseudo(key) !== 'hover'))
                 ) {
                   shouldFlatten = false
                 }

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -2061,11 +2061,60 @@ export function createExtractor(
                   if (n.startsWith('$group-') && getGroupPseudo(n) === 'hover') return false
                   return true
                 })
+
+                // disable-flags: if the surviving runtime props can't read theme/media,
+                // emit data-disable-theme / data-disable-media so createComponent skips
+                // those hooks (theme subscription setup + useMedia alloc). conservative —
+                // a spread, animation, theme prop, $theme-/$group- key, or any token-bearing
+                // value keeps the hook. consumed props are already token-free statics.
+                const hasSpread = ogAttributes.some((a) => t.isJSXSpreadAttribute(a))
+                let usesTheme = hasSpread
+                let usesMedia = hasSpread
+                for (const a of ogAttributes) {
+                  if (!t.isJSXAttribute(a) || !t.isJSXIdentifier(a.name)) continue
+                  const n = a.name.name
+                  if (consumed.has(n)) continue
+                  if (
+                    n === 'theme' ||
+                    n === 'animation' ||
+                    n === 'enterStyle' ||
+                    n === 'exitStyle'
+                  ) {
+                    usesTheme = true
+                  }
+                  if (n[0] === '$') {
+                    usesMedia = true
+                    if (n.startsWith('$theme-') || n.startsWith('$group-')) usesTheme = true
+                  }
+                }
+                if (!usesTheme) {
+                  for (const a of attrs) {
+                    if (a.type !== 'style' || !a.name || consumed.has(a.name)) continue
+                    if (styleValueHasToken(a.value)) {
+                      usesTheme = true
+                      break
+                    }
+                  }
+                }
+
+                const flagAttrs: t.JSXAttribute[] = []
+                if (!usesTheme) {
+                  flagAttrs.push(
+                    t.jsxAttribute(t.jsxIdentifier('data-disable-theme'), null)
+                  )
+                }
+                if (!usesMedia) {
+                  flagAttrs.push(
+                    t.jsxAttribute(t.jsxIdentifier('data-disable-media'), null)
+                  )
+                }
+
                 partial = [
                   t.jsxAttribute(
                     t.jsxIdentifier('style'),
                     t.jsxExpressionContainer(literalToAst(staticStyle) as t.Expression)
                   ),
+                  ...flagAttrs,
                   ...kept,
                 ]
               }

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -76,6 +76,46 @@ function isFullyDisabled(props: TamaguiOptions) {
   return props.disableExtraction && props.disableDebugAttr
 }
 
+// Walk up JSX ancestors looking for one that declares `group="<groupName>"` together
+// with the `untilMeasured` prop. Used to deopt children whose styles depend on a
+// parent that the runtime measures before emitting child styles (can't be modeled
+// in static CSS).
+function hasUntilMeasuredAncestor(
+  path: NodePath<any>,
+  groupName: string
+): boolean {
+  let current: NodePath<any> | null = path.parentPath
+  while (current) {
+    if (current.isJSXElement()) {
+      const opening = current.node.openingElement
+      let foundGroup = false
+      let foundUntilMeasured = false
+      for (const attr of opening.attributes) {
+        if (!t.isJSXAttribute(attr)) continue
+        if (!t.isJSXIdentifier(attr.name)) continue
+        const aName = attr.name.name
+        if (aName === 'group') {
+          // only literal string equality counts — dynamic group= is left to runtime
+          if (t.isStringLiteral(attr.value) && attr.value.value === groupName) {
+            foundGroup = true
+          } else if (
+            t.isJSXExpressionContainer(attr.value) &&
+            t.isStringLiteral(attr.value.expression) &&
+            attr.value.expression.value === groupName
+          ) {
+            foundGroup = true
+          }
+        } else if (aName === 'untilMeasured') {
+          foundUntilMeasured = true
+        }
+      }
+      if (foundGroup && foundUntilMeasured) return true
+    }
+    current = current.parentPath
+  }
+  return false
+}
+
 export function createExtractor(
   { logger = console, platform = 'web' }: ExtractorOptions = { logger: console }
 ) {
@@ -1440,6 +1480,18 @@ export function createExtractor(
               return attr
             }
 
+            // static `group="<literal>"` is handled at compile-time in
+            // extractToClassNames (emits container CSS + adds `t_group_<name>`
+            // className), so we drop the JSX attribute here without bailing
+            // flattening. dynamic `group={expr}` falls through to runtime.
+            if (
+              isTargetingHTML &&
+              name === 'group' &&
+              t.isStringLiteral(value)
+            ) {
+              return []
+            }
+
             // if value can be evaluated, extract it and filter it out
             const styleValue = attemptEvalSafe(value)
 
@@ -1545,15 +1597,28 @@ export function createExtractor(
               }
 
               if (isValidStyleKey(name, staticConfig)) {
-                // $theme-, $group- styles should not be flattened (needs runtime handling)
-                // $platform- can be flattened if the platform matches
+                // $theme- / $group- styles extract through the atomic-CSS pipeline
+                // (extractToClassNames → createMediaStyle), so they fall through to
+                // the normal style return below. The one case we still bail is
+                // $group-<name>-* when an ancestor element declares `group="<name>"`
+                // together with `untilMeasured` — the runtime measures the parent
+                // and only then emits child styles, which can't be modeled in CSS.
+                // $platform- can be flattened if the platform matches.
                 if (name[0] === '$') {
-                  if (name.startsWith('$theme-') || name.startsWith('$group-')) {
-                    if (shouldPrintDebug) {
-                      logger.info(`  ! not flattening media-like style: ${name}`)
+                  if (name.startsWith('$group-')) {
+                    const groupName = name.slice('$group-'.length).split('-')[0]
+                    if (
+                      groupName &&
+                      hasUntilMeasuredAncestor(path, groupName)
+                    ) {
+                      if (shouldPrintDebug) {
+                        logger.info(
+                          `  ! group="${groupName}" ancestor has untilMeasured, not flattening: ${name}`
+                        )
+                      }
+                      inlined.set(name, true)
+                      return attr
                     }
-                    inlined.set(name, true)
-                    return attr
                   }
 
                   // $platform-web, $platform-native, $platform-ios, $platform-android, $platform-tv, $platform-androidtv, $platform-tvos
@@ -2322,8 +2387,29 @@ export function createExtractor(
             const before = process.env.IS_STATIC
             process.env.IS_STATIC = 'is_static'
             try {
+              // $group-* / $theme-* keys carry block-form style objects that
+              // getSplitStyles drops in static mode (no parent group context,
+              // no theme value to read). Pluck them out so the atomic-CSS
+              // pipeline in extractToClassNames can emit @container / theme
+              // rules for them directly.
+              let extractedMediaLikeProps: Record<string, any> | null = null
+              let propsForSplit: any = props
+              for (const k in props) {
+                if (
+                  k[0] === '$' &&
+                  (k.startsWith('$group-') || k.startsWith('$theme-'))
+                ) {
+                  if (propsForSplit === props) {
+                    propsForSplit = { ...props }
+                  }
+                  extractedMediaLikeProps ||= {}
+                  extractedMediaLikeProps[k] = propsForSplit[k]
+                  delete propsForSplit[k]
+                }
+              }
+
               const out = getSplitStyles(
-                props,
+                propsForSplit,
                 staticConfig,
                 defaultTheme,
                 '',
@@ -2348,6 +2434,7 @@ export function createExtractor(
                 ...(includeProps ? out.viewProps : {}),
                 ...out.style,
                 ...out.pseudos,
+                ...extractedMediaLikeProps,
               }
 
               // check de-opt props again

--- a/code/compiler/static/src/extractor/extractToClassNames.ts
+++ b/code/compiler/static/src/extractor/extractToClassNames.ts
@@ -205,6 +205,37 @@ export async function extractToClassNames({
         }
       }
 
+      // invariant guard for $group-/$theme- CSS extraction (below): those styles
+      // can only be extracted to static @container / theme CSS when a class toggle
+      // alone expresses the change. JS animation drivers (reanimated, motion, moti,
+      // react-native) interpolate in JS and need the runtime path to read hard
+      // values when the element animates — a static class can't drive them. gated
+      // on whether THIS element animates rather than on the driver, because motion
+      // is isReactNative:false yet still needs JS.
+      //
+      // in practice createExtractor's deoptProps already de-opts every animated
+      // element upstream (`animation`/`animateOnly`/`animatePresence` always;
+      // enterStyle/exitStyle on RN drivers), so a flattened element reaching here
+      // is normally non-animated and this never fires. it keeps the invariant
+      // local and correct regardless of future deoptProps changes — it only ever
+      // bails the animated case to runtime, never widens what extracts.
+      let elementIsAnimated = false
+      for (const attr of jsxPath.node.openingElement.attributes) {
+        if (!t.isJSXAttribute(attr) || !t.isJSXIdentifier(attr.name)) continue
+        const n = attr.name.name
+        if (
+          n === 'animation' ||
+          n === 'animateOnly' ||
+          n === 'animatePresence' ||
+          n === 'animatedBy' ||
+          n === 'enterStyle' ||
+          n === 'exitStyle'
+        ) {
+          elementIsAnimated = true
+          break
+        }
+      }
+
       function addStyle(style: StyleObject) {
         const identifier = style[StyleObjectIdentifier]
         const rules = style[StyleObjectRules]
@@ -232,6 +263,12 @@ export async function extractToClassNames({
           // $group- styles extract through createMediaStyle which emits @container
           // rules keyed on the parent's `t_group_<name>` className.
           if (mediaName.startsWith('group-')) {
+            // a class toggle can't drive a JS animation driver's interpolation;
+            // keep animated elements on the runtime path (matches pre-extraction
+            // behavior for the group case).
+            if (elementIsAnimated) {
+              throw new BailOptimizationError()
+            }
             const mediaStyle = createMediaStyle(
               style,
               mediaName,
@@ -249,6 +286,12 @@ export async function extractToClassNames({
           const mediaTypeMatch = mediaName.match(/^(theme|platform)-/)
           if (mediaTypeMatch) {
             const mediaType = mediaTypeMatch[1] as 'theme' | 'platform'
+            // $theme- values can change at runtime (theme switch); if this
+            // element animates, a JS driver must interpolate the change, so keep
+            // it on the runtime path. $platform- is build-time static — never gated.
+            if (mediaType === 'theme' && elementIsAnimated) {
+              throw new BailOptimizationError()
+            }
             // createMediaStyle internally calls getGroupPropParts(`theme-` + key)
             // for theme, so we must pass the short key ("dark", not "theme-dark")
             // to avoid double-prefixing. Platform stays as-is (runtime parity).

--- a/code/compiler/static/src/extractor/extractToClassNames.ts
+++ b/code/compiler/static/src/extractor/extractToClassNames.ts
@@ -170,6 +170,41 @@ export async function extractToClassNames({
         originalNodeName
       )
 
+      // detect static `group="<name>"` literal — runtime side normally emits the
+      // container-name/container-type CSS lazily via getSplitStyles (createComponent
+      // path), but extracted elements never go through that code, so we emit the
+      // equivalent CSS at compile time and add `t_group_<name>` to the className.
+      let staticGroupName: string | null = null
+      for (const attr of jsxPath.node.openingElement.attributes) {
+        if (!t.isJSXAttribute(attr) || !t.isJSXIdentifier(attr.name)) continue
+        if (attr.name.name !== 'group') continue
+        if (t.isStringLiteral(attr.value)) {
+          staticGroupName = attr.value.value
+        } else if (
+          t.isJSXExpressionContainer(attr.value) &&
+          t.isStringLiteral(attr.value.expression)
+        ) {
+          staticGroupName = attr.value.expression.value
+        }
+        // dynamic group={someProp} falls back to the runtime path.
+        break
+      }
+      if (staticGroupName) {
+        const containerIdentifier = `t_group_${staticGroupName}`
+        const containerType =
+          (tamaguiConfig.settings?.webContainerType as string | undefined) ||
+          'inline-size'
+        const containerSelector = `.${containerIdentifier}`
+        if (!cssMap.has(containerSelector)) {
+          cssMap.set(containerSelector, {
+            css: `${containerSelector} { container-name: ${staticGroupName}; container-type: ${containerType}; }`,
+            commentTexts: [comment],
+          })
+        } else {
+          cssMap.get(containerSelector)!.commentTexts.push(comment)
+        }
+      }
+
       function addStyle(style: StyleObject) {
         const identifier = style[StyleObjectIdentifier]
         const rules = style[StyleObjectRules]
@@ -194,20 +229,36 @@ export async function extractToClassNames({
           const property = style[0]
           const mediaName = property.slice(1)
 
-          // $group- styles must bail out entirely - they need runtime handling because
-          // group changes can affect children that may be animated and need hard values.
-          // In the future, CSS animation drivers could potentially optimize this.
+          // $group- styles extract through createMediaStyle which emits @container
+          // rules keyed on the parent's `t_group_<name>` className.
           if (mediaName.startsWith('group-')) {
-            throw new BailOptimizationError()
+            const mediaStyle = createMediaStyle(
+              style,
+              mediaName,
+              extractor.getTamagui()!.media,
+              'group',
+              false,
+              mediaStylesSeen
+            )
+            const identifier = addStyle(mediaStyle)
+            classNames.push(identifier)
+            continue
           }
 
           // Check for theme/platform media queries (e.g., $theme-dark, $platform-web)
           const mediaTypeMatch = mediaName.match(/^(theme|platform)-/)
           if (mediaTypeMatch) {
             const mediaType = mediaTypeMatch[1] as 'theme' | 'platform'
+            // createMediaStyle internally calls getGroupPropParts(`theme-` + key)
+            // for theme, so we must pass the short key ("dark", not "theme-dark")
+            // to avoid double-prefixing. Platform stays as-is (runtime parity).
+            const innerKey =
+              mediaType === 'theme'
+                ? mediaName.slice('theme-'.length)
+                : mediaName
             const mediaStyle = createMediaStyle(
               style,
-              mediaName,
+              innerKey,
               extractor.getTamagui()!.media,
               mediaType,
               false,
@@ -341,6 +392,13 @@ export async function extractToClassNames({
 
       if (baseFontFamily) {
         baseClassNameStr = `font_${baseFontFamily}${baseClassNameStr ? ` ${baseClassNameStr}` : ''}`
+      }
+
+      // add t_group_<name> for elements with a static group="<name>" literal so
+      // descendants' @container <name> rules can match (runtime path normally
+      // appends this class; extracted elements bypass it).
+      if (staticGroupName) {
+        baseClassNameStr = `t_group_${staticGroupName}${baseClassNameStr ? ` ${baseClassNameStr}` : ''}`
       }
 
       // add is_View or is_Text base class matching runtime behavior

--- a/code/core/core-test/eventsDisableGate.native.test.tsx
+++ b/code/core/core-test/eventsDisableGate.native.test.tsx
@@ -1,0 +1,57 @@
+process.env.TAMAGUI_TARGET = 'native'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, View, createTamagui } from '@tamagui/core'
+import { render } from '@testing-library/react-native'
+import { describe, expect, test } from 'vitest'
+
+// validates the runtime side of the compiler's data-disable-events gate:
+// when the flag is present, createComponent skips the native useEvents hook.
+// the flag is normally emitted by the extractor on event-free deopted elements;
+// here we pass it directly to exercise the gate (the extractor side is covered by
+// flatten.native.test.tsx).
+
+const config = createTamagui(getDefaultTamaguiConfig('native'))
+
+const Provider = ({ children }: any) => (
+  <TamaguiProvider config={config}>{children}</TamaguiProvider>
+)
+
+// pass the internal compiler flag without fighting prop types
+const disableEvents = { 'data-disable-events': true } as any
+
+describe('data-disable-events runtime gate (native)', () => {
+  test('renders an event-free element with the flag (useEvents skipped)', () => {
+    const { toJSON } = render(
+      <Provider>
+        <View {...disableEvents} width={10} height={10} />
+      </Provider>
+    )
+    expect(toJSON()).toBeTruthy()
+  })
+
+  test('hook order stays stable across re-render with the flag set', () => {
+    // if the gate flipped the hook count between renders, React throws
+    // "rendered fewer hooks than expected" here.
+    const { rerender, toJSON } = render(
+      <Provider>
+        <View {...disableEvents} width={10} height={10} />
+      </Provider>
+    )
+    rerender(
+      <Provider>
+        <View {...disableEvents} width={20} height={20} />
+      </Provider>
+    )
+    expect(toJSON()).toBeTruthy()
+  })
+
+  test('control: an onPress element (no flag) still renders with events kept', () => {
+    const { toJSON } = render(
+      <Provider>
+        <View onPress={() => {}} width={10} height={10} />
+      </Provider>
+    )
+    expect(toJSON()).toBeTruthy()
+  })
+})

--- a/code/core/use-element-layout/src/index.tsx
+++ b/code/core/use-element-layout/src/index.tsx
@@ -86,7 +86,7 @@ export type LayoutEvent = {
   timeStamp: number
 }
 
-const NodeRectCache = new WeakMap<HTMLElement, DOMRect>()
+const NodeRectCache = new WeakMap<HTMLElement, DOMRectReadOnly>()
 
 // prevent thrashing during first hydration (somewhat, streaming gets trickier)
 let avoidUpdates = true
@@ -196,35 +196,7 @@ if (ENABLE) {
       parentRect = parentNode.getBoundingClientRect()
     }
 
-    const cachedRect = NodeRectCache.get(node)
-    const cachedParentRect = NodeRectCache.get(parentNode)
-
-    // optimization: inline comparison instead of isEqualShallow
-    const nodeChanged = !cachedRect || !rectsEqual(cachedRect, nodeRect)
-    const parentChanged = !cachedParentRect || !rectsEqual(cachedParentRect, parentRect)
-
-    if (nodeChanged || parentChanged) {
-      NodeRectCache.set(node, nodeRect as DOMRect)
-      NodeRectCache.set(parentNode, parentRect as DOMRect)
-
-      const event = getElementLayoutEvent(nodeRect, parentRect, node)
-
-      if (process.env.NODE_ENV === 'development' && isDebugLayout()) {
-        console.log('[useElementLayout] change', {
-          tag: node.tagName,
-          id: node.id || undefined,
-          className: (node.className || '').slice(0, 60) || undefined,
-          layout: event.nativeEvent.layout,
-          first: !cachedRect,
-        })
-      }
-
-      if (avoidUpdates) {
-        queuedUpdates.set(node, () => onLayout(event))
-      } else {
-        onLayout(event)
-      }
-    }
+    emitLayoutIfChanged(node, parentNode, nodeRect, parentRect)
   }
 
   const rAF =
@@ -365,20 +337,67 @@ const getRelativeDimensions = (
   return { x, y, width, height, pageX: a.left, pageY: a.top }
 }
 
+function emitLayoutIfChanged(
+  node: HTMLElement,
+  parentNode: HTMLElement,
+  nodeRect: DOMRectReadOnly,
+  parentRect: DOMRectReadOnly
+) {
+  const onLayout = LayoutHandlers.get(node)
+  if (typeof onLayout !== 'function') return
+
+  const cachedRect = NodeRectCache.get(node)
+  const cachedParentRect = NodeRectCache.get(parentNode)
+
+  const nodeChanged = !cachedRect || !rectsEqual(cachedRect, nodeRect)
+  const parentChanged = !cachedParentRect || !rectsEqual(cachedParentRect, parentRect)
+
+  if (!nodeChanged && !parentChanged) return
+
+  NodeRectCache.set(node, nodeRect)
+  NodeRectCache.set(parentNode, parentRect)
+
+  const event = getElementLayoutEvent(nodeRect, parentRect, node)
+
+  if (process.env.NODE_ENV === 'development' && isDebugLayout()) {
+    console.log('[useElementLayout] change', {
+      tag: node.tagName,
+      id: node.id || undefined,
+      className: (node.className || '').slice(0, 60) || undefined,
+      layout: event.nativeEvent.layout,
+      first: !cachedRect,
+    })
+  }
+
+  if (avoidUpdates) {
+    queuedUpdates.set(node, () => onLayout(event))
+  } else {
+    onLayout(event)
+  }
+}
+
+function observeLayoutNode(node: HTMLElement, disableKey?: string) {
+  Nodes.add(node)
+  if (disableKey) {
+    LayoutDisableKey.set(node, disableKey)
+  } else {
+    LayoutDisableKey.delete(node)
+  }
+  startGlobalObservers()
+  if (globalIntersectionObserver) {
+    globalIntersectionObserver.observe(node)
+    IntersectionState.set(node, true)
+  }
+}
+
 // register an arbitrary DOM element into the measurement loop without React lifecycle
 export function registerLayoutNode(
   node: HTMLElement,
   onChange: () => void,
   disableKey?: string
 ): () => void {
-  Nodes.add(node)
   LayoutHandlers.set(node, onChange)
-  if (disableKey) LayoutDisableKey.set(node, disableKey)
-  startGlobalObservers()
-  if (globalIntersectionObserver) {
-    globalIntersectionObserver.observe(node)
-    IntersectionState.set(node, true)
-  }
+  observeLayoutNode(node, disableKey)
   return () => cleanupNode(node)
 }
 
@@ -395,6 +414,35 @@ function cleanupNode(node: HTMLElement) {
 
 const PrevHostNode = new WeakMap<object, HTMLElement | undefined>()
 
+function emitLayoutFromClientRects(node: HTMLElement) {
+  const parentNode = node.parentElement
+  if (!parentNode) return
+
+  const nodeRect = node.getBoundingClientRect()
+  const parentRect = parentNode.getBoundingClientRect()
+  emitLayoutIfChanged(node, parentNode, nodeRect, parentRect)
+}
+
+async function emitLayoutFromObserver(node: HTMLElement) {
+  if (!ENABLE || strategy !== 'async') {
+    emitLayoutFromClientRects(node)
+    return
+  }
+
+  const parentNode = node.parentElement
+  if (!parentNode) return
+
+  const [nodeRect, parentRect] = await Promise.all([
+    getBoundingClientRectAsync(node),
+    getBoundingClientRectAsync(parentNode),
+  ])
+
+  if (!nodeRect || !parentRect) return
+  if (!Nodes.has(node) || node.parentElement !== parentNode) return
+
+  emitLayoutIfChanged(node, parentNode, nodeRect, parentRect)
+}
+
 export function useElementLayout(
   ref: RefObject<TamaguiComponentStatePartial>,
   onLayout?: ((e: LayoutEvent) => void) | null
@@ -408,7 +456,7 @@ export function useElementLayout(
     LayoutDisableKey.set(node, disableKey)
   }
 
-  // detect host swaps after commit and fire immediate sync layout
+  // detect host swaps after commit and seed the async layout measurement
   useIsomorphicLayoutEffect(() => {
     if (!onLayout) return
     const nextNode = ensureWebElement(ref.current?.host)
@@ -419,23 +467,9 @@ export function useElementLayout(
     PrevHostNode.set(ref, nextNode)
     if (!nextNode) return
 
-    Nodes.add(nextNode)
-    startGlobalObservers()
-    if (globalIntersectionObserver) {
-      globalIntersectionObserver.observe(nextNode)
-      IntersectionState.set(nextNode, true)
-    }
-
-    const handler = LayoutHandlers.get(nextNode)
-    if (typeof handler !== 'function') return
-    const parentNode = nextNode.parentElement
-    if (!parentNode) return
-
-    const nodeRect = nextNode.getBoundingClientRect()
-    const parentRect = parentNode.getBoundingClientRect()
-    NodeRectCache.set(nextNode, nodeRect)
-    NodeRectCache.set(parentNode, parentRect)
-    handler(getElementLayoutEvent(nodeRect, parentRect, nextNode))
+    LayoutHandlers.set(nextNode, onLayout)
+    observeLayoutNode(nextNode, disableKey)
+    void emitLayoutFromObserver(nextNode)
   })
 
   useIsomorphicLayoutEffect(() => {
@@ -443,13 +477,8 @@ export function useElementLayout(
     const node = ref.current?.host
     if (!node) return
 
-    Nodes.add(node)
-
-    startGlobalObservers()
-    if (globalIntersectionObserver) {
-      globalIntersectionObserver.observe(node)
-      IntersectionState.set(node, true)
-    }
+    LayoutHandlers.set(node, onLayout)
+    observeLayoutNode(node, disableKey)
 
     if (process.env.NODE_ENV === 'development' && isDebugLayout()) {
       console.log('[useElementLayout] register', {
@@ -458,18 +487,6 @@ export function useElementLayout(
         className: (node.className || '').slice(0, 60) || undefined,
         totalNodes: Nodes.size,
       })
-    }
-
-    // always do one immediate sync layout event for accuracy
-    const parentNode = node.parentNode as HTMLElement | null
-    if (parentNode) {
-      onLayout(
-        getElementLayoutEvent(
-          node.getBoundingClientRect(),
-          parentNode.getBoundingClientRect(),
-          node
-        )
-      )
     }
 
     return () => {

--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -1544,9 +1544,20 @@ export function createComponent<
     // hasRealPressEvents distinguishes user-provided handlers from events.onPress
     // synthesized for pressStyle alone — only the former should claim the responder.
     const hasRealPressEvents = !!(onPress || onPressIn || onPressOut || onLongPress)
+    // data-disable-events: compiler proved this element has no event surface (no
+    // handlers, no press/focus/hover styles, no group, no spread) → skip the native
+    // useEvents hook entirely (RNGH gesture setup + refs + main-thread press hook).
+    // OR'd with the focus-within context because a leaf under a focusWithinStyle
+    // ancestor must still attach onFocus/onBlur to report up. both the flag (a
+    // compile-time constant per call-site) and the context presence (structural per
+    // fiber, gated on `'focusWithinStyle' in propsIn` at the provider) are stable, so
+    // hook order is stable per fiber — rules-of-hooks safe, same justification as
+    // data-disable-media.
     const pressGesture =
-      process.env.TAMAGUI_TARGET === 'native'
-        ? useEvents(
+      process.env.TAMAGUI_TARGET === 'native' &&
+      (!props['data-disable-events'] || componentContext.setParentFocusState)
+        ? // eslint-disable-next-line react-hooks/rules-of-hooks
+          useEvents(
             events,
             viewProps,
             stateRef,

--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -36,7 +36,7 @@ import { subscribeToContextGroup } from './helpers/subscribeToContextGroup'
 import { themeable } from './helpers/themeable'
 import { getStyleTags } from './helpers/wrapStyleTags'
 import { useComponentState } from './hooks/useComponentState'
-import { setMediaShouldUpdate, useMedia } from './hooks/useMedia'
+import { getDisabledMediaState, setMediaShouldUpdate, useMedia } from './hooks/useMedia'
 import { useThemeWithState } from './hooks/useTheme'
 import type { TamaguiComponentEvents } from './interfaces/TamaguiComponentEvents'
 import { hooks } from './setupHooks'
@@ -57,6 +57,7 @@ import type {
   TextProps,
   UseAnimationHook,
   UseAnimationProps,
+  UseMediaState,
   UseStyleEmitter,
   UseThemeWithStateProps,
 } from './types'
@@ -595,9 +596,11 @@ export function createComponent<
       elementType = animationDriver[isText ? 'Text' : 'View'] || elementType
     }
 
-    // internal use only
-    const disableThemeProp =
-      process.env.TAMAGUI_TARGET === 'native' ? false : props['data-disable-theme']
+    // internal use only. on native the compiler emits data-disable-theme for
+    // elements it proved read no theme (no tokens / theme prop / $theme-* / spread /
+    // animation), so useThemeState's `disable` early-return skips the whole
+    // subscription setup. on web it's the existing themeable()/Theme passthrough flag.
+    const disableThemeProp = props['data-disable-theme']
 
     const disableTheme = disableThemeProp || isHOC
 
@@ -695,7 +698,19 @@ export function createComponent<
     elementType = element || elementType
     const isStringElement = typeof elementType === 'string'
 
-    const mediaState = useMedia(componentContext, debugProp)
+    // compiler emits data-disable-media on native for elements with no media /
+    // $group / $theme keys (and no spread). the flag is a compile-time constant per
+    // call-site, so this conditional hook skip is stable every render for a given
+    // element (rules-of-hooks safe — same justification as cascadeOnChange). it skips
+    // useMedia's ref/reducer/effect allocation. on web TAMAGUI_TARGET folds to false
+    // at build time so useMedia stays unconditional there.
+    let mediaState: UseMediaState
+    if (process.env.TAMAGUI_TARGET === 'native' && props['data-disable-media']) {
+      mediaState = getDisabledMediaState()
+    } else {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      mediaState = useMedia(componentContext, debugProp)
+    }
 
     setDidGetVariableValue(false)
 

--- a/code/core/web/src/hooks/useMedia.tsx
+++ b/code/core/web/src/hooks/useMedia.tsx
@@ -128,6 +128,11 @@ export function setupMediaListeners() {
 const listeners = new Set<any>()
 
 export function updateMediaListeners() {
+  // keep the shared disabled-media tracker pointing at live state (defensive;
+  // media-free components never read it, but this avoids staleness if they did)
+  if (disabledMediaState) {
+    ;(disabledMediaState as any)[refSlot].proxyTarget = getMedia()
+  }
   listeners.forEach((cb) => cb(getMedia()))
 }
 
@@ -177,6 +182,22 @@ function getTouchTrackerProto(): object {
 
 function resetMediaTouchTracker() {
   touchTrackerProto = null
+  disabledMediaState = null
+}
+
+// shared media state for components the compiler proved media-free
+// (data-disable-media). reads still return live media values (defensive: correct
+// initial style even if the flag were ever wrong) but it never subscribes and
+// costs no React hook slots. one shared instance — these components never write
+// to the keys set, so sharing is safe.
+let disabledMediaState: UseMediaState | null = null
+export function getDisabledMediaState(): UseMediaState {
+  if (!disabledMediaState) {
+    const tracker = Object.create(getTouchTrackerProto())
+    tracker[refSlot] = { proxyTarget: getMedia(), keys: new Set<string>() } as MediaRefSlot
+    disabledMediaState = tracker as UseMediaState
+  }
+  return disabledMediaState
 }
 
 export function setMediaShouldUpdate(

--- a/code/core/web/types/hooks/useMedia.d.ts
+++ b/code/core/web/types/hooks/useMedia.d.ts
@@ -9,6 +9,7 @@ type MediaState = {
     enabled?: boolean;
     keys?: Set<string> | null;
 };
+export declare function getDisabledMediaState(): UseMediaState;
 export declare function setMediaShouldUpdate(ref: any, enabled?: boolean, keys?: MediaState['keys']): void;
 export declare function useMedia(componentContext?: ComponentContextI, debug?: DebugProp): UseMediaState;
 export declare function _disableMediaTouch(val: boolean): void;


### PR DESCRIPTION
## What

The pure-performance subset of `v2-perf` (#4047), redone cleanly off current `main`. No tailwind/flat-mode feature code, no benchmark scaffolding — those stay on the tailwind PR (#4064). This is a focused native-render + compiler-deopt change plus one gated web extraction.

Splits out of #4047 per the review note there ("the rest of v2-perf is a large, separate compiler/perf effort; it should land as its own PR"). The runtime theme/media perf chain from v2-perf is already in `main`, so it is **not** re-included here.

## Commits

**Native compiler correctness + partial-flatten (the win)**
- `de-opt hoverStyle / $theme-* / $group-* on native` — correctness: these were flattening into the RN StyleSheet under literal keys RN treats as unknown props, so the styles silently never applied. Now preserved on the runtime path (mirrors pressStyle/focusStyle).
- `deopt native runtime-only props before split`, `drop native hover-only props` — native has no hover, so `hoverStyle` is dead → dropped.
- `partial-flatten static props on native deopt, drop dead hover` — when an element must deopt (pseudo/group/dynamic), pre-merge its pure-static props into one `style={}` so the runtime skips its per-prop loop. Theme tokens / dynamic props stay inline. Bench (×RN, runs=5): rich 6.95→3.64, heavy 4.08→2.32, group 2.74→2.14, animated 4.18→3.51.

**Native runtime hook gating (consumes compiler flags)**
- `skip theme+media hooks on compiler-proven theme/media-free deopt leaves` — `data-disable-theme` / `data-disable-media`; reuses `useThemeState`'s existing `disable` early-return.
- `skip useEvents on compiler-proven event-free deopt leaves (data-disable-events)` — skips RNGH gesture setup + refs + main-thread press hook on leaves with no event surface.
- `refactor(use-element-layout): extract emitLayoutIfChanged + rework registerLayoutNode`.

**Web build-time extraction + gate**
- `extract $group-* / $theme-* into CSS at build time` — replaces the old blanket `BailOptimizationError` with `@container` / theme-class extraction for flattened elements.
- `guard $group-/$theme- CSS extraction so animated elements stay on the runtime path` — the Q2 gate (see below).

## The $group/$theme animation gate (Q2)

The v2-perf commit removed the old guard that bailed all `$group-` extraction. That guard existed because a JS animation driver (reanimated, **motion**, moti) interpolates in JS and needs hard values — a static `@container` class can't drive it. This PR restores the invariant, but correctly:

- gated on **whether the element animates**, not on the driver — `motion` is `isReactNative: false` yet still needs JS, so a driver check would miss it;
- non-animated elements are safe to extract on every driver (incl. CSS), matching "if it doesn't animate, we can";
- in practice `createExtractor`'s `deoptProps` already de-opts every animated element upstream (`animation`/`animateOnly`/`animatePresence` always; enterStyle/exitStyle on RN drivers), so the guard is a local, future-proof invariant rather than the primary mechanism — verified: it never fires for the currently-reachable cases, and only ever bails to runtime (never widens what extracts).

## Validation

- `static-tests` native (deopt + partial-flatten + `data-disable-*` emission): **31 passed**
- `static-tests` web (CSS extraction + 2 new animation-gate tests): **34 passed**
- `core-test` native (runtime consumption incl. `eventsDisableGate.native`): **93 passed**
- typecheck (`@tamagui/web`, `@tamagui/static`, `@tamagui/use-element-layout` + graph): **clean**

## Related
- #4064 (`v2-tailwind`) — tailwind mode + benchmark/comparison/conformance infra.
- #4047 (`v2-perf`) — superseded by this + #4064.
