### PR TITLE
fix(toast): preserve v2 context through portals

### DIFF
--- a/code/tamagui.dev/data/docs/components/toast-2/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/toast-2/2.0.0.mdx
@@ -36,33 +36,25 @@ Optionally install [Burnt](https://github.com/nandorojo/burnt) for native OS-lev
 ## Quick Start
 
 ```tsx
-import { Toast, toast, useToasts } from '@tamagui/toast/v2'
+import { Toast, toast } from '@tamagui/toast/v2'
 
 function App() {
   return (
     <Toast position="bottom-right">
       <Toast.Viewport>
-        <ToastList />
+        <Toast.List
+          renderItem={({ toast: t, index }) => (
+            <Toast.Item key={t.id} toast={t} index={index}>
+              <Toast.Title>{t.title}</Toast.Title>
+              <Toast.Description>{t.description}</Toast.Description>
+              <Toast.Close />
+            </Toast.Item>
+          )}
+        />
       </Toast.Viewport>
 
       <Button onPress={() => toast('Hello!')}>Show Toast</Button>
     </Toast>
-  )
-}
-
-function ToastList() {
-  const { toasts } = useToasts()
-
-  return (
-    <>
-      {toasts.map((t, index) => (
-        <Toast.Item key={t.id} toast={t} index={index}>
-          <Toast.Title>{t.title}</Toast.Title>
-          <Toast.Description>{t.description}</Toast.Description>
-          <Toast.Close />
-        </Toast.Item>
-      ))}
-    </>
   )
 }
 ```
@@ -245,7 +237,7 @@ Action button. Extends Stack.
 
 ### useToasts
 
-Hook to access toast state inside `<Toast>`:
+Hook to access toast state from a descendant of `<Toast>`. Most apps should use `<Toast.List>` for rendering and reach for this hook only when they need custom list control.
 
 ```tsx
 const { toasts, expanded, position } = useToasts()
@@ -325,3 +317,5 @@ function App() {
   )
 }
 ```
+
+Mount `<Toaster>` inside your `TamaguiProvider`, usually next to your app navigation or root layout.

--- a/code/ui/components-test/Toast.native.test.tsx
+++ b/code/ui/components-test/Toast.native.test.tsx
@@ -1,0 +1,98 @@
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { getPortal } from '@tamagui/native'
+import { PortalProvider } from '@tamagui/portal'
+import { toast, Toaster, useToasts } from '@tamagui/toast/v2'
+import * as React from 'react'
+import type { ReactNode } from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import { afterEach, describe, expect, test } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+let rendered: TestRenderer.ReactTestRenderer | null = null
+
+afterEach(async () => {
+  toast.dismiss()
+  getPortal().set({ enabled: false, type: null })
+  await act(async () => {
+    rendered?.unmount()
+  })
+  rendered = null
+})
+
+async function renderNative(element: React.ReactElement) {
+  await act(async () => {
+    rendered = TestRenderer.create(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <PortalProvider shouldAddRootHost>{element}</PortalProvider>
+      </TamaguiProvider>
+    )
+  })
+
+  return rendered!
+}
+
+function hasText(tree: TestRenderer.ReactTestRenderer, text: string) {
+  return (
+    tree.root.findAll((node) => {
+      const children = node.props.children
+      return Array.isArray(children) ? children.includes(text) : children === text
+    }).length > 0
+  )
+}
+
+class ErrorBoundary extends React.Component<
+  { children: ReactNode; onError: (error: Error) => void },
+  { error: Error | null }
+> {
+  state = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidCatch(error: Error) {
+    this.props.onError(error)
+  }
+
+  render() {
+    return this.state.error ? null : this.props.children
+  }
+}
+
+describe('Toast v2 native context', () => {
+  test('keeps Toaster context through the native portal fallback', async () => {
+    const tree = await renderNative(<Toaster duration={Number.POSITIVE_INFINITY} />)
+
+    await act(async () => {
+      toast('Native portal toast')
+    })
+
+    expect(hasText(tree, 'Native portal toast')).toBe(true)
+  })
+
+  test('throws a setup error when useToasts is outside Toast', async () => {
+    let caught: Error | null = null
+    let missingRoot: TestRenderer.ReactTestRenderer | null = null
+
+    function MissingRoot() {
+      useToasts()
+      return null
+    }
+
+    await act(async () => {
+      missingRoot = TestRenderer.create(
+        <ErrorBoundary onError={(error) => (caught = error)}>
+          <MissingRoot />
+        </ErrorBoundary>
+      )
+    })
+
+    expect(caught?.message).toBe('`useToasts` must be used within `Toast`')
+
+    await act(async () => {
+      missingRoot?.unmount()
+    })
+  })
+})

--- a/code/ui/toast/src/ToastComposable.tsx
+++ b/code/ui/toast/src/ToastComposable.tsx
@@ -12,7 +12,7 @@ import {
   View,
 } from '@tamagui/core'
 import { withStaticProperties } from '@tamagui/helpers'
-import { Portal, needsPortalRepropagation } from '@tamagui/portal'
+import { Portal } from '@tamagui/portal'
 import { XStack, YStack } from '@tamagui/stacks'
 import { SizableText } from '@tamagui/text'
 import * as React from 'react'
@@ -90,7 +90,26 @@ const ToastContext = createStyledContext<ToastContextValue>(
   'Toast__'
 )
 
-const useToastContext = ToastContext.useStyledContext
+const useToastContextValue = ToastContext.useStyledContext
+
+function hasToastContext(ctx: Partial<ToastContextValue> | null | undefined) {
+  return (
+    !!ctx &&
+    Array.isArray(ctx.toasts) &&
+    typeof ctx.setToastHeight === 'function' &&
+    typeof ctx.removeToast === 'function'
+  )
+}
+
+function useToastContext(consumerName: string) {
+  const ctx = useToastContextValue()
+
+  if (!hasToastContext(ctx)) {
+    throw new Error(`\`${consumerName}\` must be used within \`Toast\``)
+  }
+
+  return ctx
+}
 
 /* -------------------------------------------------------------------------------------------------
  * ToastItemContext - for auto-wiring Toast.Close (web only)
@@ -490,7 +509,7 @@ const ToastViewport = ToastViewportFrame.styleable<ToastViewportProps>(
       ...rest
     } = props
 
-    const ctx = useToastContext()
+    const ctx = useToastContext('Toast.Viewport')
     const listRef = React.useRef<TamaguiElement>(null)
     const hoverTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
     const hoverCooldownRef = React.useRef(false)
@@ -671,14 +690,11 @@ const ToastViewport = ToastViewportFrame.styleable<ToastViewportProps>(
     )
 
     if (portalToRoot) {
-      // legacy native portal hosts render children outside styled context propagation.
-      const portaledContent = needsPortalRepropagation() ? (
-        <ToastContext.Provider {...ctx}>{content}</ToastContext.Provider>
-      ) : (
-        content
+      return (
+        <Portal zIndex={portalZIndex}>
+          <ToastContext.Provider {...ctx}>{content}</ToastContext.Provider>
+        </Portal>
       )
-
-      return <Portal zIndex={portalZIndex}>{portaledContent}</Portal>
     }
 
     return content
@@ -703,7 +719,7 @@ export interface ToastListProps {
 }
 
 function ToastList({ renderItem }: ToastListProps) {
-  const ctx = useToastContext()
+  const ctx = useToastContext('Toast.List')
 
   // render all toasts — hidden ones have opacity 0 but stay mounted
   // so they smoothly transition when visible toasts are dismissed
@@ -748,7 +764,7 @@ function ToastList({ renderItem }: ToastListProps) {
  * -----------------------------------------------------------------------------------------------*/
 
 function DefaultToastContent({ toast }: { toast: ToastT }) {
-  const ctx = useToastContext()
+  const ctx = useToastContext('Toast.Item')
   const { handleClose } = useToastItemContext()
   const toastType = toast.type ?? 'default'
   const dismissible = toast.dismissible !== false
@@ -886,7 +902,7 @@ export interface ToastItemProps extends GetProps<typeof ToastItemFrame> {
 const ToastItemInner = ToastItemFrame.styleable<ToastItemProps>(
   function ToastItem(props, ref) {
     const { toast, index, children, ...rest } = props
-    const ctx = useToastContext()
+    const ctx = useToastContext('Toast.Item')
 
     const [mounted, setMounted] = React.useState(false)
     const [removed, setRemoved] = React.useState(false)
@@ -1289,7 +1305,7 @@ const ToastClose = ToastCloseFrame.styleable(function ToastClose(props, ref) {
     // not inside a Toast.Item context, require manual onPress
   }
 
-  const ctx = useToastContext()
+  const ctx = useToastContext('Toast.Close')
 
   return (
     <ToastCloseFrame ref={ref} aria-label="Close toast" onPress={handleClose} {...props}>
@@ -1311,7 +1327,7 @@ const ToastAction = ToastActionFrame.styleable(function ToastAction(props, ref) 
  * -----------------------------------------------------------------------------------------------*/
 
 function ToastIcon(props: { children?: React.ReactNode }) {
-  const ctx = useToastContext()
+  const ctx = useToastContext('Toast.Icon')
   let toast: ToastT | undefined
 
   try {
@@ -1351,7 +1367,7 @@ function ToastIcon(props: { children?: React.ReactNode }) {
  * -----------------------------------------------------------------------------------------------*/
 
 export function useToasts() {
-  const ctx = useToastContext()
+  const ctx = useToastContext('useToasts')
   return {
     toasts: ctx.toasts,
     expanded: ctx.expanded,


### PR DESCRIPTION
## Summary
- Re-provide Toast v2 context inside the viewport portal payload so native portal fallback and teleport paths keep `Toast.List` / `useToasts()` state.
- Throw a clear setup error when Toast v2 state is read outside `<Toast>`.
- Update the Toast v2 docs quick start to use `<Toast.List>` first and clarify where `<Toaster>` / `useToasts()` must mount.

## Verification
- `bun run build` in `code/ui/toast`
- `TAMAGUI_TARGET=native ../../../node_modules/.bin/vitest --run --config ../../packages/vite-plugin-internal/src/vite.config.ts Toast.native.test.tsx` in `code/ui/components-test`
- `NODE_ENV=test node -r esbuild-register ../../node_modules/.bin/playwright test tests/ToastMultiple.test.tsx --project=default` in `code/kitchen-sink`
- `bun run format:check code/ui/toast/src/ToastComposable.tsx code/ui/components-test/Toast.native.test.tsx code/tamagui.dev/data/docs/components/toast-2/2.0.0.mdx`
- `git diff --check`

Fixes #4015
Fixes #4032