### PR TITLE
fix: remove inlineWhenUnflattened

### DIFF
--- a/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`webpack-tests > 15. extracts spacer (complex expansion) 1`] = `
         class="_dsp_contents  font_body"
       >
         <span
-          class="is_Spacer is_View _pe-none"
+          class="is_Spacer is_View _pe-none _w-t-space-tru101 _h-t-space-tru101 _miw-t-space-tru101 _mih-t-space-tru101"
         />
         <span
           class="is_Spacer is_View _pe-none _fg-1 _fs-1 _fb-0px _w-10px _h-10px _miw-10px _mih-10px"

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -771,7 +771,6 @@ export function createExtractor(
         }
 
         const componentSkipProps = new Set([
-          ...(Component.staticConfig.inlineWhenUnflattened || []),
           ...(Component.staticConfig.inlineProps || []),
           // for now skip variants, will return to them
           'variants',
@@ -1177,8 +1176,6 @@ export function createExtractor(
               : []),
           ])
 
-          const inlineWhenUnflattened = new Set(staticConfig.inlineWhenUnflattened || [])
-
           // Generate scope object at this level
           const staticNamespace = getStaticBindingsForScope(
             traversePath.scope,
@@ -1218,7 +1215,6 @@ export function createExtractor(
           const inlined = new Map<string, any>()
           const variantValues = new Map<string, any>()
           let hasSetOptimized = false
-          const inlineWhenUnflattenedOGVals = {}
 
           // RUN first pass
 
@@ -1630,11 +1626,6 @@ export function createExtractor(
 
             // FAILED = dynamic or ternary, keep going
             if (styleValue !== FAILED_EVAL) {
-              if (inlineWhenUnflattened.has(name)) {
-                // preserve original value for restoration
-                inlineWhenUnflattenedOGVals[name] = { styleValue, attr }
-              }
-
               if (isValidStyleKey(name, staticConfig)) {
                 // $theme- / $group- styles extract through the atomic-CSS pipeline
                 // (extractToClassNames → createMediaStyle), so they fall through to
@@ -2821,30 +2812,6 @@ export function createExtractor(
           }
 
           attrs = attrs.filter(Boolean)
-
-          // inlineWhenUnflattened
-          if (!shouldFlatten) {
-            if (inlineWhenUnflattened.size) {
-              for (const [index, attr] of attrs.entries()) {
-                if (attr.type === 'style') {
-                  for (const key in attr.value) {
-                    if (!inlineWhenUnflattened.has(key)) continue
-                    const val = inlineWhenUnflattenedOGVals[key]
-                    if (val) {
-                      // delete the style
-                      delete attr.value[key]
-
-                      // and insert it before
-                      attrs.splice(index - 1, 0, val.attr)
-                    } else {
-                      // just delete it, it was added during expansion but should be left inline
-                      delete attr.value[key]
-                    }
-                  }
-                }
-              }
-            }
-          }
 
           // delete empty styles:
           attrs = attrs.filter((x) => {

--- a/code/core/core-test/getSplitStyles.web.test.tsx
+++ b/code/core/core-test/getSplitStyles.web.test.tsx
@@ -20,6 +20,10 @@ beforeAll(() => {
 })
 
 describe('getSplitStyles', () => {
+  test('Text does not register inlineWhenUnflattened', () => {
+    expect((Text as any).staticConfig.inlineWhenUnflattened).toBeUndefined()
+  })
+
   test(`styled with variants`, () => {
     const ViewVariants = styled(Text, {
       color: 'blue',

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -925,7 +925,6 @@ export const getSplitStyles: StyleSplitter = (
     variants,
     isReactNative,
     inlineProps,
-    inlineWhenUnflattened,
     parentStaticConfig,
     acceptsClassName,
   } = staticConfig
@@ -1395,10 +1394,7 @@ export const getSplitStyles: StyleSplitter = (
         return
       }
 
-      if (
-        inlineProps?.has(key) ||
-        (process.env.IS_STATIC === 'is_static' && inlineWhenUnflattened?.has(key))
-      ) {
+      if (inlineProps?.has(key)) {
         viewProps[key] = props[key] ?? val
       }
 

--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -2955,12 +2955,6 @@ export type StaticConfigPublic = {
   inlineProps?: Set<string>
 
   /**
-   * (compiler) If not flattening, leave this prop as original value.
-   * Only applies to style attributes
-   */
-  inlineWhenUnflattened?: Set<string>
-
-  /**
    * Auto-detected, but can override. Wraps children to space them on top
    */
   isZStack?: boolean

--- a/code/core/web/src/views/Text.tsx
+++ b/code/core/web/src/views/Text.tsx
@@ -40,7 +40,6 @@ export const Text = createComponent<
           suppressHighlighting: true,
         },
 
-  inlineWhenUnflattened: new Set(['fontFamily']),
   inlineProps: new Set(['maxFontSizeMultiplier']),
 
   variants: {

--- a/code/core/web/types/types.d.ts
+++ b/code/core/web/types/types.d.ts
@@ -1658,11 +1658,6 @@ export type StaticConfigPublic = {
      */
     inlineProps?: Set<string>;
     /**
-     * (compiler) If not flattening, leave this prop as original value.
-     * Only applies to style attributes
-     */
-    inlineWhenUnflattened?: Set<string>;
-    /**
      * Auto-detected, but can override. Wraps children to space them on top
      */
     isZStack?: boolean;


### PR DESCRIPTION
Summary:
- remove the compiler/runtime inlineWhenUnflattened static config path
- remove Text.staticConfig.inlineWhenUnflattened and generated type surface
- add a regression assertion that Text no longer registers inlineWhenUnflattened
- refresh the v3 webpack Spacer snapshot to current output

Validation:
- bun run build -- --concurrency=4
- code/compiler/static-tests: bun run test:web
- code/core/core-test: TAMAGUI_TARGET=web bun run test:run -- webAlignment.web.test.tsx getSplitStyles.web.test.tsx
- code/core/core-test: TAMAGUI_TARGET=native bun run test:run -- webAlignment.native.test.tsx
