### PR TITLE
fix(core): native "unset" clears earlier-set style keys (reset parity)

### DIFF
--- a/code/core/core-test/getSplitStyles.native.test.tsx
+++ b/code/core/core-test/getSplitStyles.native.test.tsx
@@ -332,6 +332,25 @@ describe('getSplitStyles', () => {
     expect(style?.aspectRatio).toBeUndefined()
     expect(style?.backgroundColor).toBeUndefined()
   })
+
+  test('"unset" clears styled defaults on native (web reset parity)', () => {
+    // web resolves unset through the cascade, clearing earlier values (styled
+    // defaults included); native must do the same rather than silently keeping
+    // the default. shorthands clear every key they expand to.
+    const StyledView = styled(View, {
+      backgroundColor: 'red',
+      padding: 10,
+    })
+
+    const { style } = getSplitStylesFor(
+      { backgroundColor: 'unset', p: 'unset' },
+      StyledView
+    )
+
+    expect(style?.backgroundColor).toBeUndefined()
+    expect(style?.padding).toBeUndefined()
+    expect(style?.paddingTop).toBeUndefined()
+  })
 })
 
 describe.skip('getSplitStyles - pseudo prop merging', () => {

--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -45,9 +45,24 @@ export const propMapper: PropMapper = (key, value, styleState, disabled, map) =>
 
   // "unset" is a CSS-wide keyword: valid CSS on web, but React Native
   // style props reject it (e.g. aspectRatio throws "must be a number, a
-  // ratio string or `auto`"). Drop it on native so the prop falls back to
-  // its initial value instead of crashing.
+  // ratio string or `auto`"). On native, clear anything an earlier prop or
+  // styled default already merged for this key — matching web, where unset
+  // resets toward initial — then drop the value so RN never sees it.
   if (process.env.TAMAGUI_TARGET === 'native' && value === 'unset') {
+    const expandedKey =
+      (!styleProps.disableExpandShorthands && conf.shorthands[key]) || key
+    const expanded = styleProps.noExpand
+      ? null
+      : expandStyle(expandedKey, value, conf.settings.styleCompat || 'web')
+    if (styleState.style) {
+      if (expanded) {
+        for (const [nkey] of expanded) {
+          delete styleState.style[nkey]
+        }
+      } else {
+        delete styleState.style[expandedKey]
+      }
+    }
     return
   }
 


### PR DESCRIPTION
Follow-up to #4053. Dropping `unset` on native stops the crash, but `unset` is a *value* meaning "reset toward initial", so it must also clear anything an earlier prop or styled default already merged for that key. Previously `backgroundColor: "unset"` over a `styled(View,{backgroundColor:"red"})` default kept red on native (web resets it via the cascade).

This clears the already-merged key(s) - expanding shorthands (e.g. `p` -> all padding keys) - before dropping the value, matching web reset semantics. Added regression test covering styled-default clearing + shorthand expansion.