### PR TITLE
fix: avoid stale RNGH taps for native press events

### DIFF
--- a/code/core/native/src/gesture-handler.ts
+++ b/code/core/native/src/gesture-handler.ts
@@ -6,6 +6,7 @@ export type {
 } from './gestureState'
 export {
   claimExternalPressOwnership as unstable_claimExternalPressOwnership,
+  hasExternalPressOwnership as unstable_hasExternalPressOwnership,
   releaseExternalPressOwnership as unstable_releaseExternalPressOwnership,
 } from './gestureState'
 export { PressBoundary } from './PressBoundary'

--- a/code/core/native/src/gestureState.ts
+++ b/code/core/native/src/gestureState.ts
@@ -93,6 +93,15 @@ type GestureTouchEvent = {
 }
 
 type PressOwnerSource = 'internal' | 'external' | null
+type PressOwnershipState = {
+  owner: object | null
+  ownerId: number | null
+  ownerSource: PressOwnerSource
+  ownerPointerId: number | null
+  timestamp: number
+}
+
+const PRESS_STATE_KEY = '__tamagui_press_state__'
 
 function getEventPointerId(e: any): number | null {
   const pointerId =
@@ -115,13 +124,17 @@ function getEventPointerId(e: any): number | null {
  * Uses a grace period to allow child gestures to steal ownership from parent,
  * since RNGH fires parent gestures before child gestures.
  */
-const pressState = {
-  owner: null as object | null,
-  ownerId: null as number | null,
-  ownerSource: null as PressOwnerSource,
-  ownerPointerId: null as number | null,
+const pressState = ((
+  globalThis as typeof globalThis & {
+    [PRESS_STATE_KEY]?: PressOwnershipState
+  }
+)[PRESS_STATE_KEY] ??= {
+  owner: null,
+  ownerId: null,
+  ownerSource: null,
+  ownerPointerId: null,
   timestamp: 0,
-}
+})
 
 export interface Insets {
   top?: number
@@ -189,6 +202,11 @@ export function releaseExternalPressOwnership(
     return
   }
   resetPressOwner()
+}
+
+export function hasExternalPressOwnership(): boolean {
+  resetStaleOwner(Date.now())
+  return pressState.ownerSource === 'external'
 }
 
 export function getGestureHandler(): GestureHandlerAccessor {

--- a/code/core/native/src/index.ts
+++ b/code/core/native/src/index.ts
@@ -44,6 +44,7 @@ export type { PortalAccessor } from './portalState'
 export { getGestureHandler } from './gestureState'
 export {
   claimExternalPressOwnership as unstable_claimExternalPressOwnership,
+  hasExternalPressOwnership as unstable_hasExternalPressOwnership,
   releaseExternalPressOwnership as unstable_releaseExternalPressOwnership,
 } from './gestureState'
 export type {

--- a/code/core/native/types/gesture-handler.d.ts
+++ b/code/core/native/types/gesture-handler.d.ts
@@ -1,6 +1,6 @@
 export { getGestureHandler } from "./gestureState";
 export type { ExternalPressOwnershipToken, GestureHandlerAccessor, PressGestureConfig } from "./gestureState";
-export { claimExternalPressOwnership as unstable_claimExternalPressOwnership, releaseExternalPressOwnership as unstable_releaseExternalPressOwnership } from "./gestureState";
+export { claimExternalPressOwnership as unstable_claimExternalPressOwnership, hasExternalPressOwnership as unstable_hasExternalPressOwnership, releaseExternalPressOwnership as unstable_releaseExternalPressOwnership } from "./gestureState";
 export { PressBoundary } from "./PressBoundary";
 export type { PressBoundaryProps } from "./PressBoundary";
 export { getGestureHandlerConfig, setupGestureHandler, type GestureHandlerConfig } from "./setup-gesture-handler";

--- a/code/core/native/types/gestureState.d.ts
+++ b/code/core/native/types/gestureState.d.ts
@@ -25,6 +25,7 @@ export interface GestureHandlerAccessor {
 export type ExternalPressOwnershipToken = object;
 export declare function claimExternalPressOwnership(debugName?: string | null): ExternalPressOwnershipToken;
 export declare function releaseExternalPressOwnership(token: ExternalPressOwnershipToken | null | undefined, debugName?: string | null): void;
+export declare function hasExternalPressOwnership(): boolean;
 export declare function getGestureHandler(): GestureHandlerAccessor;
 
 //# sourceMappingURL=gestureState.d.ts.map

--- a/code/core/native/types/index.d.ts
+++ b/code/core/native/types/index.d.ts
@@ -22,7 +22,7 @@ export type { NativePortalState, GestureState, WorkletsState, SafeAreaState, Saf
 export { getPortal } from "./portalState";
 export type { PortalAccessor } from "./portalState";
 export { getGestureHandler } from "./gestureState";
-export { claimExternalPressOwnership as unstable_claimExternalPressOwnership, releaseExternalPressOwnership as unstable_releaseExternalPressOwnership } from "./gestureState";
+export { claimExternalPressOwnership as unstable_claimExternalPressOwnership, hasExternalPressOwnership as unstable_hasExternalPressOwnership, releaseExternalPressOwnership as unstable_releaseExternalPressOwnership } from "./gestureState";
 export type { ExternalPressOwnershipToken, GestureHandlerAccessor, PressGestureConfig } from "./gestureState";
 export type { GestureHandlerConfig } from "./setup-gesture-handler";
 export { getWorklets } from "./workletsState";

--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -280,10 +280,14 @@ export function createComponent<
 
     // test only
     if (process.env.NODE_ENV === 'test') {
-      if (propsIn['data-test-renders']) {
-        propsIn['data-test-renders']['current'] =
-          propsIn['data-test-renders']['current'] ?? 0
-        propsIn['data-test-renders']['current'] += 1
+      const testRenderCount = propsIn['data-test-renders']
+      if (
+        testRenderCount &&
+        typeof testRenderCount === 'object' &&
+        !Object.isFrozen(testRenderCount)
+      ) {
+        testRenderCount.current = testRenderCount.current ?? 0
+        testRenderCount.current += 1
       }
     }
 
@@ -1629,7 +1633,8 @@ export function createComponent<
         pressGesture,
         stateRef,
         isHOC,
-        isCompositeComponent
+        isCompositeComponent,
+        hasRealPressEvents
       )
     }
 

--- a/code/core/web/src/eventHandling.native.ts
+++ b/code/core/web/src/eventHandling.native.ts
@@ -153,15 +153,20 @@ export function useEvents(
     const callbacksRef = useRef<any>(isUsingRNGH ? {} : null)
     const gestureRef = useRef<any>(null)
 
+    // Real press handlers use the responder system for delivery even when RNGH
+    // is configured. RNGH Tap begin/end ordering is not stable enough for
+    // nested Tamagui press arbitration, and Fabric can mount a stale Tap that
+    // claims responder but never finalizes. The responder path is the source of
+    // truth RN already uses for innermost press ownership.
+    //
     // Android pressStyle-only fallback: wire synthesized press handlers to the
     // responder system on viewProps instead of an RNGH Manual observer (which
     // freezes Android — see top-of-file isAndroid comment). Hook is called
     // unconditionally here for stable hooks order; useMainThreadPressEvents
     // no-ops when enabled is false.
     const useResponderFallback =
-      getIsAndroid() &&
-      !(hasRealPressEvents || stateRef.current.hasRealPressEvents) &&
-      Boolean(hasPressEvents)
+      !isInsideNativeMenu &&
+      Boolean(hasRealPressEvents || (getIsAndroid() && hasPressEvents))
     useMainThreadPressEvents(events, viewProps, useResponderFallback, debugName)
 
     if (everEnabled) {
@@ -174,6 +179,14 @@ export function useEvents(
             onLongPress: events.onLongPress,
           }
         : {}
+
+      if (hasRealPressEvents && !isInsideNativeMenu) {
+        // Real handlers are delivered by useMainThreadPressEvents above. Clear
+        // any cached pressStyle observer from an earlier render so it cannot
+        // double-fire after onPress appears dynamically.
+        gestureRef.current = null
+        return null
+      }
 
       // only create gesture once, callbacks are read from ref
       if (!gestureRef.current) {
@@ -197,19 +210,6 @@ export function useEvents(
               callbacksRef.current.onPressOut?.({})
             })
           gestureRef.current = manual
-        } else if (hasRealPressEvents || stateRef.current.hasRealPressEvents) {
-          // real user handler: full PressGesture, participates in the press
-          // ownership token system so nested real-handler children win
-          // arbitration (NestedPressExclusive semantics).
-          gestureRef.current = gh.createPressGesture({
-            debugName,
-            onPressIn: (e: any) => callbacksRef.current.onPressIn?.(e),
-            onPressOut: (e: any) => callbacksRef.current.onPressOut?.(e),
-            onPress: (e: any) => callbacksRef.current.onPress?.(e),
-            onLongPress: (e: any) => callbacksRef.current.onLongPress?.(e),
-            delayLongPress: events?.delayLongPress,
-            hitSlop: viewProps.hitSlop,
-          })
         } else if (!getIsAndroid()) {
           // pressStyle-only (events.onPress was synthesized to drive pressStyle
           // visuals, no user handler): use Manual + manualActivation. Touch
@@ -249,9 +249,10 @@ export function useEvents(
 export function wrapWithGestureDetector(
   content: any,
   gesture: any,
-  stateRef: { current: TamaguiComponentStateRef },
+  _stateRef: { current: TamaguiComponentStateRef },
   isHOC?: boolean,
-  isCompositeComponent?: boolean
+  isCompositeComponent?: boolean,
+  hasRealPressEvents?: boolean
 ) {
   // Skip wrapping for HOC and composite components - they pass press events
   // to the inner component via props instead of using GestureDetector
@@ -260,25 +261,12 @@ export function wrapWithGestureDetector(
   }
 
   const gh = getGestureHandler()
-  const { GestureDetector, Gesture } = gh.state
+  const { GestureDetector } = gh.state
 
-  // wrap whenever any press gesture was attached (real handler OR
-  // synthesized pressStyle observer). only the real-handler path claims
-  // the responder on Paper — observers must not preempt parents.
-  // On Android we skip the observer gesture entirely (see top-of-file
-  // isAndroid comment), so the wrap is real-handlers-only there.
-  const shouldWrap = getIsAndroid()
-    ? stateRef.current.hasRealPressEvents
-    : stateRef.current.hasHadEvents
-
-  if (!GestureDetector || !shouldWrap) {
-    return content
-  }
-
-  // use actual gesture or no-op Manual gesture to maintain tree structure
-  const gestureToUse = gesture || Gesture?.Manual()
-
-  if (!gestureToUse) {
+  // Only wrap when useEvents actually produced an RNGH gesture. Real press
+  // handlers are responder-delivered; wrapping them in a no-op GestureDetector
+  // recreates the same stale Tap/dead-zone failure mode this path avoids.
+  if (!GestureDetector || !gesture) {
     return content
   }
 
@@ -288,8 +276,8 @@ export function wrapWithGestureDetector(
   // where the View carries the merged navigate handler and the inner Button
   // has only pressStyle). The Manual gesture observes touches on the UI thread
   // for fast pressStyle visuals without participating in arbitration.
-  if (!stateRef.current.hasRealPressEvents) {
-    return React.createElement(GestureDetector, { gesture: gestureToUse }, content)
+  if (!hasRealPressEvents) {
+    return React.createElement(GestureDetector, { gesture }, content)
   }
 
   if (isFabric) {
@@ -310,7 +298,7 @@ export function wrapWithGestureDetector(
     const claimed = React.cloneElement(content, {
       onStartShouldSetResponder: responderClaim,
     })
-    return React.createElement(GestureDetector, { gesture: gestureToUse }, claimed)
+    return React.createElement(GestureDetector, { gesture }, claimed)
   }
 
   // Paper: keep the hoisted display:contents wrapper. claiming on the gesture
@@ -325,6 +313,6 @@ export function wrapWithGestureDetector(
       style: responderWrapperStyle,
       onStartShouldSetResponder: responderClaim,
     },
-    React.createElement(GestureDetector, { gesture: gestureToUse }, content)
+    React.createElement(GestureDetector, { gesture }, content)
   )
 }

--- a/code/core/web/src/eventHandling.ts
+++ b/code/core/web/src/eventHandling.ts
@@ -27,7 +27,8 @@ export function wrapWithGestureDetector(
   _gesture: any,
   _stateRef: { current: any },
   _isHOC?: boolean,
-  _isCompositeComponent?: boolean
+  _isCompositeComponent?: boolean,
+  _hasRealPressEvents?: boolean
 ) {
   return content
 }

--- a/code/core/web/src/helpers/mainThreadPressEvents.native.ts
+++ b/code/core/web/src/helpers/mainThreadPressEvents.native.ts
@@ -6,6 +6,7 @@
  * long press, cancellation, and min press duration.
  */
 
+import { unstable_hasExternalPressOwnership } from '@tamagui/native'
 import { useRef } from 'react'
 
 type PressState =
@@ -20,6 +21,7 @@ interface PressRef {
   pressOutTimer: ReturnType<typeof setTimeout> | null
   longPressTimer: ReturnType<typeof setTimeout> | null
   activateTime: number
+  blockedByExternalOwnership: boolean
 }
 
 const DEFAULT_LONG_PRESS_DELAY = 500
@@ -39,6 +41,7 @@ export function useMainThreadPressEvents(
       pressOutTimer: null,
       longPressTimer: null,
       activateTime: 0,
+      blockedByExternalOwnership: false,
     }
   }
 
@@ -92,12 +95,22 @@ export function useMainThreadPressEvents(
   const userTerminationRequest = viewProps.onResponderTerminationRequest
   const userMove = viewProps.onResponderMove
 
-  viewProps.onStartShouldSetResponder = (e: any) =>
-    Boolean(userStartShouldSet?.(e)) || !events.disabled
+  viewProps.onStartShouldSetResponder = (e: any) => {
+    if (userStartShouldSet?.(e)) return true
+    return !events.disabled && !unstable_hasExternalPressOwnership()
+  }
 
   viewProps.onResponderGrant = (e: any) => {
-    userGrant?.(e)
     cleanup()
+
+    if (unstable_hasExternalPressOwnership()) {
+      ref.current.state = 'idle'
+      ref.current.blockedByExternalOwnership = true
+      return
+    }
+
+    userGrant?.(e)
+    ref.current.blockedByExternalOwnership = false
     ref.current.state = 'pressing'
 
     if (delayPressIn > 0) {
@@ -117,6 +130,13 @@ export function useMainThreadPressEvents(
   }
 
   viewProps.onResponderRelease = (e: any) => {
+    if (ref.current.blockedByExternalOwnership || unstable_hasExternalPressOwnership()) {
+      cleanup()
+      ref.current.blockedByExternalOwnership = false
+      ref.current.state = 'idle'
+      return
+    }
+
     userRelease?.(e)
     const wasLongPressed = ref.current.state === 'longPressed'
     cleanup()
@@ -132,6 +152,7 @@ export function useMainThreadPressEvents(
 
     deactivate(e)
     ref.current.state = 'idle'
+    ref.current.blockedByExternalOwnership = false
   }
 
   viewProps.onResponderTerminate = (e: any) => {
@@ -141,6 +162,7 @@ export function useMainThreadPressEvents(
       deactivate(e)
     }
     ref.current.state = 'idle'
+    ref.current.blockedByExternalOwnership = false
   }
 
   viewProps.onResponderTerminationRequest = (e: any) => {

--- a/code/core/web/types/eventHandling.d.ts
+++ b/code/core/web/types/eventHandling.d.ts
@@ -19,7 +19,7 @@ export declare function getWebEvents<E extends EventLikeObject>(events: E, webSt
 };
 export declare function wrapWithGestureDetector(content: any, _gesture: any, _stateRef: {
     current: any;
-}, _isHOC?: boolean, _isCompositeComponent?: boolean): any;
+}, _isHOC?: boolean, _isCompositeComponent?: boolean, _hasRealPressEvents?: boolean): any;
 export declare function useEvents(_events: any, _viewProps: any, _stateRef: {
     current: any;
 }, _staticConfig: any, _isHOC?: boolean, _isInsideNativeMenu?: boolean, _debugName?: string | null, _hasRealPressEvents?: boolean): null;

--- a/code/core/web/types/eventHandling.native.d.ts
+++ b/code/core/web/types/eventHandling.native.d.ts
@@ -6,7 +6,7 @@ export declare function getWebEvents(): {};
 export declare function useEvents(events: any, viewProps: any, stateRef: {
     current: TamaguiComponentStateRef;
 }, staticConfig: StaticConfig, isHOC?: boolean, isInsideNativeMenu?: boolean, debugName?: string | null, hasRealPressEvents?: boolean): any;
-export declare function wrapWithGestureDetector(content: any, gesture: any, stateRef: {
+export declare function wrapWithGestureDetector(content: any, gesture: any, _stateRef: {
     current: TamaguiComponentStateRef;
-}, isHOC?: boolean, isCompositeComponent?: boolean): any;
+}, isHOC?: boolean, isCompositeComponent?: boolean, hasRealPressEvents?: boolean): any;
 //# sourceMappingURL=eventHandling.native.d.ts.map

--- a/code/kitchen-sink/e2e/SheetPressResponderSheetRngh.test.ts
+++ b/code/kitchen-sink/e2e/SheetPressResponderSheetRngh.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression for setupGestureHandler({ pressEvents: false, sheet: true }).
+ *
+ * pressEvents: false must move Tamagui pressables onto the responder fallback
+ * without dragging Sheet down to its PanResponder fallback. This mirrors the
+ * workaround from #4024 while keeping Sheet on RNGH.
+ */
+
+import { by, element, expect, waitFor } from 'detox'
+import { remountDirectUseCase } from './utils/navigation'
+import { safeLaunchApp } from './utils/detox'
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+const testElement = (id: string) => element(by.id(id)).atIndex(0)
+
+async function openSheet() {
+  await testElement('sheet-press-trigger').tap()
+  await waitFor(testElement('sheet-press-input')).toBeVisible().withTimeout(5000)
+  await sleep(700)
+}
+
+describe('SheetPressResponderSheetRngh', () => {
+  beforeAll(async () => {
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: {
+        directUseCase: 'SheetPressRegressionCase',
+        disablePressEventsKeepSheet: true,
+      },
+    })
+    await waitFor(element(by.id('sheet-press-screen')))
+      .toExist()
+      .withTimeout(180000)
+  })
+
+  beforeEach(async () => {
+    await remountDirectUseCase('sheet-press-screen')
+  })
+
+  it('disables press RNGH while keeping Sheet RNGH enabled', async () => {
+    await expect(testElement('sheet-press-press-rngh-status')).toHaveText(
+      'pressRNGH: off'
+    )
+    await expect(testElement('sheet-press-sheet-rngh-status')).toHaveText('sheetRNGH: on')
+  })
+
+  it('fires responder-backed pressables inside an RNGH sheet', async () => {
+    await openSheet()
+
+    await testElement('sheet-press-scroll-button').tap()
+    await sleep(200)
+    await expect(testElement('sheet-press-scroll-button-count')).toHaveText(
+      'scrollButton: 1'
+    )
+
+    await testElement('sheet-press-media-card').tap()
+    await sleep(200)
+    await expect(testElement('sheet-press-media-card-count')).toHaveText('mediaCard: 1')
+
+    await testElement('sheet-press-footer-post').tap()
+    await sleep(200)
+    await expect(testElement('sheet-press-post-count')).toHaveText('post: 1')
+  })
+
+  it('keeps sheet drag working with press RNGH disabled', async () => {
+    await openSheet()
+
+    await testElement('sheet-press-frame').swipe('down', 'slow', 0.75)
+    await sleep(700)
+
+    await waitFor(testElement('sheet-press-input')).not.toBeVisible().withTimeout(5000)
+  })
+})

--- a/code/kitchen-sink/src/App.native.tsx
+++ b/code/kitchen-sink/src/App.native.tsx
@@ -1,9 +1,11 @@
 // check launch args for disabling RNGH (for testing without gesture handler)
 import { LaunchArguments } from 'react-native-launch-arguments'
 import { getGestureHandler } from '@tamagui/native'
+import { setupGestureHandler } from '@tamagui/native/setup-gesture-handler'
 
 interface TestLaunchArgs {
   disableGestureHandler?: boolean
+  disablePressEventsKeepSheet?: boolean
   disableKeyboardController?: boolean
   initialTestCase?: string
   directUseCase?: string
@@ -21,10 +23,13 @@ const isTrueArg = (value: unknown) =>
 const launchArgs = {
   ...rawLaunchArgs,
   disableGestureHandler: isTrueArg(rawLaunchArgs.disableGestureHandler),
+  disablePressEventsKeepSheet: isTrueArg(rawLaunchArgs.disablePressEventsKeepSheet),
   disableKeyboardController: isTrueArg(rawLaunchArgs.disableKeyboardController),
 }
 
-if (launchArgs.disableGestureHandler) {
+if (launchArgs.disablePressEventsKeepSheet) {
+  setupGestureHandler({ pressEvents: false, sheet: true })
+} else if (launchArgs.disableGestureHandler) {
   getGestureHandler().disable()
 }
 

--- a/code/kitchen-sink/src/usecases/SheetPressRegressionCase.tsx
+++ b/code/kitchen-sink/src/usecases/SheetPressRegressionCase.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { getGestureHandler } from '@tamagui/native'
+import { unstable_isSheetGestureHandlerEnabled } from '@tamagui/sheet'
 import { Button, Input, Sheet, Text, View, XStack, YStack } from 'tamagui'
 
 /**
@@ -17,6 +19,8 @@ import { Button, Input, Sheet, Text, View, XStack, YStack } from 'tamagui'
 export function SheetPressRegressionCase() {
   const [open, setOpen] = useState(false)
   const [caption, setCaption] = useState('')
+  const pressRnghEnabled = getGestureHandler().isEnabled
+  const sheetRnghEnabled = unstable_isSheetGestureHandlerEnabled()
 
   const [postCount, setPostCount] = useState(0)
   const [cancelCount, setCancelCount] = useState(0)
@@ -37,6 +41,14 @@ export function SheetPressRegressionCase() {
       <Text fontSize="$5" fontWeight="bold">
         Sheet Press Regression
       </Text>
+      <XStack gap="$3">
+        <Text testID="sheet-press-press-rngh-status">
+          pressRNGH: {pressRnghEnabled ? 'on' : 'off'}
+        </Text>
+        <Text testID="sheet-press-sheet-rngh-status">
+          sheetRNGH: {sheetRnghEnabled ? 'on' : 'off'}
+        </Text>
+      </XStack>
 
       <Button
         testID="sheet-press-trigger"

--- a/code/ui/components-test/Button.native.test.tsx
+++ b/code/ui/components-test/Button.native.test.tsx
@@ -1,10 +1,68 @@
 import { getDefaultTamaguiConfig } from '@tamagui/config-default'
 import { Button } from '@tamagui/button'
-import { TamaguiProvider, createTamagui, styled } from '@tamagui/core'
+import { TamaguiProvider, View, createTamagui, styled } from '@tamagui/core'
+import {
+  getGestureHandler,
+  unstable_claimExternalPressOwnership,
+  unstable_hasExternalPressOwnership,
+  unstable_releaseExternalPressOwnership,
+} from '@tamagui/native'
+import type { ReactNode } from 'react'
 import TestRenderer, { act } from 'react-test-renderer'
-import { describe, expect, test } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
 const conf = createTamagui(getDefaultTamaguiConfig())
+const GESTURE_ENABLED_FREEZE_KEY = '__tamagui_gesture_enabled_freeze__'
+
+function createGestureStub() {
+  const gesture: any = {}
+
+  for (const method of [
+    'runOnJS',
+    'maxDuration',
+    'minDuration',
+    'manualActivation',
+    'hitSlop',
+    'onBegin',
+    'onStart',
+    'onEnd',
+    'onFinalize',
+    'onTouchesDown',
+    'onTouchesMove',
+    'onTouchesUp',
+    'onTouchesCancelled',
+  ]) {
+    gesture[method] = () => gesture
+  }
+
+  return gesture
+}
+
+function resetGestureHandlerFreeze() {
+  delete (globalThis as any)[GESTURE_ENABLED_FREEZE_KEY]
+}
+
+function setGestureHandlerEnabled(
+  enabled: boolean,
+  GestureDetector?: any,
+  GestureOverrides?: Record<string, any>
+) {
+  getGestureHandler().set({
+    enabled,
+    GestureDetector: enabled ? GestureDetector : null,
+    Gesture: enabled
+      ? {
+          Tap: createGestureStub,
+          LongPress: createGestureStub,
+          Manual: createGestureStub,
+          Exclusive: (...gestures: any[]) => gestures[0],
+          ...GestureOverrides,
+        }
+      : null,
+    ScrollView: null,
+    RootView: null,
+  })
+}
 
 async function renderButton(element: React.ReactElement) {
   let rendered: TestRenderer.ReactTestRenderer | null = null
@@ -41,6 +99,18 @@ function flattenStyle(style: any): Record<string, any> {
 
   return style || {}
 }
+
+beforeEach(() => {
+  resetGestureHandlerFreeze()
+  setGestureHandlerEnabled(false)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  resetGestureHandlerFreeze()
+  setGestureHandlerEnabled(false)
+})
 
 describe('Button native text props', () => {
   test('passes maxFontSizeMultiplier from root props to wrapped text', async () => {
@@ -99,5 +169,99 @@ describe('Button native text props', () => {
     const rendered = await renderButton(<Button>HELLO</Button>)
 
     expect(flattenStyle(findWrappedText(rendered).props.style).cursor).toBeUndefined()
+  })
+
+  test('uses responder events for real press handlers when RNGH is enabled', async () => {
+    vi.useFakeTimers()
+
+    const GestureDetector = ({ children }: { children: ReactNode }) => {
+      return children
+    }
+    let tapGestureCalls = 0
+    setGestureHandlerEnabled(true, GestureDetector, {
+      Tap: () => {
+        tapGestureCalls += 1
+        return createGestureStub()
+      },
+    })
+
+    const onPressIn = vi.fn()
+    const onPress = vi.fn()
+    const onPressOut = vi.fn()
+
+    const rendered = await renderButton(
+      <View
+        width={10}
+        height={10}
+        minPressDuration={0}
+        onPressIn={onPressIn}
+        onPress={onPress}
+        onPressOut={onPressOut}
+      />
+    )
+
+    expect(tapGestureCalls).toBe(0)
+
+    const responderNode = rendered.root.find(
+      (node) =>
+        typeof node.props.onResponderGrant === 'function' &&
+        typeof node.props.onResponderRelease === 'function'
+    )
+
+    await act(async () => {
+      responderNode.props.onResponderGrant({})
+      responderNode.props.onResponderRelease({})
+      vi.runAllTimers()
+    })
+
+    expect(onPressIn).toHaveBeenCalledTimes(1)
+    expect(onPress).toHaveBeenCalledTimes(1)
+    expect(onPressOut).toHaveBeenCalledTimes(1)
+  })
+
+  test('responder press fallback respects external press ownership', async () => {
+    vi.useFakeTimers()
+
+    setGestureHandlerEnabled(true, ({ children }: { children: ReactNode }) => children)
+
+    const onPressIn = vi.fn()
+    const onPress = vi.fn()
+    const onPressOut = vi.fn()
+
+    const rendered = await renderButton(
+      <Button
+        minPressDuration={0}
+        onPressIn={onPressIn}
+        onPress={onPress}
+        onPressOut={onPressOut}
+      >
+        HELLO
+      </Button>
+    )
+
+    const responderNodes = rendered.root.findAll(
+      (node) =>
+        typeof node.props.onStartShouldSetResponder === 'function' &&
+        typeof node.props.onResponderGrant === 'function' &&
+        typeof node.props.onResponderRelease === 'function'
+    )
+
+    const owner = unstable_claimExternalPressOwnership('button-test')
+    expect(unstable_hasExternalPressOwnership()).toBe(true)
+    const responderNode = responderNodes.find(
+      (node) => node.props.onStartShouldSetResponder({}) === false
+    )
+    expect(responderNode).toBeTruthy()
+
+    await act(async () => {
+      responderNode!.props.onResponderGrant({})
+      unstable_releaseExternalPressOwnership(owner, 'button-test')
+      responderNode!.props.onResponderRelease({})
+      vi.runAllTimers()
+    })
+
+    expect(onPressIn).not.toHaveBeenCalled()
+    expect(onPress).not.toHaveBeenCalled()
+    expect(onPressOut).not.toHaveBeenCalled()
   })
 })

--- a/code/ui/components-test/SheetGestureState.native.test.tsx
+++ b/code/ui/components-test/SheetGestureState.native.test.tsx
@@ -1,0 +1,76 @@
+import { getGestureHandler } from '@tamagui/native'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import {
+  getGestureHandlerState,
+  isGestureHandlerEnabled,
+  setGestureHandlerState,
+} from '../sheet/src/gestureState'
+import {
+  isGestureHandlerEnabled as isLegacyGestureHandlerEnabled,
+  setupGestureHandler,
+} from '../sheet/src/setupGestureHandler'
+
+const SHEET_GESTURE_STATE_KEY = '__tamagui_sheet_gesture_state__'
+const SHEET_LEGACY_SETUP_KEY = '__tamagui_sheet_gesture_handler_setup'
+const GESTURE_ENABLED_FREEZE_KEY = '__tamagui_gesture_enabled_freeze__'
+
+function resetGlobals() {
+  delete (globalThis as any)[SHEET_GESTURE_STATE_KEY]
+  delete (globalThis as any)[SHEET_LEGACY_SETUP_KEY]
+  delete (globalThis as any)[GESTURE_ENABLED_FREEZE_KEY]
+}
+
+function setPressGestureHandlerEnabled(enabled: boolean) {
+  getGestureHandler().set({
+    enabled,
+    Gesture: null,
+    GestureDetector: null,
+    ScrollView: null,
+    RootView: null,
+  })
+}
+
+beforeEach(() => {
+  resetGlobals()
+  setPressGestureHandlerEnabled(false)
+})
+
+afterEach(() => {
+  resetGlobals()
+  setPressGestureHandlerEnabled(false)
+})
+
+describe('Sheet gesture state', () => {
+  test('reads sheet RNGH state independently from pressEvents state', () => {
+    const sheetState = {
+      enabled: true,
+      Gesture: { Pan: () => null },
+      GestureDetector: () => null,
+      ScrollView: {},
+      RootView: {},
+    }
+
+    ;(globalThis as any)[SHEET_GESTURE_STATE_KEY] = sheetState
+
+    expect(getGestureHandler().isEnabled).toBe(false)
+    expect(isGestureHandlerEnabled()).toBe(true)
+    expect(getGestureHandlerState()).toBe(sheetState)
+
+    setGestureHandlerState({ enabled: false })
+
+    expect(sheetState.enabled).toBe(false)
+    expect(getGestureHandler().isEnabled).toBe(false)
+  })
+
+  test('legacy sheet setup does not enable global press events', () => {
+    setupGestureHandler({
+      Gesture: { Pan: () => null },
+      GestureDetector: () => null,
+      ScrollView: {},
+    })
+
+    expect(isLegacyGestureHandlerEnabled()).toBe(true)
+    expect(isGestureHandlerEnabled()).toBe(true)
+    expect(getGestureHandler().isEnabled).toBe(false)
+  })
+})

--- a/code/ui/sheet/src/gestureState.ts
+++ b/code/ui/sheet/src/gestureState.ts
@@ -7,16 +7,36 @@ import { getGestureHandler, type GestureState } from '@tamagui/native'
 
 export type { GestureState as GestureHandlerState } from '@tamagui/native'
 
+const SHEET_GESTURE_STATE_KEY = '__tamagui_sheet_gesture_state__'
+
+function getSheetGestureHandlerState(): GestureState {
+  const g = globalThis as typeof globalThis & {
+    [SHEET_GESTURE_STATE_KEY]?: GestureState
+  }
+
+  return g[SHEET_GESTURE_STATE_KEY] ?? getGestureHandler().state
+}
+
 // backward compat helpers
 export function isGestureHandlerEnabled(): boolean {
-  return getGestureHandler().isEnabled
+  return getSheetGestureHandlerState().enabled
 }
 
 export function getGestureHandlerState(): GestureState {
-  return getGestureHandler().state
+  return getSheetGestureHandlerState()
 }
 
 export function setGestureHandlerState(updates: Partial<GestureState>): void {
+  const g = globalThis as typeof globalThis & {
+    [SHEET_GESTURE_STATE_KEY]?: GestureState
+  }
+
+  const sheetState = g[SHEET_GESTURE_STATE_KEY]
+  if (sheetState) {
+    Object.assign(sheetState, updates)
+    return
+  }
+
   getGestureHandler().set(updates)
 }
 

--- a/code/ui/sheet/src/index.ts
+++ b/code/ui/sheet/src/index.ts
@@ -9,3 +9,7 @@ export * from './SheetScrollView'
 export * from './nativeSheet'
 export * from './types'
 export * from './contexts'
+export {
+  getGestureHandlerState as unstable_getSheetGestureHandlerState,
+  isGestureHandlerEnabled as unstable_isSheetGestureHandlerEnabled,
+} from './gestureState'

--- a/code/ui/sheet/src/setupGestureHandler.ts
+++ b/code/ui/sheet/src/setupGestureHandler.ts
@@ -4,8 +4,16 @@
 
 import { getGestureHandler } from '@tamagui/native'
 
+import type { GestureState } from '@tamagui/native'
+
+const SHEET_GESTURE_STATE_KEY = '__tamagui_sheet_gesture_state__'
+
 export function isGestureHandlerEnabled(): boolean {
-  return getGestureHandler().isEnabled
+  const g = globalThis as typeof globalThis & {
+    [SHEET_GESTURE_STATE_KEY]?: GestureState
+  }
+
+  return g[SHEET_GESTURE_STATE_KEY]?.enabled ?? getGestureHandler().isEnabled
 }
 
 export interface SetupGestureHandlerConfig {
@@ -24,11 +32,12 @@ export function setupGestureHandler(config: SetupGestureHandlerConfig): void {
   const { Gesture, GestureDetector, ScrollView } = config
 
   if (Gesture && GestureDetector) {
-    getGestureHandler().set({
+    g[SHEET_GESTURE_STATE_KEY] = {
       enabled: true,
       Gesture,
       GestureDetector,
       ScrollView: ScrollView || null,
-    })
+      RootView: null,
+    } satisfies GestureState
   }
 }

--- a/code/ui/sheet/types/index.d.ts
+++ b/code/ui/sheet/types/index.d.ts
@@ -9,4 +9,5 @@ export * from './SheetScrollView';
 export * from './nativeSheet';
 export * from './types';
 export * from './contexts';
+export { getGestureHandlerState as unstable_getSheetGestureHandlerState, isGestureHandlerEnabled as unstable_isSheetGestureHandlerEnabled, } from './gestureState';
 //# sourceMappingURL=index.d.ts.map


### PR DESCRIPTION
Summary
- deliver native Tamagui real press handlers through the RN responder fallback instead of RNGH Tap, while preserving pressStyle-only RNGH observers where safe
- split Sheet RNGH state from global pressEvents so setupGestureHandler({ pressEvents: false, sheet: true }) keeps Sheet on RNGH
- add unit coverage plus a Detox regression for responder-backed pressables inside an RNGH Sheet

Validation
- bunx turbo run build --filter=@tamagui/core...
- bunx turbo run build --filter=@tamagui/sheet...
- bunx turbo run build --filter=@tamagui/vite-plugin... --filter=@tamagui/vite-plugin-internal...
- bunx turbo run build --filter=@tamagui/button...
- TAMAGUI_TARGET=native bunx vitest --run --config ../../packages/vite-plugin-internal/src/vite.config.ts Button.native.test.tsx SheetGestureState.native.test.tsx
- TAMAGUI_TARGET=native bunx vitest --run --config ../packages/vite-plugin-internal/src/vite.config.ts core-test/gestureHandlerFreeze.native.test.tsx core-test/buttonDisabledHooks.native.test.tsx
- SKIP_METRO=1 bun run detox:run:ios e2e/SheetPressResponderSheetRngh.test.ts (clean Metro --clear on port 9034)
- bun run format:check -- touched files
- bunx oxlint touched files
- git diff --check

Ready for publish after merge.

Fixes #4024