### PR TITLE
chore(release): add beta/prerelease dist-tag path so prereleases never publish to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
     "llink": "lllink ~/one",
     "next-site": "./scripts/bun-run.sh @tamagui/next-site dev",
     "release:canary": "bun release --canary --ci",
+    "release:beta": "bun release --beta --ci",
+    "release:beta:dirty": "bun release --beta --dirty --ci",
     "release": "bun ./scripts/release.ts",
     "check:references": "bun ./scripts/check-references.ts",
     "check:references:fix": "bun ./scripts/check-references.ts --fix",

--- a/scripts/release-publish-tag.test.ts
+++ b/scripts/release-publish-tag.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test'
+
+import { computePublishTag } from './release-publish-tag'
+
+describe('computePublishTag', () => {
+  test('stable X.Y.Z -> latest', () => {
+    expect(computePublishTag('2.4.0')).toBe('latest')
+    expect(computePublishTag('3.0.0')).toBe('latest')
+  })
+
+  test('beta prerelease -> beta', () => {
+    expect(computePublishTag('3.0.0-beta.0')).toBe('beta')
+    expect(computePublishTag('3.0.0-beta.12')).toBe('beta')
+  })
+
+  test('rc prerelease -> rc (never latest)', () => {
+    expect(computePublishTag('2.0.0-rc.34')).toBe('rc')
+  })
+
+  test('alpha / next / nightly channels', () => {
+    expect(computePublishTag('3.0.0-alpha.1')).toBe('alpha')
+    expect(computePublishTag('3.0.0-next.1')).toBe('next')
+    expect(computePublishTag('3.0.0-nightly.1')).toBe('nightly')
+  })
+
+  test('canary timestamp version -> canary', () => {
+    expect(computePublishTag('3.0.0-1751023456789')).toBe('canary')
+  })
+
+  test('--canary flag -> canary', () => {
+    expect(computePublishTag('3.0.0', { canary: true })).toBe('canary')
+  })
+
+  test('explicit --tag always wins', () => {
+    // even a stable version can be forced onto an arbitrary tag
+    expect(computePublishTag('2.4.0', { explicitTag: 'beta' })).toBe('beta')
+    // and a prerelease can be explicitly forced onto latest (the escape hatch)
+    expect(computePublishTag('3.0.0-beta.0', { explicitTag: 'latest' })).toBe('latest')
+  })
+
+  test('unrecognized prerelease WITHOUT --tag fails loudly (never latest)', () => {
+    expect(() => computePublishTag('3.0.0-experimental.1')).toThrow(
+      /Refusing to publish prerelease/
+    )
+    expect(() => computePublishTag('3.0.0-foo')).toThrow(/no known dist-tag/)
+  })
+
+  test('unrecognized prerelease WITH explicit --tag succeeds', () => {
+    expect(
+      computePublishTag('3.0.0-experimental.1', { explicitTag: 'experimental' })
+    ).toBe('experimental')
+  })
+})

--- a/scripts/release-publish-tag.ts
+++ b/scripts/release-publish-tag.ts
@@ -1,0 +1,64 @@
+// single source of truth for the npm dist-tag a version publishes under.
+//
+// used by every path in release.ts (the publish step, the skipped-package
+// version resolution, and the post-publish dist-tag fixups) so a prerelease
+// can never silently land on `latest` and clobber the stable line.
+//
+//   stable   X.Y.Z          -> latest
+//   canary   X.Y.Z-<ts>     -> canary   (all-numeric prerelease, or opts.canary)
+//   channel  X.Y.Z-beta.N   -> beta     (rc / alpha / next / nightly likewise)
+//   explicit --tag <name>                -> that tag (always wins)
+//   any other prerelease     -> throws (never defaults to latest)
+
+// prerelease identifiers we recognize as their own dist-tag channel. a
+// prerelease whose identifier isn't in here has no safe home, so we refuse
+// rather than fall through to `latest`.
+export const KNOWN_PRERELEASE_TAGS = new Set([
+  'alpha',
+  'beta',
+  'canary',
+  'next',
+  'nightly',
+  'rc',
+])
+
+export function computePublishTag(
+  version: string,
+  opts: { canary?: boolean; explicitTag?: string } = {}
+): string {
+  const explicitTag = opts.explicitTag?.trim()
+  if (explicitTag) {
+    return explicitTag
+  }
+  if (opts.canary) {
+    return 'canary'
+  }
+
+  const dashIdx = version.indexOf('-')
+  if (dashIdx === -1) {
+    // plain X.Y.Z -> stable line
+    return 'latest'
+  }
+
+  // the prerelease identifier is the first dot-segment after the dash:
+  // 3.0.0-beta.5 -> "beta", 2.0.0-rc.34 -> "rc", 3.0.0-1751... -> "1751..."
+  const label = version
+    .slice(dashIdx + 1)
+    .split('.')[0]
+    .toLowerCase()
+
+  if (/^\d+$/.test(label)) {
+    // an all-numeric prerelease is a canary timestamp (e.g. 3.0.0-1751023456789)
+    return 'canary'
+  }
+  if (KNOWN_PRERELEASE_TAGS.has(label)) {
+    return label
+  }
+
+  throw new Error(
+    `Refusing to publish prerelease "${version}": its prerelease identifier "${label}" ` +
+      `maps to no known dist-tag (${[...KNOWN_PRERELEASE_TAGS].sort().join(', ')}).\n` +
+      `Publishing it to "latest" would clobber the stable line. ` +
+      `Pass an explicit --tag <name> to choose a dist-tag (e.g. --tag ${label}).`
+  )
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util'
 import pMap from 'p-map'
 import prompts from 'prompts'
 
+import { computePublishTag } from './release-publish-tag'
 import { spawnify } from './spawnify'
 
 process.setMaxListeners(50)
@@ -27,6 +28,16 @@ const undocumented = process.argv.includes('--undocumented')
 
 const canary = process.argv.includes('--canary')
 const isRC = process.argv.includes('--rc')
+const isBeta = process.argv.includes('--beta')
+// the prerelease channel requested via flag (null for stable / canary releases)
+const requestedChannel = isBeta ? 'beta' : isRC ? 'rc' : null
+
+// explicit dist-tag override: `--tag <name>`. always wins over version-based
+// detection (the escape hatch for publishing to an arbitrary tag).
+const explicitTagIdx = process.argv.indexOf('--tag')
+const explicitTag =
+  explicitTagIdx !== -1 ? (process.argv[explicitTagIdx + 1] || '').trim() : undefined
+
 const skipStarters = canary || skipAll || process.argv.includes('--skip-starters')
 const skipVersion = shouldFinish || rePublish || process.argv.includes('--skip-version')
 const shouldPatch = process.argv.includes('--patch')
@@ -107,13 +118,14 @@ async function hasSourceChanges(dir: string, tag: string): Promise<boolean> {
   }
 }
 
-// Check if current version is an RC (e.g., 1.143.0-rc.1 or 1.143.0-rc.1-1234567890)
-// Strip any canary timestamp suffix first
+// Detect the current prerelease channel, if any (e.g. 2.0.0-rc.34 or 3.0.0-beta.5).
+// Strip any canary timestamp suffix first so a canary of X.Y.Z isn't mistaken
+// for a channel prerelease.
 const curVersionStripped = curVersion.replace(/-\d{10,}$/, '')
-const rcMatch = curVersionStripped.match(/^(\d+\.\d+\.\d+)-rc\.(\d+)$/)
-const isCurrentRC = !!rcMatch
-const currentRCBase = rcMatch ? rcMatch[1] : null
-const currentRCNumber = rcMatch ? Number.parseInt(rcMatch[2], 10) : 0
+const channelMatch = curVersionStripped.match(/^(\d+\.\d+\.\d+)-([a-z]+)\.(\d+)$/i)
+const currentChannel = channelMatch ? channelMatch[2].toLowerCase() : null
+const currentChannelBase = channelMatch ? channelMatch[1] : null
+const currentChannelNumber = channelMatch ? Number.parseInt(channelMatch[3], 10) : 0
 
 const nextVersion = (() => {
   if (rePublish) {
@@ -124,26 +136,26 @@ const nextVersion = (() => {
     return `${curVersion.replace(/(-\d+)+$/, '')}-${Date.now()}`
   }
 
-  // RC mode: bump existing RC or compute new RC version
-  if (isRC) {
-    if (isCurrentRC) {
-      // Already an RC, bump the RC number
-      return `${currentRCBase}-rc.${currentRCNumber + 1}`
+  // prerelease channel mode (--rc / --beta): bump within the channel or start it
+  if (requestedChannel) {
+    if (currentChannel === requestedChannel && currentChannelBase) {
+      // already on this channel, bump the channel number
+      return `${currentChannelBase}-${requestedChannel}.${currentChannelNumber + 1}`
     }
-    // Not an RC yet - compute the RC version
+    // switching channels (rc -> beta) or coming from a canary: start the channel
+    // at .0 on the current base version (e.g. canary of X.Y.Z -> X.Y.Z-beta.0)
     const baseVersion = curVersion.replace(/-.*$/, '') // strip any existing prerelease
     const isCanaryOfCurrent = /-\d+$/.test(curVersion)
-    if (isCanaryOfCurrent) {
-      // canary of X.Y.Z -> X.Y.Z-rc.0
-      return `${baseVersion}-rc.0`
+    if (isCanaryOfCurrent || currentChannel) {
+      return `${baseVersion}-${requestedChannel}.0`
     }
-    // otherwise return null - will be set via prompt
+    // coming from a stable version - the base is ambiguous, set via prompt
     return null
   }
 
-  // promoting an RC to stable: just use the base version (e.g. 2.0.0-rc.34 -> 2.0.0)
-  if (isCurrentRC && currentRCBase) {
-    return currentRCBase
+  // promoting a prerelease to stable: use the base version (e.g. 2.0.0-rc.34 -> 2.0.0)
+  if (currentChannel && currentChannelBase) {
+    return currentChannelBase
   }
 
   let plusVersion = skipVersion ? 0 : 1
@@ -246,13 +258,13 @@ async function run() {
     let version = curVersion
 
     // ensure we are up to date
-    // ensure we are on main (skip branch check for canary releases)
-    if (!canary && !rePublish) {
+    // ensure we are on main (skip branch check for canary releases and dry runs)
+    if (!canary && !rePublish && !dryRun) {
       if (!isMain) {
         throw new Error(`Not on main`)
       }
     }
-    if (!dirty && !rePublish && !shouldFinish && !canary) {
+    if (!dirty && !rePublish && !shouldFinish && !canary && !dryRun) {
       await spawnify(`git pull --rebase origin main`)
     }
 
@@ -338,46 +350,53 @@ async function run() {
       let answer: { version: string }
 
       if (isCI || skipVersion) {
-        answer = { version: nextVersion! }
-      } else if (isRC && !isCurrentRC) {
-        // New RC - prompt for which version to RC
+        if (!nextVersion) {
+          throw new Error(
+            `Cannot compute a ${requestedChannel} version from a stable base (${curVersion}) non-interactively.\n` +
+              `Run without --ci to pick the base, or bump to a canary/${requestedChannel} version first.`
+          )
+        }
+        answer = { version: nextVersion }
+      } else if (requestedChannel && currentChannel !== requestedChannel) {
+        // Starting a new prerelease channel - prompt for which base version to use
         const baseVersion = curVersion.replace(/-.*$/, '') // strip any existing prerelease
         const [major, minor, patch] = baseVersion.split('.').map(Number)
 
         // check if current version is a canary (has prerelease suffix like -1234567)
         const isCanaryOfCurrent = /-\d+$/.test(curVersion)
 
-        const rcChoices = isCanaryOfCurrent
-          ? [
-              // canary of X.Y.Z -> offer X.Y.Z-rc.0 as the RC
-              {
-                title: `${major}.${minor}.${patch}-rc.0`,
-                value: `${major}.${minor}.${patch}-rc.0`,
-              },
-            ]
-          : [
-              {
-                title: `${major}.${minor + 1}.0-rc.0 (next minor)`,
-                value: `${major}.${minor + 1}.0-rc.0`,
-              },
-              {
-                title: `${major}.${minor}.${patch + 1}-rc.0 (next patch)`,
-                value: `${major}.${minor}.${patch + 1}-rc.0`,
-              },
-              {
-                title: `${major + 1}.0.0-rc.0 (next major)`,
-                value: `${major + 1}.0.0-rc.0`,
-              },
-            ]
+        const channelChoices =
+          isCanaryOfCurrent || currentChannel
+            ? [
+                // canary/other-channel of X.Y.Z -> offer X.Y.Z-<channel>.0
+                {
+                  title: `${major}.${minor}.${patch}-${requestedChannel}.0`,
+                  value: `${major}.${minor}.${patch}-${requestedChannel}.0`,
+                },
+              ]
+            : [
+                {
+                  title: `${major}.${minor + 1}.0-${requestedChannel}.0 (next minor)`,
+                  value: `${major}.${minor + 1}.0-${requestedChannel}.0`,
+                },
+                {
+                  title: `${major}.${minor}.${patch + 1}-${requestedChannel}.0 (next patch)`,
+                  value: `${major}.${minor}.${patch + 1}-${requestedChannel}.0`,
+                },
+                {
+                  title: `${major + 1}.0.0-${requestedChannel}.0 (next major)`,
+                  value: `${major + 1}.0.0-${requestedChannel}.0`,
+                },
+              ]
 
-        const rcAnswer = await prompts({
+        const channelAnswer = await prompts({
           type: 'select',
           name: 'version',
-          message: 'Which version to release as RC?',
-          choices: rcChoices,
+          message: `Which version to release as ${requestedChannel}?`,
+          choices: channelChoices,
         })
 
-        answer = rcAnswer
+        answer = channelAnswer
       } else {
         answer = await prompts({
           type: 'text',
@@ -391,10 +410,18 @@ async function run() {
       console.info('Next:', version, '\n')
     }
 
-    // safety check for major version bumps - always require interactive confirmation
+    // resolve + validate the npm dist-tag up front, so a prerelease can never
+    // slip onto `latest`, and so --dry-run can print the exact publish plan.
+    // throws loudly for an unrecognized prerelease instead of defaulting to latest.
+    const publishTag = computePublishTag(version, { canary, explicitTag })
+    console.info(`Publishing to npm dist-tag: ${publishTag}\n`)
+
+    // safety check for major version bumps going to `latest` - require interactive
+    // confirmation. a prerelease of a new major (e.g. 3.0.0-beta.0 -> `beta`) can't
+    // clobber the stable line, so it skips this gate.
     const curMajor = Number.parseInt(curVersion.split('.')[0], 10)
     const nextMajor = Number.parseInt(version.split('.')[0], 10)
-    if (nextMajor > curMajor) {
+    if (nextMajor > curMajor && publishTag === 'latest') {
       console.info(`\n⚠️  MAJOR VERSION BUMP: ${curVersion} → ${version}\n`)
 
       for (let i = 1; i <= 3; i++) {
@@ -410,14 +437,17 @@ async function run() {
       }
     }
 
-    console.info('install and build')
+    // dry run only previews the publish plan, so skip the heavy install/build/test
+    if (!dryRun) {
+      console.info('install and build')
+    }
 
-    if (!rePublish && !shouldFinish) {
+    if (!rePublish && !shouldFinish && !dryRun) {
       await spawnify(`bun install`)
     }
 
     // build from fresh
-    if (!skipBuild && !shouldFinish) {
+    if (!skipBuild && !shouldFinish && !dryRun) {
       // lets do a full clean and build:force, to ensure we dont have weird cached or leftover files
       if (buildFast) {
         await spawnify(`bun run build`)
@@ -428,7 +458,7 @@ async function run() {
     }
 
     // run checks
-    if (!shouldFinish) {
+    if (!shouldFinish && !dryRun) {
       if (!skipChecks) {
         console.info('run checks')
         await Promise.all([
@@ -458,8 +488,8 @@ async function run() {
       }
     }
 
-    // update version
-    if (!skipVersion && !shouldFinish) {
+    // update version (never write files during a dry run - it's a read-only preview)
+    if (!skipVersion && !shouldFinish && !dryRun) {
       await Promise.all(
         allPackageJsons.map(async ({ json, path }) => {
           const next = { ...json }
@@ -521,7 +551,9 @@ async function run() {
     const skippedVersions = new Map<string, string>()
 
     if (skippedPackages.length > 0) {
-      const distTag = canary ? 'canary' : 'latest'
+      // resolve against the same dist-tag we're publishing to, so a beta release
+      // points beta deps at the last beta, a stable at the last stable, etc.
+      const distTag = publishTag
       console.info(
         `Resolving last published versions for skipped packages (tag: ${distTag})...`
       )
@@ -548,7 +580,25 @@ async function run() {
     }
 
     if (!shouldFinish && dryRun) {
-      console.info(`Dry run, exiting before publish`)
+      console.info(`\n── dry run: publish plan ──`)
+      console.info(`version:      ${version}`)
+      console.info(`npm dist-tag: ${publishTag}`)
+      console.info(`\npublishing ${packagesToPublish.length} packages:\n`)
+      for (const { name } of packagesToPublish) {
+        const accessOption = name.startsWith('@') ? ' --access public' : ''
+        console.info(
+          `  npm publish ${name}@${version} --tag ${publishTag}${accessOption}`
+        )
+      }
+      if (skippedPackages.length > 0) {
+        console.info(
+          `\nskipped (unchanged), dist-tag "${publishTag}" will point at last published:`
+        )
+        for (const { name } of skippedPackages) {
+          console.info(`  ${name}@${skippedVersions.get(name) ?? '(unpublished)'}`)
+        }
+      }
+      console.info(`\nDry run, exiting before publish`)
       return
     }
 
@@ -572,11 +622,8 @@ async function run() {
       const tmpDir = `/tmp/tamagui-publish`
       await ensureDir(tmpDir)
 
-      const isCanaryVersion = /^\d+\.\d+\.\d+-\d+$/.test(version)
-      const publishTag = canary || isCanaryVersion ? 'canary' : 'latest'
-      const publishOptions = [publishTag && `--tag ${publishTag}`]
-        .filter(Boolean)
-        .join(' ')
+      // publishTag was resolved + validated up front (single source of truth)
+      const publishOptions = `--tag ${publishTag}`
 
       // shared OTP state — set once on first EOTP, then threaded through every
       // subsequent npm publish. single-flight so parallel failures don't
@@ -742,11 +789,12 @@ async function run() {
 
       console.info(`✅ Published\n`)
 
-      // for canary releases, point the canary dist-tag to the latest version for skipped packages
-      // so `npm install @tamagui/lucide-icons-2@canary` still resolves
-      if ((canary || isCanaryVersion) && skippedPackages.length > 0) {
+      // for a non-latest channel (canary/beta/rc/…), point that dist-tag at the
+      // latest published version of each skipped package so e.g.
+      // `npm install @tamagui/lucide-icons-2@beta` still resolves
+      if (publishTag !== 'latest' && skippedPackages.length > 0) {
         console.info(
-          `Updating canary dist-tags for ${skippedPackages.length} skipped packages...`
+          `Updating ${publishTag} dist-tags for ${skippedPackages.length} skipped packages...`
         )
         await pMap(
           skippedPackages,
@@ -755,13 +803,16 @@ async function run() {
               const { stdout } = await exec(`npm view ${name} dist-tags.latest`)
               const latestVersion = stdout.trim()
               if (latestVersion) {
-                await spawnify(`npm dist-tag add ${name}@${latestVersion} canary`, {
-                  avoidLog: true,
-                })
-                console.info(`  ✓ ${name}@${latestVersion} tagged as canary`)
+                await spawnify(
+                  `npm dist-tag add ${name}@${latestVersion} ${publishTag}`,
+                  {
+                    avoidLog: true,
+                  }
+                )
+                console.info(`  ✓ ${name}@${latestVersion} tagged as ${publishTag}`)
               }
             } catch (err) {
-              console.warn(`  ✗ ${name}: could not update canary tag`, err)
+              console.warn(`  ✗ ${name}: could not update ${publishTag} tag`, err)
             }
           },
           { concurrency: 10 }


### PR DESCRIPTION
## Why

`scripts/release.ts` had no `beta`/prerelease dist-tag path. The tag was picked
by an ad-hoc `canary || isCanaryVersion ? 'canary' : 'latest'`, so a version like
`3.0.0-beta.N` (or `3.0.0-rc.N`) matched neither branch and **silently published
to `latest`**, clobbering every `npm install tamagui` v2 user. This blocked
cutting the v3 tailwind beta (#4064).

## What

One mechanism, generalized from the existing canary handling (no parallel path):

- **`scripts/release-publish-tag.ts`** — a single pure `computePublishTag(version)`:
  - stable `X.Y.Z` → `latest`
  - canary `X.Y.Z-<timestamp>` (or `--canary`) → `canary`
  - channel `X.Y.Z-beta.N` / `-rc.N` / `-alpha.N` / `-next.N` / `-nightly.N` → that channel
  - explicit `--tag <name>` always wins (escape hatch)
  - **any unrecognized prerelease throws** instead of defaulting to `latest`
- `release.ts` now resolves the tag **once**, up front, and reuses it in all three
  places that used to compute it independently (publish, skipped-package version
  resolution, post-publish dist-tag fixups).
- `--beta` flag + `release:beta` / `release:beta:dirty` scripts (the release
  workflow already referenced `release:beta:dirty`). `--rc` was generalized into
  the same channel machinery.
- The major-bump triple-confirm now only fires when the target is `latest`, so a
  `3.0.0-beta.0` prerelease doesn't need the paranoid gate (it can't clobber the
  stable line).
- `--dry-run` is now a fast, read-only, branch-agnostic preview: it no longer
  installs/builds/tests or writes version files, and it prints the exact
  `npm publish … --tag <tag>` command for every package.

### Behavior change worth noting

`--rc` / any `-rc.N` version now publishes to the **`rc`** dist-tag instead of
`latest`. That's the same class of bug this PR fixes (a prerelease must never land
on `latest`). Promoting an RC to stable (plain `release` on a `-rc.N` version)
still resolves to the base version on `latest`.

## Validation (real `release.ts --dry-run`)

| scenario | version | resolved tag |
|---|---|---|
| stable base `2.4.0` | `2.5.0` | `latest` (all 160 pkgs) |
| `--beta` from canary | `3.0.0-beta.0` | `beta` (all 160 pkgs) |
| bump existing beta | `3.0.0-beta.3` → `3.0.0-beta.4` | `beta` |
| `--rc` from canary | `3.0.0-rc.0` | `rc` (not latest) |
| RC version, no flag | `3.0.0-rc.5` → `3.0.0` | `latest` (promotion) |
| unrecognized prerelease `3.0.0-experimental.1`, no `--tag` | — | **refuses, exit 1** |
| same + `--tag beta` | `3.0.0-experimental.1` | `beta` (escape hatch) |

`scripts/release-publish-tag.test.ts` (`bun test`) covers the pure logic: 9/9 pass.
oxfmt + oxlint clean.

## Not included

No publish / release is run here — this only changes the tooling. Cutting the
actual beta is a separate, explicitly-authorized step.
