### PR TITLE
fix(sheet): refresh hoisted overlay props

### DIFF
--- a/code/kitchen-sink/src/usecases/SheetOverlayStyleCase.tsx
+++ b/code/kitchen-sink/src/usecases/SheetOverlayStyleCase.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+import { Button, Paragraph, Sheet, YStack } from 'tamagui'
+
+export function SheetOverlayStyleCase() {
+  const [open, setOpen] = useState(false)
+  const [alternate, setAlternate] = useState(false)
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <Button data-testid="sheet-overlay-style-open" onPress={() => setOpen(true)}>
+        Open styled overlay sheet
+      </Button>
+
+      <Sheet
+        modal
+        open={open}
+        onOpenChange={setOpen}
+        snapPoints={[45]}
+        dismissOnSnapToBottom
+        transition="quick"
+      >
+        <Sheet.Overlay
+          data-testid="sheet-overlay-style-overlay"
+          transition="quick"
+          backgroundColor={
+            alternate ? 'rgba(10, 120, 80, 0.35)' : 'rgba(210, 40, 40, 0.35)'
+          }
+          opacity={0.61}
+          enterStyle={{ opacity: 0 }}
+          exitStyle={{ opacity: 0 }}
+        />
+
+        <Sheet.Frame data-testid="sheet-overlay-style-frame" padding="$4" gap="$4">
+          <Paragraph>Overlay style regression</Paragraph>
+          <Button
+            data-testid="sheet-overlay-style-toggle"
+            onPress={() => setAlternate((value) => !value)}
+          >
+            Toggle overlay color
+          </Button>
+          <Button data-testid="sheet-overlay-style-close" onPress={() => setOpen(false)}>
+            Close
+          </Button>
+        </Sheet.Frame>
+      </Sheet>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -185,6 +185,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
     require('./SheetOnAnimationCompleteCase').SheetOnAnimationCompleteCase,
   SheetDragCase: () => require('./SheetDragCase').SheetDragCase,
   SheetDragResistCase: () => require('./SheetDragResistCase.web').SheetDragResistCase,
+  SheetOverlayStyleCase: () => require('./SheetOverlayStyleCase').SheetOverlayStyleCase,
   SheetScrollableDrag: () => require('./SheetScrollableDrag').SheetScrollableDrag,
   SheetScrollLockCase: () => require('./SheetScrollLockCase').SheetScrollLockCase,
   SheetSnapPointsFitCase: () =>

--- a/code/kitchen-sink/tests/SheetOverlayStyle.test.tsx
+++ b/code/kitchen-sink/tests/SheetOverlayStyle.test.tsx
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test'
+import { setupPage } from './test-utils'
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page, {
+    name: 'SheetOverlayStyleCase',
+    type: 'useCase',
+    searchParams: { animationDriver: 'css' },
+  })
+})
+
+async function overlayStyles(page: import('@playwright/test').Page) {
+  return page.getByTestId('sheet-overlay-style-overlay').evaluate((element) => {
+    const style = getComputedStyle(element)
+    return {
+      backgroundColor: style.backgroundColor,
+      opacity: Number(style.opacity),
+    }
+  })
+}
+
+test('Sheet.Overlay keeps caller styles when hoisted into the sheet portal', async ({
+  page,
+}) => {
+  await page.getByTestId('sheet-overlay-style-open').click()
+  await expect(page.getByTestId('sheet-overlay-style-frame')).toBeVisible({
+    timeout: 5000,
+  })
+  await page.waitForTimeout(250)
+
+  const initial = await overlayStyles(page)
+  expect(initial.backgroundColor).toBe('rgba(210, 40, 40, 0.35)')
+  expect(initial.opacity).toBeCloseTo(0.61, 1)
+
+  await page.getByTestId('sheet-overlay-style-toggle').click()
+  await page.waitForTimeout(100)
+
+  const updated = await overlayStyles(page)
+  expect(updated.backgroundColor).toBe('rgba(10, 120, 80, 0.35)')
+  expect(updated.opacity).toBeCloseTo(0.61, 1)
+})

--- a/code/ui/sheet/src/createSheet.tsx
+++ b/code/ui/sheet/src/createSheet.tsx
@@ -108,6 +108,7 @@ export function createSheet<
         // @ts-ignore
         <Overlay
           {...props}
+          ref={ref}
           onPress={composeEventHandlers(
             props.onPress,
             context.dismissOnOverlayPress
@@ -118,7 +119,7 @@ export function createSheet<
           )}
         />
       )
-    }, [props.onPress, props.opacity, context.dismissOnOverlayPress])
+    }, [props, ref, context.dismissOnOverlayPress, context.setOpen])
 
     useIsomorphicLayoutEffect(() => {
       context.onOverlayComponent?.(element)


### PR DESCRIPTION
## Summary

- refreshes the hoisted `Sheet.Overlay` element when caller props change instead of memoizing only `onPress` and `opacity`
- forwards the overlay ref through the hoisted element
- adds a kitchen-sink repro and Playwright regression for overlay background/opacity styles after the overlay is portaled

Root cause: `SheetOverlay` hoists its rendered overlay through sheet context, but its memo dependency list ignored most caller props. Background, style, className, and animation props could stay stale while the default opaque overlay remained visible.

Fixes #3947

## Tests

- `cd code/kitchen-sink && PORT=9014 NODE_ENV=test node -r esbuild-register ../../node_modules/.bin/playwright test tests/SheetOverlayStyle.test.tsx --project=default --workers=1`
- `cd code/kitchen-sink && PORT=9015 NODE_ENV=test node -r esbuild-register ../../node_modules/.bin/playwright test tests/SheetWebKeyboard.test.tsx --project=webkit-sheet --workers=1`
- `cd code/ui/sheet && bun run build`
