### PR TITLE
fix(radio-group): remove stray v1 pressTheme prop that leaks to the DOM on web

### DIFF
--- a/code/ui/radio-group/src/RadioGroup.tsx
+++ b/code/ui/radio-group/src/RadioGroup.tsx
@@ -95,7 +95,6 @@ export const RadioGroupIndicatorFrame = styled(YStack, {
         height: '33%',
         borderRadius: 1000,
         backgroundColor: '$color',
-        pressTheme: true,
       },
     },
   } as const,


### PR DESCRIPTION
Fixes #4074

`pressTheme` was a v1 prop that the v2 style system no longer consumes, but `RadioGroupIndicatorFrame` still sets it in its `unstyled: false` variant. Since nothing extracts it anymore, it passes through to the underlying element on web, putting a `presstheme` attribute on the DOM and logging a React unknown-prop console error the first time a radio option is selected (the Indicator only mounts once its item is checked).

This removes the line — v2 already applies press feedback via the Item's `pressStyle`, so there's no visual change. Verified with `bun run build` in `code/ui/radio-group`, and confirmed in an Expo SDK 57 / react-native-web app (via a pnpm patch of the published package) that the console error is gone and radio behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)