### PR TITLE
fix(sheet): cover native sheet gesture setup option

### DIFF
--- a/code/ui/components-test/SheetGestureState.native.test.tsx
+++ b/code/ui/components-test/SheetGestureState.native.test.tsx
@@ -98,9 +98,8 @@ describe('Sheet gesture state', () => {
     }
 
     try {
-      const { setupGestureHandler: setupNativeGestureHandler } = await import(
-        '../../core/native/src/setup-gesture-handler'
-      )
+      const { setupGestureHandler: setupNativeGestureHandler } =
+        await import('../../core/native/src/setup-gesture-handler')
 
       setupNativeGestureHandler({ pressEvents: false, sheet: true })
 

--- a/code/ui/components-test/SheetGestureState.native.test.tsx
+++ b/code/ui/components-test/SheetGestureState.native.test.tsx
@@ -1,5 +1,6 @@
 import { getGestureHandler } from '@tamagui/native'
-import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+import Module from 'node:module'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   getGestureHandlerState,
   isGestureHandlerEnabled,
@@ -12,11 +13,13 @@ import {
 
 const SHEET_GESTURE_STATE_KEY = '__tamagui_sheet_gesture_state__'
 const SHEET_LEGACY_SETUP_KEY = '__tamagui_sheet_gesture_handler_setup'
+const NATIVE_GESTURE_SETUP_KEY = '__tamagui_native_gesture_setup_complete'
 const GESTURE_ENABLED_FREEZE_KEY = '__tamagui_gesture_enabled_freeze__'
 
 function resetGlobals() {
   delete (globalThis as any)[SHEET_GESTURE_STATE_KEY]
   delete (globalThis as any)[SHEET_LEGACY_SETUP_KEY]
+  delete (globalThis as any)[NATIVE_GESTURE_SETUP_KEY]
   delete (globalThis as any)[GESTURE_ENABLED_FREEZE_KEY]
 }
 
@@ -72,5 +75,48 @@ describe('Sheet gesture state', () => {
     expect(isLegacyGestureHandlerEnabled()).toBe(true)
     expect(isGestureHandlerEnabled()).toBe(true)
     expect(getGestureHandler().isEnabled).toBe(false)
+  })
+
+  test('native setup sheet option works independently from pressEvents', async () => {
+    vi.resetModules()
+    resetGlobals()
+    setPressGestureHandlerEnabled(false)
+
+    const fakeRngh = {
+      Gesture: { Pan: () => null },
+      GestureDetector: () => null,
+      ScrollView: {},
+      GestureHandlerRootView: {},
+    }
+
+    const originalRequire = Module.prototype.require
+    Module.prototype.require = function (id: string) {
+      if (id === 'react-native-gesture-handler') {
+        return fakeRngh
+      }
+      return originalRequire.apply(this, arguments as any)
+    }
+
+    try {
+      const { setupGestureHandler: setupNativeGestureHandler } = await import(
+        '../../core/native/src/setup-gesture-handler'
+      )
+
+      setupNativeGestureHandler({ pressEvents: false, sheet: true })
+
+      expect(getGestureHandler().isEnabled).toBe(false)
+      expect(isGestureHandlerEnabled()).toBe(true)
+      expect(getGestureHandlerState().Gesture).toBe(fakeRngh.Gesture)
+      expect(getGestureHandlerState().GestureDetector).toBe(fakeRngh.GestureDetector)
+      expect(getGestureHandlerState().ScrollView).toBe(fakeRngh.ScrollView)
+      expect(getGestureHandlerState().RootView).toBe(fakeRngh.GestureHandlerRootView)
+
+      setupNativeGestureHandler({ pressEvents: false, sheet: false })
+
+      expect(getGestureHandler().isEnabled).toBe(false)
+      expect(isGestureHandlerEnabled()).toBe(false)
+    } finally {
+      Module.prototype.require = originalRequire
+    }
   })
 })


### PR DESCRIPTION
## Summary

- adds direct native setup coverage for `setupGestureHandler({ pressEvents: false, sheet: true })`
- verifies the sheet RNGH state stays enabled independently from press-event RNGH state
- verifies `sheet: false` disables only the sheet gesture path

The source-side reader fix for this issue is already present on `main` from the adjacent RNGH stale-tap work; this PR locks the reported setup option behavior with targeted regression coverage.

Fixes #4023

## Tests

- `cd code/ui/components-test && /Users/n8/tamagui/node_modules/.bin/vitest --run --config ../../packages/vite-plugin-internal/src/vite.config.ts SheetGestureState.native.test.tsx`
