### PR TITLE
fix(vite-plugin): correct invalid vite peer dependency semver

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -235,6 +235,9 @@
         "@tamagui/build": "workspace:*",
         "vite": "^8.0.3",
       },
+      "peerDependencies": {
+        "vite": "^8.0.3",
+      },
     },
     "code/compiler/vite-plugin-cjs": {
       "name": "@tamagui/vite-plugin-cjs",

--- a/code/compiler/vite-plugin/package.json
+++ b/code/compiler/vite-plugin/package.json
@@ -47,6 +47,9 @@
     "@tamagui/build": "workspace:*",
     "vite": "^8.0.3"
   },
+  "peerDependencies": {
+    "vite": "^8.0.3"
+  },
   "tamagui": {
     "build": {
       "skipEnvToMeta": true


### PR DESCRIPTION
Fixes #4008.

Summary:
- restores @tamagui/vite-plugin peerDependencies.vite as ^8.0.3
- updates bun.lock workspace metadata for the package peer
- swept 186 package.json files for malformed semver dependency ranges; no other malformed ranges found

Validation:
- bun install --frozen-lockfile
- bun run build in code/compiler/vite-plugin
- semver sweep across all package.json dependency-like fields, including malformed star-prefixed ranges such as *8.0.3
- npm pack into /tmp and verified packed package.json has peerDependencies.vite: ^8.0.3
- bun run check:deps
