### PR TITLE
fix(list-item): align composable structure

### DIFF
--- a/code/core/helpers-tamagui/package.json
+++ b/code/core/helpers-tamagui/package.json
@@ -34,6 +34,7 @@
     "clean:build": "tamagui-build clean:build"
   },
   "dependencies": {
+    "@tamagui/font-size": "workspace:*",
     "@tamagui/helpers": "workspace:*",
     "@tamagui/web": "workspace:*"
   },

--- a/code/core/helpers-tamagui/src/useGetThemedIcon.tsx
+++ b/code/core/helpers-tamagui/src/useGetThemedIcon.tsx
@@ -1,19 +1,23 @@
-import React from 'react'
+import { getFontSize } from '@tamagui/font-size'
+import type { SizeTokens, Token } from '@tamagui/web'
+
+import { getIcon } from './getIcon'
 import type { ColorProp } from './useCurrentColor'
 import { useCurrentColor } from './useCurrentColor'
 
-export const useGetThemedIcon = (props: { color: ColorProp; size: number }) => {
+export const getThemedIconSize = (
+  size: SizeTokens | number | null | undefined,
+  scaleIcon = 1
+) => {
+  return (typeof size === 'number' ? size * 0.5 : getFontSize(size as Token)) * scaleIcon
+}
+
+export const useGetThemedIcon = (props: { color: ColorProp; size?: number }) => {
   const color = useCurrentColor(props.color)
   return (el: any) => {
-    if (!el) return el
-    if (React.isValidElement(el)) {
-      return React.cloneElement(el, {
-        ...props,
-        color,
-        // @ts-expect-error
-        ...el.props,
-      })
-    }
-    return React.createElement(el, props)
+    return getIcon(el, {
+      ...props,
+      color,
+    })
   }
 }

--- a/code/core/helpers-tamagui/types/useGetThemedIcon.d.ts
+++ b/code/core/helpers-tamagui/types/useGetThemedIcon.d.ts
@@ -1,6 +1,8 @@
+import type { SizeTokens } from '@tamagui/web';
 import type { ColorProp } from './useCurrentColor';
+export declare const getThemedIconSize: (size: SizeTokens | number | null | undefined, scaleIcon?: number) => number;
 export declare const useGetThemedIcon: (props: {
     color: ColorProp;
-    size: number;
+    size?: number;
 }) => (el: any) => any;
 //# sourceMappingURL=useGetThemedIcon.d.ts.map

--- a/code/kitchen-sink/src/tamagui.config.ts
+++ b/code/kitchen-sink/src/tamagui.config.ts
@@ -6,7 +6,7 @@ import { config } from '@tamagui/config/v3'
 import { defaultConfig as configV4, shorthands } from '@tamagui/config/v4'
 import { defaultConfig } from '@tamagui/config/v5'
 import { tamaguiThemes } from '@tamagui/themes/v4'
-import { createTamagui, type CreateTamaguiProps } from 'tamagui'
+import { createTamagui } from 'tamagui'
 // TODO just move this into this folder
 import { config as tamaguiDevConfig } from '../../packages/tamagui-dev-config/src/index'
 import { themeDev } from '../../packages/tamagui-dev-config/src/theme.dev'
@@ -348,8 +348,17 @@ const v5config = search.includes('v5config')
 const tamav5Config = search.includes('tamav5config')
 const generatedV5 = search.includes('generatedV5')
 
+const withTrueToken = <Tokens extends { true?: any; $true?: any; 4?: any; $4?: any }>(
+  tokens: Tokens
+) => ({
+  ...tokens,
+  true: tokens.true ?? tokens.$true ?? tokens[4] ?? tokens.$4,
+})
+
 const tokens = {
   ...config.tokens,
+  size: withTrueToken(config.tokens.size),
+  space: withTrueToken(config.tokens.space),
   color: {
     ...config.tokens.color,
     testsomethingdifferent: '#ff0000',

--- a/code/kitchen-sink/src/usecases/ListItem.tsx
+++ b/code/kitchen-sink/src/usecases/ListItem.tsx
@@ -119,5 +119,21 @@ export const ThemedListItem = () => (
         borderRadius="$3"
       />
     </ListItem.Apply>
+
+    <ListItem
+      id="themed-list-item-child-icon"
+      size="$10"
+      color="$red10"
+      borderRadius="$3"
+    >
+      <ListItem.Icon>
+        <Star />
+      </ListItem.Icon>
+      <ListItem.Text>Child icon inherits ListItem props</ListItem.Text>
+    </ListItem>
+
+    <ListItem id="themed-list-item-unstyled" unstyled>
+      Unstyled text
+    </ListItem>
   </View>
 )

--- a/code/kitchen-sink/tests/ListItem.test.tsx
+++ b/code/kitchen-sink/tests/ListItem.test.tsx
@@ -18,6 +18,8 @@ test('ListItem renders correctly with default theme', async ({ page }) => {
 
   const styles = await getStyles(listItem)
   expect(styles.backgroundColor).toBe('rgb(242, 242, 242)')
+
+  await expect(page.locator('#themed-list-item-default > svg')).toBeVisible()
 })
 
 test('ListItem renders correctly with light theme', async ({ page }) => {
@@ -126,4 +128,37 @@ test('ListItem.Apply passes variant to children', async ({ page }) => {
   // Outlined variant applied via Apply context
   expect(styles.backgroundColor).toBe('rgba(0, 0, 0, 0)')
   expect(styles.borderWidth).toBe('1px')
+})
+
+test('ListItem re-provides size and color context to child icons', async ({ page }) => {
+  const listItem = page.locator('#themed-list-item-child-icon')
+  const icon = listItem.locator('svg').first()
+  const path = icon.locator('path').first()
+
+  await expect(listItem).toBeVisible()
+  await expect(icon).toBeVisible()
+
+  const box = await icon.boundingBox()
+  expect(box?.width).toBeGreaterThanOrEqual(18)
+  expect(box?.height).toBeGreaterThanOrEqual(18)
+
+  const stroke = await path.evaluate((el) => getComputedStyle(el).stroke)
+  expect(stroke).toBeTruthy()
+  expect(stroke).not.toBe('none')
+  expect(stroke).not.toBe('rgb(0, 0, 0)')
+})
+
+test('ListItem unstyled applies to bare text children', async ({ page }) => {
+  const listItem = page.locator('#themed-list-item-unstyled')
+  const text = listItem.getByText('Unstyled text', { exact: true })
+
+  await expect(listItem).toBeVisible()
+  await expect(text).toBeVisible()
+
+  const listItemStyles = await getStyles(listItem)
+  expect(listItemStyles.backgroundColor).toBe('rgba(0, 0, 0, 0)')
+  expect(listItemStyles.paddingLeft).toBe('0px')
+
+  const textStyles = await getStyles(text)
+  expect(textStyles.textOverflow).not.toBe('ellipsis')
 })

--- a/code/tamagui.dev/data/docs/components/list-item/2.0.0.mdx
+++ b/code/tamagui.dev/data/docs/components/list-item/2.0.0.mdx
@@ -104,7 +104,7 @@ export default () => (
 
 Icons can be passed to `icon` (before content) or `iconAfter` (after content) props.
 
-- **Automatic Sizing & Spacing**: Icons are automatically sized based on the ListItem's `size` prop. You can override this with the `iconSize` prop (accepts `SizeTokens`). Spacing between the icon and text is also automatically applied (40% of the icon's final size).
+- **Automatic Sizing & Spacing**: Icons are automatically sized based on the ListItem's `size` prop. You can override this with the `iconSize` prop (accepts `SizeTokens`). Spacing is applied using the frame `gap`, so it applies between all direct ListItem frame children, not only around icons.
 - **Scaling**: Use `scaleIcon` (number, default: 1) to further adjust the icon size relative to its base size.
 - **Component Props**: If you pass a component as an icon, it will receive `size` (the calculated pixel size) as a prop.
 
@@ -241,6 +241,13 @@ ListItems extend Stack views, inheriting all the [Tamagui standard props](/docs/
       type: 'SizeTokens',
       description:
         'Adjusts padding, min-height, and default font/icon sizes. Uses theme size tokens (e.g., "$3", "$4").',
+    },
+    {
+      name: 'color',
+      required: false,
+      type: 'ColorTokens | string',
+      description:
+        'Color token or CSS color inherited by `ListItem.Icon` children and icon props.',
     },
     {
       name: 'variant',

--- a/code/ui/button/src/Button.tsx
+++ b/code/ui/button/src/Button.tsx
@@ -1,7 +1,11 @@
-import { getFontSize } from '@tamagui/font-size'
 import { getButtonSized } from '@tamagui/get-button-sized'
-import { getIcon, useCurrentColor } from '@tamagui/helpers-tamagui'
-import { ButtonNestingContext, getElevation, themeableVariants } from '@tamagui/stacks'
+import { getThemedIconSize, useGetThemedIcon } from '@tamagui/helpers-tamagui'
+import {
+  ButtonNestingContext,
+  getElevation,
+  themeableVariants,
+  themeableVariantStyles,
+} from '@tamagui/stacks'
 import type { TextContextStyles, TextParentStyles } from '@tamagui/text'
 import { SizableText, wrapChildrenInText } from '@tamagui/text'
 import type { GetProps, SizeTokens, Token } from '@tamagui/web'
@@ -88,24 +92,7 @@ const Frame = styled(View, {
     },
 
     variant: {
-      outlined:
-        process.env.TAMAGUI_HEADLESS === '1'
-          ? {}
-          : {
-              backgroundColor: 'transparent',
-              borderWidth: 1,
-              borderColor: '$borderColor',
-
-              hoverStyle: {
-                backgroundColor: 'transparent',
-                borderColor: '$borderColorHover',
-              },
-
-              pressStyle: {
-                backgroundColor: 'transparent',
-                borderColor: '$borderColorPress',
-              },
-            },
+      outlined: themeableVariantStyles.outlined,
     },
 
     circular: themeableVariants.circular,
@@ -191,16 +178,13 @@ const Icon = (props: {
     styledContext.color === 'unset' || typeof styledContext.color === 'number'
       ? undefined
       : styledContext.color
-  const iconColor = useCurrentColor(iconColorProp)
-
-  const iconSize =
-    (typeof sizeToken === 'number' ? sizeToken * 0.5 : getFontSize(sizeToken as Token)) *
-    scaleIcon
-
-  return getIcon(children, {
+  const iconSize = getThemedIconSize(sizeToken, scaleIcon)
+  const getThemedIcon = useGetThemedIcon({
     size: iconSize,
-    color: iconColor,
+    color: iconColorProp,
   })
+
+  return getThemedIcon(children)
 }
 
 export const ButtonContext = createStyledContext<{
@@ -270,19 +254,16 @@ const ButtonComponent = createStyledHOC(Frame)<ButtonExtraProps>((propsIn, ref) 
     contextColor === 'unset' || typeof contextColor === 'number'
       ? undefined
       : contextColor
-  const iconColor = useCurrentColor(iconColorProp)
   const finalSize = iconSize ?? size ?? styledContext?.size
-  const iconSizeNumber =
-    (typeof finalSize === 'number' ? finalSize * 0.5 : getFontSize(finalSize as Token)) *
-    scaleIcon
+  const iconSizeNumber = getThemedIconSize(finalSize, scaleIcon)
+  const getThemedIcon = useGetThemedIcon({
+    size: iconSizeNumber,
+    color: iconColorProp,
+  })
 
   const [themedIcon, themedIconAfter] = [icon, iconAfter].map((icon) => {
     if (!icon) return null
-    return getIcon(icon, {
-      size: iconSizeNumber,
-      color: iconColor,
-      // No marginLeft or marginRight needed - spacing is handled by the gap property in Frame's size variants
-    })
+    return getThemedIcon(icon)
   })
 
   const wrappedChildren = wrapChildrenInText(

--- a/code/ui/components-test/ListItem.native.test.tsx
+++ b/code/ui/components-test/ListItem.native.test.tsx
@@ -1,0 +1,124 @@
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, View, createFont, createTamagui } from '@tamagui/core'
+import { ListItem } from '@tamagui/list-item'
+import TestRenderer, { act } from 'react-test-renderer'
+import { describe, expect, test } from 'vitest'
+
+const baseConfig = getDefaultTamaguiConfig('native')
+const testFont = createFont({
+  family: 'System',
+  size: {
+    1: 15,
+    true: 18,
+    10: 46,
+  },
+  lineHeight: {
+    1: 20,
+    true: 24,
+    10: 52,
+  },
+  transform: {},
+  weight: {
+    1: '400',
+    true: '400',
+    10: '400',
+  },
+  color: {
+    1: '$color',
+    true: '$color',
+    10: '$color',
+  },
+  letterSpacing: {
+    1: 0,
+    true: 0,
+    10: 0,
+  },
+})
+
+const conf = createTamagui({
+  ...baseConfig,
+  fonts: {
+    ...baseConfig.fonts,
+    body: testFont,
+  },
+})
+
+async function renderListItem(element: React.ReactElement) {
+  let rendered: TestRenderer.ReactTestRenderer | null = null
+
+  await act(async () => {
+    rendered = TestRenderer.create(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        {element}
+      </TamaguiProvider>
+    )
+  })
+
+  return rendered!
+}
+
+function flattenStyle(style: any): Record<string, any> {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style.map(flattenStyle))
+  }
+
+  return style || {}
+}
+
+function findTextNode(rendered: TestRenderer.ReactTestRenderer, text: string) {
+  const nodes = rendered.root.findAll((node) => node.props.children === text)
+  const textNode = nodes.find((node) => {
+    const type = node.type
+    return type === 'Text' || (typeof type === 'function' && type.name === 'Text')
+  })
+
+  if (!textNode) {
+    throw new Error(`text node not found: ${text}`)
+  }
+
+  return textNode
+}
+
+describe('ListItem native composition', () => {
+  test('re-provides size and color to child icons', async () => {
+    const iconProps: any[] = []
+
+    const ProbeIcon = (props: any) => {
+      iconProps.push(props)
+      return <View testID="probe-icon" />
+    }
+
+    await renderListItem(
+      <ListItem size="$10" color="#ff0000">
+        <ListItem.Icon>
+          <ProbeIcon />
+        </ListItem.Icon>
+        <ListItem.Text>Icon child</ListItem.Text>
+      </ListItem>
+    )
+
+    expect(iconProps.at(-1)).toMatchObject({
+      size: 46,
+      color: '#ff0000',
+    })
+  })
+
+  test('applies unstyled to bare text children', async () => {
+    const rendered = await renderListItem(
+      <ListItem testID="unstyled-list-item" unstyled>
+        Plain text
+      </ListItem>
+    )
+
+    const frame = rendered.root.findByProps({ testID: 'unstyled-list-item' })
+    const frameStyle = flattenStyle(frame.props.style)
+    expect(frameStyle.backgroundColor).toBeUndefined()
+    expect(frameStyle.minHeight).toBeUndefined()
+    expect(frameStyle.paddingHorizontal).toBeUndefined()
+
+    const textStyle = flattenStyle(findTextNode(rendered, 'Plain text').props.style)
+    expect(textStyle.color).toBeUndefined()
+    expect(textStyle.flexGrow).toBeUndefined()
+    expect(textStyle.textOverflow).toBeUndefined()
+  })
+})

--- a/code/ui/list-item/src/ListItem.tsx
+++ b/code/ui/list-item/src/ListItem.tsx
@@ -1,9 +1,8 @@
-import { getFontSize } from '@tamagui/font-size'
 import { getFontSized } from '@tamagui/get-font-sized'
 import { getSize, getSpace } from '@tamagui/get-token'
 import { withStaticProperties } from '@tamagui/helpers'
-import { getIcon, useCurrentColor } from '@tamagui/helpers-tamagui'
-import { YStack } from '@tamagui/stacks'
+import { getThemedIconSize, useGetThemedIcon } from '@tamagui/helpers-tamagui'
+import { themeableVariantStyles, YStack } from '@tamagui/stacks'
 import { SizableText, wrapChildrenInText } from '@tamagui/text'
 import type { ColorTokens, FontSizeTokens, GetProps, SizeTokens } from '@tamagui/web'
 import {
@@ -11,6 +10,7 @@ import {
   createStyledHOC,
   resolveDefaultSizeToken,
   styled,
+  useProps,
   View,
 } from '@tamagui/web'
 import type { FunctionComponent, JSX, ReactNode } from 'react'
@@ -26,6 +26,7 @@ export type ListItemExtraProps = {
   title?: ReactNode
   subTitle?: ReactNode
   iconSize?: SizeTokens
+  color?: ColorTokens | string
 }
 
 export type ListItemProps = GetProps<typeof ListItemFrame> & ListItemExtraProps
@@ -76,24 +77,7 @@ const ListItemFrame = styled(View, {
     },
 
     variant: {
-      outlined:
-        process.env.TAMAGUI_HEADLESS === '1'
-          ? {}
-          : {
-              backgroundColor: 'transparent',
-              borderWidth: 1,
-              borderColor: '$borderColor',
-
-              hoverStyle: {
-                backgroundColor: 'transparent',
-                borderColor: '$borderColorHover',
-              },
-
-              pressStyle: {
-                backgroundColor: 'transparent',
-                borderColor: '$borderColorPress',
-              },
-            },
+      outlined: themeableVariantStyles.outlined,
     },
 
     size: {
@@ -105,6 +89,7 @@ const ListItemFrame = styled(View, {
           paddingVertical: getSpace(tokens.space[sizeToken], {
             shift: -4,
           }),
+          gap: getThemedIconSize(resolveDefaultSizeToken(val), 0.4),
         }
       },
     },
@@ -206,90 +191,118 @@ const ListItemIcon = (props: {
   }
 
   const sizeToken = size ?? styledContext.size ?? '$true'
-  const iconColor = useCurrentColor(styledContext.color)
+  const contextColor = styledContext.color
+  const iconColorProp =
+    contextColor === 'unset' || typeof contextColor === 'number'
+      ? undefined
+      : contextColor
 
-  const iconSize = getFontSize(sizeToken as any) * scaleIcon
-
-  return getIcon(children, {
+  const iconSize = getThemedIconSize(sizeToken, scaleIcon)
+  const getThemedIcon = useGetThemedIcon({
     size: iconSize,
-    color: iconColor,
+    color: iconColorProp,
   })
+
+  return getThemedIcon(children)
 }
 
 const ListItemComponent = createStyledHOC(ListItemFrame)<ListItemExtraProps>(
   function ListItem(propsIn, ref) {
+    const processedProps = useProps(propsIn, {
+      noNormalize: true,
+      noExpand: true,
+    })
+
     const {
       children,
       icon,
       iconAfter,
       scaleIcon = 1,
-      unstyled = false,
+      unstyled,
       subTitle,
       title,
       iconSize,
+      color,
       ...rest
-    } = propsIn
+    } = processedProps
 
-    const size = propsIn.size || '$true'
     const styledContext = context.useStyledContext()
-    const iconColor = useCurrentColor(styledContext?.color)
-    const iconSizeNumber = getFontSize(iconSize || (size as any)) * scaleIcon
+    const isUnstyled = unstyled ?? process.env.TAMAGUI_HEADLESS === '1'
+    const size =
+      rest.size ??
+      propsIn.size ??
+      (isUnstyled ? undefined : styledContext?.size || '$true')
+    const contextColor = color ?? propsIn.color ?? styledContext?.color
+    const iconColorProp =
+      contextColor === 'unset' || typeof contextColor === 'number'
+        ? undefined
+        : contextColor
+    const iconSizeNumber = getThemedIconSize(iconSize || (size as any), scaleIcon)
+    const getThemedIcon = useGetThemedIcon({
+      size: iconSizeNumber,
+      color: iconColorProp,
+    })
 
-    const iconSpacing = iconSizeNumber * 0.4
-    const themedIcon = icon ? (
-      <View marginRight={iconSpacing}>
-        {getIcon(icon, { size: iconSizeNumber, color: iconColor })}
-      </View>
-    ) : null
-    const themedIconAfter = iconAfter ? (
-      <View marginLeft={iconSpacing}>
-        {getIcon(iconAfter, { size: iconSizeNumber, color: iconColor })}
-      </View>
-    ) : null
+    const themedIcon = icon ? getThemedIcon(icon) : null
+    const themedIconAfter = iconAfter ? getThemedIcon(iconAfter) : null
 
     const wrappedChildren = wrapChildrenInText(
       ListItemText,
       { children },
-      propsIn.unstyled !== true
-        ? {
-            unstyled: process.env.TAMAGUI_HEADLESS === '1',
-            fontSize: propsIn.size,
-          }
-        : undefined
+      {
+        unstyled: isUnstyled,
+        size,
+      }
     )
 
+    const listItemContext = {
+      ...styledContext,
+      color: contextColor,
+      size,
+      variant: rest.variant ?? propsIn.variant ?? styledContext?.variant,
+    }
+    const frameProps = {
+      ...rest,
+      size,
+      variant: listItemContext.variant,
+    }
+
     return (
-      <ListItemFrame ref={ref} {...rest}>
-        {themedIcon}
-        {title || subTitle ? (
-          <YStack flex={1}>
-            {title ? (
-              typeof title === 'string' ? (
-                <ListItemTitle unstyled={unstyled} size={size as any}>
-                  {title}
-                </ListItemTitle>
-              ) : (
-                title
-              )
-            ) : null}
-            {subTitle ? (
-              <>
-                {typeof subTitle === 'string' ? (
-                  <ListItemSubtitle unstyled={unstyled} size={size}>
-                    {subTitle}
-                  </ListItemSubtitle>
-                ) : (
-                  subTitle
-                )}
-              </>
-            ) : null}
-            {wrappedChildren}
-          </YStack>
-        ) : (
-          wrappedChildren
-        )}
-        {themedIconAfter}
-      </ListItemFrame>
+      <context.Provider {...listItemContext}>
+        <ListItemFrame ref={ref} unstyled={isUnstyled} {...(frameProps as any)}>
+          <context.Provider {...listItemContext}>
+            {themedIcon}
+            {title || subTitle ? (
+              <YStack flex={1}>
+                {title ? (
+                  typeof title === 'string' ? (
+                    <ListItemTitle unstyled={isUnstyled} size={size as any}>
+                      {title}
+                    </ListItemTitle>
+                  ) : (
+                    title
+                  )
+                ) : null}
+                {subTitle ? (
+                  <>
+                    {typeof subTitle === 'string' ? (
+                      <ListItemSubtitle unstyled={isUnstyled} size={size}>
+                        {subTitle}
+                      </ListItemSubtitle>
+                    ) : (
+                      subTitle
+                    )}
+                  </>
+                ) : null}
+                {wrappedChildren}
+              </YStack>
+            ) : (
+              wrappedChildren
+            )}
+            {themedIconAfter}
+          </context.Provider>
+        </ListItemFrame>
+      </context.Provider>
     )
   }
 )

--- a/code/ui/list-item/types/ListItem.d.ts
+++ b/code/ui/list-item/types/ListItem.d.ts
@@ -12,6 +12,7 @@ export type ListItemExtraProps = {
     title?: ReactNode;
     subTitle?: ReactNode;
     iconSize?: SizeTokens;
+    color?: ColorTokens | string;
 };
 export type ListItemProps = GetProps<typeof ListItemFrame> & ListItemExtraProps;
 declare const ListItemFrame: import("@tamagui/web").TamaguiComponent<import("@tamagui/web").TamaDefer, import("@tamagui/web").TamaguiElement, import("@tamagui/web").StackNonStyleProps, import("@tamagui/web").StackStyleBase, {

--- a/code/ui/stacks/src/ThemeableStack.tsx
+++ b/code/ui/stacks/src/ThemeableStack.tsx
@@ -15,6 +15,29 @@ const chromelessStyle = {
   },
 }
 
+const outlinedStyle =
+  process.env.TAMAGUI_HEADLESS === '1'
+    ? {}
+    : {
+        backgroundColor: 'transparent',
+        borderWidth: 1,
+        borderColor: '$borderColor',
+
+        hoverStyle: {
+          backgroundColor: 'transparent',
+          borderColor: '$borderColorHover',
+        },
+
+        pressStyle: {
+          backgroundColor: 'transparent',
+          borderColor: '$borderColorPress',
+        },
+      }
+
+export const themeableVariantStyles = {
+  outlined: outlinedStyle,
+} as const
+
 export const themeableVariants = {
   circular,
   elevate,

--- a/code/ui/stacks/types/ThemeableStack.d.ts
+++ b/code/ui/stacks/types/ThemeableStack.d.ts
@@ -1,4 +1,25 @@
 import type { GetProps } from '@tamagui/core';
+export declare const themeableVariantStyles: {
+    readonly outlined: {
+        backgroundColor?: undefined;
+        borderWidth?: undefined;
+        borderColor?: undefined;
+        hoverStyle?: undefined;
+        pressStyle?: undefined;
+    } | {
+        backgroundColor: string;
+        borderWidth: number;
+        borderColor: string;
+        hoverStyle: {
+            backgroundColor: string;
+            borderColor: string;
+        };
+        pressStyle: {
+            backgroundColor: string;
+            borderColor: string;
+        };
+    };
+};
 export declare const themeableVariants: {
     readonly circular: {
         true: (_: any, { props, tokens }: {


### PR DESCRIPTION
## Summary

- align ListItem with Button composition: use `useProps`, re-provide the resolved styled ListItem context inside the frame, and let `ListItem.Icon` inherit instance size/color without a duplicate plain React icon context
- add `color` as a documented public `ListItem` prop; icon children and icon props inherit it through the resolved ListItem context
- replace ListItem icon wrapper margins with size-variant frame `gap` spacing
- gap semantics change: `gap` now applies between all direct ListItem frame children, not just around icons, so multiple raw JSX children gain spacing
- fix bare string children under `<ListItem unstyled>` so wrapped text is also unstyled
- share outlined variant styling and themed icon sizing between Button/ListItem

## Validation

Local non-browser validation only, per CTO directive: no local kitchen-sink Playwright/browser run. Tamagui CI owns web/render-count proof for this PR.

- `bun run build` in `code/ui/list-item`: pass
- `TAMAGUI_TARGET=native bunx vitest --run --config ../../packages/vite-plugin-internal/src/vite.config.ts ListItem.native.test.tsx` in `code/ui/components-test`: pass
- same two-test native file fails against `origin/v3-beta @ 90bca68892`: 2 failed, proving the baseline lacks resolved icon size (`18` vs expected `46`) and keeps styled unstyled text color (`#000`)
- `node_modules/.bin/oxfmt --check code/ui/list-item/src/ListItem.tsx code/ui/components-test/ListItem.native.test.tsx code/tamagui.dev/data/docs/components/list-item/2.0.0.mdx`: pass
- `bun run check:references`: pass
- earlier full non-browser pass remains attached: `@tamagui/helpers-tamagui`, `@tamagui/stacks`, `@tamagui/button`, and `@tamagui/list-item` builds pass

Local artifact paths for the coordinator/reviewer:

- `/tmp/tamagui-cs3-proof-15563b/list-item-build-review.log`
- `/tmp/tamagui-cs3-proof-15563b/native-listitem-review-pass.log`
- `/tmp/tamagui-cs3-proof-15563b/negative-native-baseline.log`
- `/tmp/tamagui-cs3-proof-15563b/check-references-review.log`
- `/tmp/tamagui-cs3-proof-15563b/format-review-check.log`
- `/tmp/tamagui-cs3-proof-15563b/non-browser-validation.log`
- `/tmp/tamagui-cs3-proof-15563b/root-format-check.log`
- `/tmp/tamagui-cs3-proof-15563b/README.md`

Note: full root `bun run format:check` currently reports unrelated pre-existing files from `origin/v3-beta`; touched-file formatting passes.

## Refactor Contract Axes

1. Screen sizes/media flip: web screenshot proof is delegated to Tamagui CI. ListItem is non-adaptive, so media-flip proof is N/A.
2. Web and native: web proof is delegated to CI. Native component proof is covered by `code/ui/components-test/ListItem.native.test.tsx`, including the ListItem context re-provision path for resolved icon size/color.
3. Render count: delegated to Tamagui CI render-count proof.
4. Remount/identity: delegated to Tamagui CI proof.
5. Animations/gestures/handoff: N/A. ListItem has no enter/exit presence animation, gesture handoff, portal, or Adapt path in this PR.
6. Perf/bundle: N/A for decoupling bundle shrink. This PR does not remove Sheet/Dialog/Select dependencies or touch core hot paths; it removes two icon wrapper Views from ListItem render output.
7. SSR: CI-render proof owns render/hydrate equality. Select blank-value SSR fix is N/A for CS-3; Select is owned by CS-1.
