### PR TITLE
ci: add v3 validation gates

### DIFF
--- a/.github/scripts/check-ios-detox-shards.mjs
+++ b/.github/scripts/check-ios-detox-shards.mjs
@@ -5,6 +5,15 @@ const repoRoot = process.cwd()
 const e2eDir = join(repoRoot, 'code/kitchen-sink/e2e')
 const shouldWriteGitHubOutput = process.argv.includes('--github-output')
 
+// 4 seed shards balanced by test execution time. The old ~7min/shard ts-jest
+// type-check tax is gone (e2e now transpiles via e2e/tsconfig.json), so startup
+// is small and these fit well under the native-ci runner's 45-minute process
+// timeout. CompilerExtraction runs an in-test `npx tamagui build` (~12-19min,
+// variable) so it gets its OWN shard (with the iOS-skipped SafeArea/
+// SheetKeyboardDrag, which cost ~0, plus the small iOS-running
+// SheetFitKeyboardSafeArea, ~1 launch); the remaining files are bin-packed to
+// ~14.5min test-exec each (~25min wall). SelectAndroidOnPress is android-only
+// and remains explicitly excluded below; it still runs in the android job.
 const seedShards = [
   {
     name: '1/4',
@@ -120,6 +129,12 @@ if (missingAssignments.length > 0) {
   console.info('Auto-discovered new iOS Detox tests:')
   for (const testName of missingAssignments) {
     console.info(`- ${testName}`)
+  }
+
+  if (missingAssignments.length > 4) {
+    console.info(
+      `::warning::Auto-discovered iOS Detox shard has ${missingAssignments.length} files; consider re-seeding shards if this approaches the 45-minute native-ci cap.`
+    )
   }
 }
 

--- a/.github/scripts/check-ios-detox-shards.mjs
+++ b/.github/scripts/check-ios-detox-shards.mjs
@@ -1,9 +1,36 @@
-import { readdirSync, readFileSync } from 'node:fs'
+import { readdirSync } from 'node:fs'
 import { basename, join } from 'node:path'
 
 const repoRoot = process.cwd()
-const workflowPath = join(repoRoot, '.github/workflows/test-native.yml')
 const e2eDir = join(repoRoot, 'code/kitchen-sink/e2e')
+const shouldWriteGitHubOutput = process.argv.includes('--github-output')
+
+const seedShards = [
+  {
+    name: '1/4',
+    slug: '1-4',
+    test_files:
+      'e2e/CompilerExtraction.test.ts e2e/SafeArea.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetFitKeyboardSafeArea.test.ts e2e/SheetPressResponderSheetRngh.test.ts',
+  },
+  {
+    name: '2/4',
+    slug: '2-4',
+    test_files:
+      'e2e/PressStyleNative.noRngh.test.ts e2e/CompilerTernaryActive.test.ts e2e/TabsOnInteraction.test.ts e2e/PointerEvents.test.ts e2e/GroupPressNative.test.ts e2e/ShorthandVariables.test.ts e2e/check-rngh-status.test.ts',
+  },
+  {
+    name: '3/4',
+    slug: '3-4',
+    test_files:
+      'e2e/SheetScrollableDrag.test.ts e2e/ThemeMutation.test.ts e2e/NativePortal.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/MenuRadioGroup.test.ts e2e/PressStyleScrollStuck.test.ts',
+  },
+  {
+    name: '4/4',
+    slug: '4-4',
+    test_files:
+      'e2e/PressStyleNative.test.ts e2e/SheetPressRegression.test.ts e2e/SheetKeyboardFitContent.test.ts e2e/SelectRemount.test.ts e2e/SheetDragResist.test.ts e2e/ThemeChangeBasic.test.ts e2e/NestedPressExclusive.test.ts e2e/MediaQueryGtMd.test.ts',
+  },
+]
 
 const explicitlyExcludedTests = new Map([
   // android-only: every test skips on iOS (device.getPlatform() === 'ios'), so running
@@ -15,21 +42,7 @@ const explicitlyExcludedTests = new Map([
   ],
 ])
 
-const workflow = readFileSync(workflowPath, 'utf8')
-const shardMatches = [...workflow.matchAll(/test_files:\s*'([^']*)'/g)]
-
-if (shardMatches.length === 0) {
-  console.error(`No iOS Detox shard definitions found in ${workflowPath}`)
-  process.exit(1)
-}
-
-const assignedTestFiles = shardMatches.flatMap((match) =>
-  match[1]
-    .split(/\s+/)
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-)
-
+const assignedTestFiles = seedShards.flatMap((shard) => splitTestFiles(shard.test_files))
 const assignedTestBasenames = assignedTestFiles
   .filter((entry) => entry.endsWith('.test.ts'))
   .map((entry) => basename(entry))
@@ -47,6 +60,10 @@ const duplicateAssignments = [...counts.entries()]
   .filter(([, count]) => count > 1)
   .map(([testName, count]) => `${testName} (${count}x)`)
 
+const staleAssignments = assignedTestBasenames.filter(
+  (testName) => !allDetoxTests.includes(testName)
+)
+
 const missingAssignments = allDetoxTests.filter(
   (testName) => !counts.has(testName) && !explicitlyExcludedTests.has(testName)
 )
@@ -55,15 +72,6 @@ const staleExclusions = [...explicitlyExcludedTests.keys()].filter(
   (testName) => !allDetoxTests.includes(testName)
 )
 
-if (
-  duplicateAssignments.length === 0 &&
-  missingAssignments.length === 0 &&
-  staleExclusions.length === 0
-) {
-  console.info('iOS Detox shard coverage is valid.')
-  process.exit(0)
-}
-
 if (duplicateAssignments.length > 0) {
   console.error('Duplicate iOS Detox shard assignments:')
   for (const entry of duplicateAssignments) {
@@ -71,9 +79,9 @@ if (duplicateAssignments.length > 0) {
   }
 }
 
-if (missingAssignments.length > 0) {
-  console.error('Missing iOS Detox tests from shard matrix:')
-  for (const testName of missingAssignments) {
+if (staleAssignments.length > 0) {
+  console.error('Stale iOS Detox shard assignments:')
+  for (const testName of staleAssignments) {
     console.error(`- ${testName}`)
   }
 }
@@ -86,10 +94,55 @@ if (staleExclusions.length > 0) {
 }
 
 if (explicitlyExcludedTests.size > 0) {
-  console.error('Explicitly excluded iOS Detox tests:')
+  console.info('Explicitly excluded iOS Detox tests:')
   for (const [testName, reason] of explicitlyExcludedTests.entries()) {
-    console.error(`- ${testName}: ${reason}`)
+    console.info(`- ${testName}: ${reason}`)
   }
 }
 
-process.exit(1)
+if (
+  duplicateAssignments.length > 0 ||
+  staleAssignments.length > 0 ||
+  staleExclusions.length > 0
+) {
+  process.exit(1)
+}
+
+const plannedShards = [...seedShards]
+if (missingAssignments.length > 0) {
+  const test_files = missingAssignments.map((testName) => `e2e/${testName}`).join(' ')
+  plannedShards.push({
+    name: 'auto-discovered',
+    slug: 'auto-discovered',
+    test_files,
+  })
+
+  console.info('Auto-discovered new iOS Detox tests:')
+  for (const testName of missingAssignments) {
+    console.info(`- ${testName}`)
+  }
+}
+
+console.info(
+  `iOS Detox shard plan is valid (${plannedShards.length} shard${
+    plannedShards.length === 1 ? '' : 's'
+  }).`
+)
+
+if (shouldWriteGitHubOutput) {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) {
+    console.error('GITHUB_OUTPUT is not set')
+    process.exit(1)
+  }
+
+  const fs = await import('node:fs')
+  fs.appendFileSync(outputPath, `shards=${JSON.stringify(plannedShards)}\n`)
+}
+
+function splitTestFiles(testFiles) {
+  return testFiles
+    .split(/\s+/)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}

--- a/.github/scripts/compare-webpack-stats.mjs
+++ b/.github/scripts/compare-webpack-stats.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { basename, join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+
+const args = new Map()
+for (let i = 2; i < process.argv.length; i += 2) {
+  const key = process.argv[i]
+  const value = process.argv[i + 1]
+  if (!key?.startsWith('--') || !value) {
+    usage()
+  }
+  args.set(key.slice(2), value)
+}
+
+const baseStatsPath = requiredArg('base')
+const headStatsPath = requiredArg('head')
+const baseDist = args.get('base-dist')
+const headDist = args.get('head-dist')
+const outPath = args.get('out')
+
+const base = summarizeStats(baseStatsPath, baseDist)
+const head = summarizeStats(headStatsPath, headDist)
+const markdown = renderMarkdown(base, head)
+
+if (outPath) {
+  writeFileSync(outPath, markdown)
+} else {
+  process.stdout.write(markdown)
+}
+
+const gzipDelta = head.totals.gzip - base.totals.gzip
+if (gzipDelta > 0) {
+  console.log(`::warning::Bundle gzip total increased by ${formatBytes(gzipDelta)}`)
+}
+
+function usage() {
+  console.error(
+    'Usage: compare-webpack-stats.mjs --base <stats.json> --head <stats.json> [--base-dist <dir>] [--head-dist <dir>] [--out <markdown>]'
+  )
+  process.exit(1)
+}
+
+function requiredArg(name) {
+  const value = args.get(name)
+  if (!value) usage()
+  return value
+}
+
+function summarizeStats(statsPath, distDir) {
+  const stats = JSON.parse(readFileSync(statsPath, 'utf8'))
+  const assets = Array.isArray(stats.assets) ? stats.assets : []
+  const filtered = assets
+    .filter((asset) => typeof asset.name === 'string')
+    .filter((asset) => !asset.name.endsWith('.map'))
+    .filter((asset) => asset.name.endsWith('.js') || asset.name.endsWith('.css'))
+    .map((asset) => {
+      const raw = Number(asset.size) || 0
+      const gzip = gzipAsset(distDir, asset.name)
+      return {
+        name: asset.name,
+        kind: asset.name.endsWith('.css') ? 'css' : 'js',
+        raw,
+        gzip: gzip ?? 0,
+        hasGzip: gzip !== null,
+      }
+    })
+
+  return {
+    label: basename(statsPath),
+    assetCount: filtered.length,
+    totals: sumAssets(filtered),
+    byKind: {
+      js: sumAssets(filtered.filter((asset) => asset.kind === 'js')),
+      css: sumAssets(filtered.filter((asset) => asset.kind === 'css')),
+    },
+    largest: [...filtered].sort((a, b) => b.raw - a.raw).slice(0, 10),
+  }
+}
+
+function gzipAsset(distDir, assetName) {
+  if (!distDir) return null
+
+  const path = join(distDir, assetName)
+  if (!existsSync(path) || !statSync(path).isFile()) return null
+
+  return gzipSync(readFileSync(path)).byteLength
+}
+
+function sumAssets(assets) {
+  return assets.reduce(
+    (sum, asset) => {
+      sum.raw += asset.raw
+      sum.gzip += asset.gzip
+      if (asset.hasGzip) sum.gzipAssetCount += 1
+      return sum
+    },
+    { raw: 0, gzip: 0, gzipAssetCount: 0 }
+  )
+}
+
+function renderMarkdown(base, head) {
+  const lines = [
+    '# Kitchen Sink Bundle Delta',
+    '',
+    '| Scope | Base Raw | Head Raw | Raw Delta | Base Gzip | Head Gzip | Gzip Delta |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: |',
+    renderRow('All JS/CSS', base.totals, head.totals),
+    renderRow('JS', base.byKind.js, head.byKind.js),
+    renderRow('CSS', base.byKind.css, head.byKind.css),
+    '',
+    `Base assets: ${base.assetCount}; head assets: ${head.assetCount}.`,
+    '',
+    '## Largest Head Assets',
+    '',
+    '| Asset | Raw | Gzip |',
+    '| --- | ---: | ---: |',
+  ]
+
+  for (const asset of head.largest) {
+    lines.push(
+      `| \`${asset.name}\` | ${formatBytes(asset.raw)} | ${
+        asset.hasGzip ? formatBytes(asset.gzip) : 'n/a'
+      } |`
+    )
+  }
+
+  lines.push('')
+  return `${lines.join('\n')}\n`
+}
+
+function renderRow(label, base, head) {
+  return `| ${label} | ${formatBytes(base.raw)} | ${formatBytes(head.raw)} | ${formatDelta(
+    head.raw - base.raw
+  )} | ${formatMaybeGzip(base)} | ${formatMaybeGzip(head)} | ${formatDelta(
+    head.gzip - base.gzip
+  )} |`
+}
+
+function formatMaybeGzip(total) {
+  return total.gzipAssetCount > 0 ? formatBytes(total.gzip) : 'n/a'
+}
+
+function formatDelta(bytes) {
+  const sign = bytes > 0 ? '+' : ''
+  return `${sign}${formatBytes(bytes)}`
+}
+
+function formatBytes(bytes) {
+  const abs = Math.abs(bytes)
+  if (abs >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+  if (abs >= 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${bytes} B`
+}

--- a/.github/scripts/run-maestro-flows.sh
+++ b/.github/scripts/run-maestro-flows.sh
@@ -23,6 +23,8 @@
 #                  driver makes `maestro test` hang with no exit, so without it
 #                  the loop never advances and the job sits idle until the
 #                  runner's 45-min cap                        (default: 360)
+#   MAESTRO_DEVICE_ID
+#                  simulator UDID to target explicitly        (default: booted)
 #
 # NOT using `set -e`: a failing/timed-out `maestro test` is expected and handled inline.
 
@@ -34,6 +36,12 @@ MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
 SKIP_FLOWS="${SKIP_FLOWS:-OpenApp.yaml WarmUp.yaml}"
 METRO_PID_FILE="${METRO_PID_FILE:-/tmp/metro-pid}"
 FLOW_TIMEOUT="${FLOW_TIMEOUT:-360}"
+MAESTRO_DEVICE_ID="${MAESTRO_DEVICE_ID:-}"
+
+maestro_cmd=(maestro)
+if [ -n "$MAESTRO_DEVICE_ID" ]; then
+  maestro_cmd+=(--device "$MAESTRO_DEVICE_ID")
+fi
 
 metro_alive() {
   local pid
@@ -44,7 +52,7 @@ metro_alive() {
 
 recover_sim() {
   echo "recovering simulator state (terminate app, keep Hermes bytecode cache)..."
-  xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+  xcrun simctl terminate "${MAESTRO_DEVICE_ID:-booted}" "$BUNDLE_ID" 2>/dev/null || true
   sleep 2
   if ! metro_alive; then
     echo "::error::Metro died during test run — aborting (every retry would fail)"
@@ -65,7 +73,7 @@ recover_sim() {
 run_flow_with_timeout() {
   local flow="$1"
   set -m
-  maestro test "$flow" --no-ansi &
+  "${maestro_cmd[@]}" test "$flow" --no-ansi &
   local pid=$!
   set +m
   local waited=0

--- a/.github/workflows/build-ios-kitchensink-app.yml
+++ b/.github/workflows/build-ios-kitchensink-app.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Set Xcode version

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -10,6 +10,8 @@ on:
       - main
       - v2
       - 'v2-*'
+      - v3
+      - 'v3-*'
 
 permissions:
   contents: read
@@ -110,6 +112,14 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
+            BASE_REF="${{ github.base_ref }}"
+            HEAD_REF="${{ github.head_ref }}"
+
+            if [ "$BASE_REF" = "v3-beta" ] || [[ "$BASE_REF" == v3-* ]] || [[ "$HEAD_REF" == v3-* ]]; then
+              echo "relevant=true" >> $GITHUB_OUTPUT
+              echo "::notice::Kitchen-sink integration forced for v3 PR ($HEAD_REF -> $BASE_REF)"
+              exit 0
+            fi
           else
             BASE="HEAD~1"
           fi
@@ -154,6 +164,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'pull_request' && (github.base_ref == 'v3-beta' || startsWith(github.base_ref, 'v3-') || startsWith(github.head_ref, 'v3-')) && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Install
@@ -180,6 +191,115 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-
 
-      - name: Run integration tests (shard ${{ matrix.shard }})
+      - name: Run kitchen-sink web + render-count tests (shard ${{ matrix.shard }})
         run: cd code/kitchen-sink && NODE_ENV=test npx playwright test --shard=${{ matrix.shard }}
         timeout-minutes: 20
+
+  v3-ssr-hydration:
+    if: github.event_name == 'pull_request' && (github.base_ref == 'v3-beta' || startsWith(github.base_ref, 'v3-') || startsWith(github.head_ref, 'v3-'))
+    runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: '--max-old-space-size=6144'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 1
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(bunx playwright --version | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
+      - name: Install Playwright Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run SSR hydration checks
+        run: |
+          cd code/sandbox
+          TEST_MODE=dev NODE_ENV=test bunx playwright test \
+            hydration-drivers.test.ts \
+            motion-hydration.test.ts \
+            ssr-theme.test.ts \
+            tooltip-ssr.test.ts \
+            tooltip-heavy-ssr.test.ts
+        timeout-minutes: 20
+
+      - name: Upload SSR artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: v3-ssr-hydration-artifacts
+          path: |
+            code/sandbox/.playwright-report
+            code/sandbox/.playwright-results
+          retention-days: 7
+
+  v3-bundle-delta:
+    if: github.event_name == 'pull_request' && (github.base_ref == 'v3-beta' || startsWith(github.base_ref, 'v3-') || startsWith(github.head_ref, 'v3-'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      NODE_OPTIONS: '--max-old-space-size=6144'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install head dependencies
+        uses: ./.github/actions/install
+
+      - name: Capture head bundle stats
+        run: |
+          rm -rf code/kitchen-sink/dist /tmp/tamagui-head-dist
+          cd code/kitchen-sink
+          NODE_ENV=production bun run prod:web
+          cp -R dist /tmp/tamagui-head-dist
+
+      - name: Add base worktree
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git worktree add /tmp/tamagui-base "$BASE_SHA"
+
+      - name: Install base dependencies
+        working-directory: /tmp/tamagui-base
+        run: bun install --frozen-lockfile
+
+      - name: Capture base bundle stats
+        working-directory: /tmp/tamagui-base/code/kitchen-sink
+        run: |
+          rm -rf dist
+          NODE_ENV=production bun run prod:web
+
+      - name: Compare bundle stats
+        run: |
+          node .github/scripts/compare-webpack-stats.mjs \
+            --base /tmp/tamagui-base/code/kitchen-sink/dist/compilation-stats.json \
+            --base-dist /tmp/tamagui-base/code/kitchen-sink/dist \
+            --head /tmp/tamagui-head-dist/compilation-stats.json \
+            --head-dist /tmp/tamagui-head-dist \
+            --out /tmp/v3-bundle-delta.md
+
+          mkdir -p bundle-delta-artifacts
+          cp /tmp/v3-bundle-delta.md bundle-delta-artifacts/v3-bundle-delta.md
+          cp /tmp/tamagui-head-dist/compilation-stats.json bundle-delta-artifacts/head-compilation-stats.json
+          cp /tmp/tamagui-base/code/kitchen-sink/dist/compilation-stats.json bundle-delta-artifacts/base-compilation-stats.json
+          cat /tmp/v3-bundle-delta.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload bundle delta
+        uses: actions/upload-artifact@v4
+        with:
+          name: v3-bundle-delta
+          path: bundle-delta-artifacts
+          retention-days: 14

--- a/.github/workflows/test-ios-kitchensink-go.yml
+++ b/.github/workflows/test-ios-kitchensink-go.yml
@@ -2,9 +2,9 @@ name: Test iOS Kitchen Sink Go (Maestro)
 
 on:
   push:
-    branches: [main, 'v2-*']
+    branches: [main, 'v2-*', 'v3-*']
   pull_request:
-    branches: [main, 'v*']
+    branches: [main, 'v2-*', 'v3-*']
   workflow_dispatch:
 
 permissions:
@@ -17,13 +17,18 @@ jobs:
   test:
     # TODO: re-enable once Sheet demo is fixed on Expo Go CI
     if: false
-    name: Run Maestro Tests (exports=${{ matrix.package-exports }})
+    name: Run Maestro Tests (${{ matrix.ios_device.slug }}, exports=${{ matrix.package-exports }})
     runs-on: macos-14
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         package-exports: [true, false]
+        ios_device:
+          - name: iPhone 16
+            slug: iphone-16
+          - name: iPhone 16 Pro Max
+            slug: iphone-16-pro-max
     defaults:
       run:
         working-directory: ${{ env.test_container_app_path }}
@@ -31,6 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Set Xcode version
@@ -51,14 +57,21 @@ jobs:
       - name: Boot iOS Simulator
         working-directory: ${{ github.workspace }}
         run: |
-          DEVICE_ID=$(xcrun simctl list devices available -j | jq -r '.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.name == "iPhone 16") | .udid' | head -1)
+          xcrun simctl shutdown all 2>/dev/null || true
+          sleep 1
+
+          DEVICE_NAME="${{ matrix.ios_device.name }}"
+          DEVICE_ID=$(xcrun simctl list devices available -j | jq -r --arg name "$DEVICE_NAME" '.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.name == $name) | .udid' | head -1)
           if [ -z "$DEVICE_ID" ]; then
-            echo "iPhone 16 not found, using first available iPhone"
-            DEVICE_ID=$(xcrun simctl list devices available -j | jq -r '.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.name | contains("iPhone")) | .udid' | head -1)
+            echo "::error::$DEVICE_NAME simulator not found"
+            xcrun simctl list devices available
+            exit 1
           fi
-          echo "Booting simulator: $DEVICE_ID"
+          echo "Booting simulator: $DEVICE_NAME ($DEVICE_ID)"
           xcrun simctl boot "$DEVICE_ID" || true
           xcrun simctl bootstatus "$DEVICE_ID" -b
+          echo "SIM_DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
+          echo "MAESTRO_DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
 
           echo "Waiting for simulator to be fully ready for Maestro..."
           for i in {1..30}; do
@@ -127,6 +140,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-artifacts-exports-${{ matrix.package-exports }}
+          name: maestro-artifacts-${{ matrix.ios_device.slug }}-exports-${{ matrix.package-exports }}
           path: |
             ~/.maestro/tests/**/*

--- a/.github/workflows/test-ios-native.yml
+++ b/.github/workflows/test-ios-native.yml
@@ -2,9 +2,9 @@ name: Test iOS Native (Maestro)
 
 on:
   push:
-    branches: [main, 'v2-*', rn82]
+    branches: [main, 'v2-*', 'v3-*', rn82]
   pull_request:
-    branches: [main, 'v*']
+    branches: [main, 'v2-*', 'v3-*']
   workflow_dispatch:
 
 permissions:
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
 
   test:
-    name: Run Maestro Tests (exports=${{ matrix.package-exports }})
+    name: Run Maestro Tests (${{ matrix.ios_device.slug }}, exports=${{ matrix.package-exports }})
     needs: build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: macos-15
@@ -37,6 +37,11 @@ jobs:
       fail-fast: false
       matrix:
         package-exports: [true, false]
+        ios_device:
+          - name: iPhone 16
+            slug: iphone-16
+          - name: iPhone 16 Pro Max
+            slug: iphone-16-pro-max
     defaults:
       run:
         working-directory: ${{ env.test_container_app_path }}
@@ -44,6 +49,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Set Xcode version
@@ -90,28 +96,35 @@ jobs:
           echo "$METRO_PID" > /tmp/metro-pid
           cd "${{ github.workspace }}"
 
+          xcrun simctl shutdown all 2>/dev/null || true
+          sleep 1
+
           # boot simulator
-          DEVICE_ID=$(xcrun simctl list devices available -j | jq -r '.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.name == "iPhone 16") | .udid' | head -1)
+          DEVICE_NAME="${{ matrix.ios_device.name }}"
+          DEVICE_ID=$(xcrun simctl list devices available -j | jq -r --arg name "$DEVICE_NAME" '.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.name == $name) | .udid' | head -1)
           if [ -z "$DEVICE_ID" ]; then
-            echo "iPhone 16 not found, using first available iPhone"
-            DEVICE_ID=$(xcrun simctl list devices available -j | jq -r '.devices | to_entries[] | select(.key | contains("iOS")) | .value[] | select(.name | contains("iPhone")) | .udid' | head -1)
+            echo "::error::$DEVICE_NAME simulator not found"
+            xcrun simctl list devices available
+            exit 1
           fi
-          echo "Booting simulator: $DEVICE_ID"
+          echo "Booting simulator: $DEVICE_NAME ($DEVICE_ID)"
           xcrun simctl boot "$DEVICE_ID" || true
           xcrun simctl bootstatus "$DEVICE_ID" -b
+          echo "SIM_DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
+          echo "MAESTRO_DEVICE_ID=$DEVICE_ID" >> "$GITHUB_ENV"
 
           # install app and verify FrontBoard registration
           APP_PATH="${{ needs.build.outputs.built-app-path }}"
           BUNDLE_ID="com.tamagui.tamaguikitchensink"
           for attempt in 1 2 3; do
-            xcrun simctl install booted "$APP_PATH"
+            xcrun simctl install "$DEVICE_ID" "$APP_PATH"
             sleep 3
-            if xcrun simctl get_app_container booted "$BUNDLE_ID" 2>/dev/null; then
+            if xcrun simctl get_app_container "$DEVICE_ID" "$BUNDLE_ID" 2>/dev/null; then
               echo "App installed and registered (attempt $attempt)"
               break
             fi
             echo "::warning::App not registered after install (attempt $attempt)"
-            xcrun simctl uninstall booted "$BUNDLE_ID" 2>/dev/null || true
+            xcrun simctl uninstall "$DEVICE_ID" "$BUNDLE_ID" 2>/dev/null || true
             sleep 3
             if [ $attempt -eq 3 ]; then
               echo "::error::App failed to register after 3 attempts"
@@ -167,10 +180,10 @@ jobs:
         if: env.SKIP_MAESTRO_TESTS != 'true'
         run: |
           # capture simulator device logs in background for debugging app crashes
-          xcrun simctl spawn booted log stream --predicate 'process == "tamaguikitchensink" OR subsystem == "com.tamagui.tamaguikitchensink"' --level debug > /tmp/simulator-app.log 2>&1 &
+          xcrun simctl spawn "$SIM_DEVICE_ID" log stream --predicate 'process == "tamaguikitchensink" OR subsystem == "com.tamagui.tamaguikitchensink"' --level debug > /tmp/simulator-app.log 2>&1 &
           echo $! > /tmp/simlog-pid
           # also capture broader crash/error logs
-          xcrun simctl spawn booted log stream --predicate 'eventMessage CONTAINS "crash" OR eventMessage CONTAINS "fatal" OR eventMessage CONTAINS "error" OR process == "ReportCrash"' --level error > /tmp/simulator-errors.log 2>&1 &
+          xcrun simctl spawn "$SIM_DEVICE_ID" log stream --predicate 'eventMessage CONTAINS "crash" OR eventMessage CONTAINS "fatal" OR eventMessage CONTAINS "error" OR process == "ReportCrash"' --level error > /tmp/simulator-errors.log 2>&1 &
           echo $! > /tmp/simlog-errors-pid
 
       - name: Warm up App (cold start + Hermes bytecode compile)
@@ -182,7 +195,7 @@ jobs:
           # if WarmUp fails, the Maestro xcuitest driver (port 7001) is usually
           # dead — every subsequent flow will fail with "Failed to connect to
           # /127.0.0.1:7001", so fail fast rather than burn 15+ min on doomed retries.
-          if ! maestro test ./flows/WarmUp.yaml --no-ansi; then
+          if ! maestro --device "$MAESTRO_DEVICE_ID" test ./flows/WarmUp.yaml --no-ansi; then
             echo "::error::WarmUp failed — Maestro driver is likely dead, aborting"
             echo "=== Recent app logs ==="
             tail -50 /tmp/simulator-app.log 2>/dev/null || echo "No app logs"
@@ -230,7 +243,7 @@ jobs:
         if: failure() && env.SKIP_MAESTRO_TESTS != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-artifacts-exports-${{ matrix.package-exports }}
+          name: maestro-artifacts-${{ matrix.ios_device.slug }}-exports-${{ matrix.package-exports }}
           path: |
             ~/.maestro/tests/**/*
             /tmp/simulator-app.log

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -38,6 +38,8 @@ jobs:
   validate-ios-detox-shards:
     name: Validate iOS Detox Shards
     runs-on: ubuntu-latest
+    outputs:
+      shards: ${{ steps.plan-shards.outputs.shards }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,7 +48,8 @@ jobs:
           fetch-depth: 1
 
       - name: Validate shard coverage
-        run: node .github/scripts/check-ios-detox-shards.mjs
+        id: plan-shards
+        run: node .github/scripts/check-ios-detox-shards.mjs --github-output
 
   build-ios:
     name: Build iOS App
@@ -72,30 +75,7 @@ jobs:
             slug: iphone-16
           - name: iPhone 16 Pro Max
             slug: iphone-16-pro-max
-        shard:
-          # 4 shards balanced by test execution time. the old ~7min/shard ts-jest
-          # type-check tax is gone (e2e now transpiles via e2e/tsconfig.json), so
-          # startup is small and these fit well under the native-ci runner's
-          # 45-minute process timeout. CompilerExtraction runs an in-test
-          # `npx tamagui build` (~12-19min, variable) so it gets its OWN shard
-          # (with the iOS-skipped SafeArea/SheetKeyboardDrag, which cost ~0, plus
-          # the small iOS-running SheetFitKeyboardSafeArea, ~1 launch); the
-          # remaining files are bin-packed to ~14.5min test-exec each (~25min wall).
-          # SelectAndroidOnPress is android-only (excluded here via
-          # check-ios-detox-shards.mjs, still runs in the android job). Coverage
-          # validated by that script (every e2e test assigned exactly once).
-          - name: '1/4'
-            slug: '1-4'
-            test_files: 'e2e/CompilerExtraction.test.ts e2e/SafeArea.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetFitKeyboardSafeArea.test.ts e2e/SheetPressResponderSheetRngh.test.ts'
-          - name: '2/4'
-            slug: '2-4'
-            test_files: 'e2e/PressStyleNative.noRngh.test.ts e2e/CompilerTernaryActive.test.ts e2e/TabsOnInteraction.test.ts e2e/PointerEvents.test.ts e2e/GroupPressNative.test.ts e2e/ShorthandVariables.test.ts e2e/check-rngh-status.test.ts'
-          - name: '3/4'
-            slug: '3-4'
-            test_files: 'e2e/SheetScrollableDrag.test.ts e2e/ThemeMutation.test.ts e2e/NativePortal.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/MenuRadioGroup.test.ts e2e/PressStyleScrollStuck.test.ts'
-          - name: '4/4'
-            slug: '4-4'
-            test_files: 'e2e/PressStyleNative.test.ts e2e/SheetPressRegression.test.ts e2e/SheetKeyboardFitContent.test.ts e2e/SelectRemount.test.ts e2e/SheetDragResist.test.ts e2e/ThemeChangeBasic.test.ts e2e/NestedPressExclusive.test.ts e2e/MediaQueryGtMd.test.ts'
+        shard: ${{ fromJson(needs.validate-ios-detox-shards.outputs.shards) }}
     defaults:
       run:
         working-directory: ${{ env.test_container_app_path }}

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -7,6 +7,11 @@ on:
       - 'native-*'
       - 'v*'
       - rn82
+  pull_request:
+    branches:
+      - main
+      - 'v2-*'
+      - 'v3-*'
   workflow_dispatch:
 
 permissions:
@@ -37,6 +42,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Validate shard coverage
@@ -44,22 +50,29 @@ jobs:
 
   build-ios:
     name: Build iOS App
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/build-ios-kitchensink-app.yml
     with:
       configuration: Debug
     secrets: inherit
 
   test-ios:
-    name: iOS Detox Tests (${{ matrix.shard_name }})
+    name: iOS Detox Tests (${{ matrix.ios_device.slug }}, ${{ matrix.shard.name }})
     needs:
       - build-ios
       - validate-ios-detox-shards
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: macos-15
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        include:
+        ios_device:
+          - name: iPhone 16
+            slug: iphone-16
+          - name: iPhone 16 Pro Max
+            slug: iphone-16-pro-max
+        shard:
           # 4 shards balanced by test execution time. the old ~7min/shard ts-jest
           # type-check tax is gone (e2e now transpiles via e2e/tsconfig.json), so
           # startup is small and these fit well under the native-ci runner's
@@ -71,13 +84,17 @@ jobs:
           # SelectAndroidOnPress is android-only (excluded here via
           # check-ios-detox-shards.mjs, still runs in the android job). Coverage
           # validated by that script (every e2e test assigned exactly once).
-          - shard_name: '1/4'
+          - name: '1/4'
+            slug: '1-4'
             test_files: 'e2e/CompilerExtraction.test.ts e2e/SafeArea.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetFitKeyboardSafeArea.test.ts e2e/SheetPressResponderSheetRngh.test.ts'
-          - shard_name: '2/4'
+          - name: '2/4'
+            slug: '2-4'
             test_files: 'e2e/PressStyleNative.noRngh.test.ts e2e/CompilerTernaryActive.test.ts e2e/TabsOnInteraction.test.ts e2e/PointerEvents.test.ts e2e/GroupPressNative.test.ts e2e/ShorthandVariables.test.ts e2e/check-rngh-status.test.ts'
-          - shard_name: '3/4'
+          - name: '3/4'
+            slug: '3-4'
             test_files: 'e2e/SheetScrollableDrag.test.ts e2e/ThemeMutation.test.ts e2e/NativePortal.test.ts e2e/GroupPressTransitionMatrix.test.ts e2e/MenuRadioGroup.test.ts e2e/PressStyleScrollStuck.test.ts'
-          - shard_name: '4/4'
+          - name: '4/4'
+            slug: '4-4'
             test_files: 'e2e/PressStyleNative.test.ts e2e/SheetPressRegression.test.ts e2e/SheetKeyboardFitContent.test.ts e2e/SelectRemount.test.ts e2e/SheetDragResist.test.ts e2e/ThemeChangeBasic.test.ts e2e/NestedPressExclusive.test.ts e2e/MediaQueryGtMd.test.ts'
     defaults:
       run:
@@ -86,6 +103,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Set Xcode version
@@ -112,26 +130,26 @@ jobs:
           xcrun simctl shutdown all 2>/dev/null || true
           sleep 1
 
-          # find iPhone 16 simulator
-          DEVICE_ID=$(xcrun simctl list devices available -j | jq -r '
+          # find requested simulator
+          DEVICE_NAME="${{ matrix.ios_device.name }}"
+          DEVICE_ID=$(xcrun simctl list devices available -j | jq -r --arg name "$DEVICE_NAME" '
             .devices | to_entries[]
             | select(.key | contains("iOS"))
             | .value[]
-            | select(.name == "iPhone 16")
+            | select(.name == $name)
             | .udid' | head -1)
 
           if [ -z "$DEVICE_ID" ]; then
-            DEVICE_ID=$(xcrun simctl list devices available -j | jq -r '
-              .devices | to_entries[]
-              | select(.key | contains("iOS"))
-              | .value[]
-              | select(.name | contains("iPhone"))
-              | .udid' | head -1)
+            echo "::error::$DEVICE_NAME simulator not found"
+            xcrun simctl list devices available
+            exit 1
           fi
 
-          echo "Booting simulator: $DEVICE_ID"
+          echo "Booting simulator: $DEVICE_NAME ($DEVICE_ID)"
           xcrun simctl boot "$DEVICE_ID" || true
           echo "SIM_DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
+          echo "DETOX_DEVICE=$DEVICE_NAME" >> "$GITHUB_ENV"
+          echo "DETOX_DEVICE_UDID=$DEVICE_ID" >> "$GITHUB_ENV"
 
       - name: Install Dependencies
         if: env.SKIP_IOS_TESTS != 'true'
@@ -186,12 +204,12 @@ jobs:
         if: env.SKIP_IOS_TESTS != 'true'
         working-directory: ${{ github.workspace }}
         run: |
-          xcrun simctl ui booted appearance light
+          xcrun simctl ui "$SIM_DEVICE_ID" appearance light
 
           # wait for SpringBoard to be fully ready (FrontBoard app registration depends on it)
           echo "Waiting for SpringBoard readiness..."
           for i in {1..30}; do
-            if xcrun simctl spawn booted launchctl list 2>/dev/null | grep -q SpringBoard; then
+            if xcrun simctl spawn "$SIM_DEVICE_ID" launchctl list 2>/dev/null | grep -q SpringBoard; then
               echo "SpringBoard ready after ~${i}s"
               break
             fi
@@ -207,23 +225,23 @@ jobs:
 
           for attempt in 1 2 3; do
             echo "Install attempt $attempt/3..."
-            xcrun simctl install booted "$APP_PATH"
+            xcrun simctl install "$SIM_DEVICE_ID" "$APP_PATH"
             sleep 3
 
             # verify FrontBoard registered the app
-            if xcrun simctl get_app_container booted "$BUNDLE_ID" 2>/dev/null; then
+            if xcrun simctl get_app_container "$SIM_DEVICE_ID" "$BUNDLE_ID" 2>/dev/null; then
               echo "App installed and registered on attempt $attempt"
 
               # launch once to prime FrontBoard, then terminate
-              xcrun simctl launch booted "$BUNDLE_ID" 2>/dev/null || true
+              xcrun simctl launch "$SIM_DEVICE_ID" "$BUNDLE_ID" 2>/dev/null || true
               sleep 2
-              xcrun simctl terminate booted "$BUNDLE_ID" 2>/dev/null || true
+              xcrun simctl terminate "$SIM_DEVICE_ID" "$BUNDLE_ID" 2>/dev/null || true
               break
             fi
 
             echo "::warning::App not registered with FrontBoard after install (attempt $attempt)"
             if [ $attempt -lt 3 ]; then
-              xcrun simctl uninstall booted "$BUNDLE_ID" 2>/dev/null || true
+              xcrun simctl uninstall "$SIM_DEVICE_ID" "$BUNDLE_ID" 2>/dev/null || true
               sleep 5
             else
               echo "::error::App failed to register after 3 install attempts"
@@ -245,7 +263,7 @@ jobs:
           # --retries 0: no whole-file retry (that re-ran beforeAll + every test of a
           # flaky file, the 2x wall-time variance). individual flaky tests retry
           # in-place via jest.retryTimes (e2e/jest.setup.ts).
-          bun run ../packages/native-ci/src/run-detox-ios.ts --project-root "$PWD" --record-logs failing --retries 0 ${{ matrix.test_files }}
+          bun run ../packages/native-ci/src/run-detox-ios.ts --project-root "$PWD" --record-logs failing --retries 0 ${{ matrix.shard.test_files }}
 
       - name: Report iOS Test Status
         if: always() && env.SKIP_IOS_TESTS == 'true'
@@ -256,7 +274,7 @@ jobs:
         if: failure() && env.SKIP_IOS_TESTS != 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: detox-artifacts-ios-${{ strategy.job-index }}
+          name: detox-artifacts-ios-${{ matrix.ios_device.slug }}-${{ matrix.shard.slug }}
           path: ${{ env.test_container_app_path }}/e2e/artifacts/
           retention-days: 7
 
@@ -288,6 +306,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Calculate Pre-Fingerprint Hash
@@ -546,6 +565,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 1
 
       - name: Enable KVM

--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -9,8 +9,6 @@ on:
       - rn82
   pull_request:
     branches:
-      - main
-      - 'v2-*'
       - 'v3-*'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- extend native Detox/Maestro CI to v3 branch targets and PRs into v3-beta without changing main/v2 PR cost policy
- run iOS native conformance on iPhone 16 and iPhone 16 Pro Max matrices, with PR-head checkout for the native proof path
- auto-discover newly added iOS Detox tests into an extra shard, so interaction tests such as AdaptLiveSlotSpike.test.ts and Sheet SH-B additions run without a CI follow-up
- force kitchen-sink web/render-count checks on v3 PRs and add SSR hydration plus bundle-delta CI artifacts

## Validation
- node --check .github/scripts/check-ios-detox-shards.mjs
- node --check .github/scripts/compare-webpack-stats.mjs
- bash -n .github/scripts/run-maestro-flows.sh
- node .github/scripts/check-ios-detox-shards.mjs
- simulated AdaptLiveSlotSpike.test.ts auto-discovery locally; planner emitted an auto-discovered fifth shard
- ruby YAML.load_file on updated workflows
- git diff --check