### PR TITLE
fix: add default size token resolution

### DIFF
--- a/code/core/config-default/src/index.ts
+++ b/code/core/config-default/src/index.ts
@@ -9,9 +9,11 @@ export function getDefaultTamaguiConfig(platform: 'native' | 'web' = 'web') {
     family: 'Heading',
     size: {
       1: 15,
+      4: 15,
     },
     lineHeight: {
       1: 15,
+      4: 15,
     },
     transform: {},
     weight: {
@@ -29,9 +31,11 @@ export function getDefaultTamaguiConfig(platform: 'native' | 'web' = 'web') {
     family: 'System',
     size: {
       1: 15,
+      4: 15,
     },
     lineHeight: {
       1: 15,
+      4: 15,
     },
     transform: {},
     weight: {

--- a/code/core/config-default/types/index.d.ts
+++ b/code/core/config-default/types/index.d.ts
@@ -133,9 +133,11 @@ export declare function getDefaultTamaguiConfig(platform?: 'native' | 'web'): {
             family: string;
             size: {
                 1: number;
+                4: number;
             };
             lineHeight: {
                 1: number;
+                4: number;
             };
             transform: {};
             weight: {
@@ -152,9 +154,11 @@ export declare function getDefaultTamaguiConfig(platform?: 'native' | 'web'): {
             family: string;
             size: {
                 1: number;
+                4: number;
             };
             lineHeight: {
                 1: number;
+                4: number;
             };
             transform: {};
             weight: {

--- a/code/core/core-test/createTamagui.web.test.tsx
+++ b/code/core/core-test/createTamagui.web.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, test } from 'vitest'
 
 import config from '../config-default'
 import { createTamagui } from '../core/src'
+import { getFontSizeToken } from '../font-size/src'
+import { getSize } from '../get-token/src'
 
 describe('createTamagui', () => {
   test(`z-index resolves to correct unitless values`, () => {
@@ -12,5 +14,98 @@ describe('createTamagui', () => {
     expect(theme.tokensParsed.zIndex['$1'].name).toEqual('t-zIndex-1')
     expect(theme.tokensParsed.zIndex['$1'].variable).toEqual('var(--t-zIndex-1)')
     expect(theme.tokensParsed.zIndex['$1'].val).toEqual(100)
+  })
+
+  test(`settings.defaultSize defaults to $4`, () => {
+    const theme = createTamagui(config.getDefaultTamaguiConfig())
+    expect(theme.settings.defaultSize).toBe('$4')
+  })
+
+  test(`settings.defaultSize normalizes unprefixed token names`, () => {
+    const baseConfig = config.getDefaultTamaguiConfig()
+    const theme = createTamagui({
+      ...baseConfig,
+      settings: {
+        ...baseConfig.settings,
+        defaultSize: '5',
+      },
+    })
+
+    expect(theme.settings.defaultSize).toBe('$5')
+  })
+
+  test(`settings.defaultSize validates size, space, and font size maps in development`, () => {
+    const baseConfig = config.getDefaultTamaguiConfig()
+    const originalNodeEnv = process.env.NODE_ENV
+    process.env.NODE_ENV = 'development'
+
+    try {
+      expect(() =>
+        createTamagui({
+          ...baseConfig,
+          settings: {
+            ...baseConfig.settings,
+            defaultSize: '$missing',
+          },
+        })
+      ).toThrow(/settings\.defaultSize.*tokens\.size\.\$missing/)
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv
+    }
+  })
+
+  test(`true and $true helper inputs resolve through settings.defaultSize`, () => {
+    createTamagui({
+      tokens: {
+        color: {
+          background: '#fff',
+          color: '#000',
+        },
+        size: {
+          4: 44,
+          5: 52,
+        },
+        space: {
+          4: 18,
+          5: 24,
+        },
+        radius: {
+          4: 9,
+        },
+        zIndex: {
+          4: 400,
+        },
+      },
+      fonts: {
+        body: {
+          family: 'System',
+          size: {
+            4: 16,
+            5: 20,
+          },
+          lineHeight: {
+            4: 20,
+            5: 24,
+          },
+        },
+      },
+      themes: {
+        light: {
+          background: '#fff',
+          color: '#000',
+        },
+      },
+      settings: {
+        defaultFont: 'body',
+        defaultSize: '$4',
+      },
+    })
+
+    expect(getSize(true).key).toBe('$4')
+    expect(getSize('$true').key).toBe('$4')
+    expect(getSize(true, { shift: 1 }).key).toBe('$5')
+    expect(getSize(true, { shift: 1, excludeHalfSteps: true }).key).toBe('$5')
+    expect(getFontSizeToken(true)).toBe('$4')
+    expect(getFontSizeToken('$true' as any, { relativeSize: 1 })).toBe('$5')
   })
 })

--- a/code/core/core-test/getSplitStyles.native.test.tsx
+++ b/code/core/core-test/getSplitStyles.native.test.tsx
@@ -1,4 +1,5 @@
 import { View, Text, createTamagui, getSplitStyles, styled } from '@tamagui/core'
+import { StyleObjectProperty, StyleObjectValue } from '@tamagui/helpers'
 import { beforeAll, describe, expect, test } from 'vitest'
 
 import config from '../config-default'
@@ -39,6 +40,55 @@ describe('getSplitStyles', () => {
 
     expect(style?.columnGap).toBe(10)
     expect(style?.rowGap).toBe(10)
+  })
+
+  test(`default size markers resolve to native layout values`, () => {
+    const direct = getSplitStylesFor(
+      {
+        padding: '$true',
+        borderRadius: '$true',
+      },
+      View,
+      {
+        resolveValues: 'value',
+      }
+    )
+
+    expect(findLayoutValue(direct, 'paddingTop')).toBe('18px')
+    expect(findLayoutValue(direct, 'paddingRight')).toBe('18px')
+    expect(findLayoutValue(direct, 'paddingBottom')).toBe('18px')
+    expect(findLayoutValue(direct, 'paddingLeft')).toBe('18px')
+    expect(findLayoutValue(direct, 'borderTopLeftRadius')).toBe('9px')
+    expect(findLayoutValue(direct, 'borderTopRightRadius')).toBe('9px')
+    expect(findLayoutValue(direct, 'borderBottomRightRadius')).toBe('9px')
+    expect(findLayoutValue(direct, 'borderBottomLeftRadius')).toBe('9px')
+
+    let seenSize: unknown
+    const SpreadSizeView = styled(View, {
+      variants: {
+        size: {
+          '...size': (val) => {
+            seenSize = val
+            return {
+              width: val,
+            }
+          },
+        },
+      } as const,
+    })
+
+    const spread = getSplitStylesFor(
+      {
+        size: '$true',
+      },
+      SpreadSizeView,
+      {
+        resolveValues: 'value',
+      }
+    )
+
+    expect(seenSize).toBe('$4')
+    expect(findLayoutValue(spread, 'width')).toBe('44px')
   })
 
   test('functional variants see media-resolved sibling variant props', () => {
@@ -402,7 +452,11 @@ describe.skip('getSplitStyles - pseudo prop merging', () => {
 function getSplitStylesFor(
   props: Record<string, any>,
   Component = View,
-  options: { mediaState?: Record<string, any>; groupContext?: any } = {}
+  options: {
+    mediaState?: Record<string, any>
+    groupContext?: any
+    resolveValues?: 'none' | 'value' | 'web' | 'auto'
+  } = {}
 ) {
   return getSplitStyles(
     props,
@@ -421,6 +475,7 @@ function getSplitStylesFor(
     {
       isAnimated: false,
       mediaState: options.mediaState,
+      resolveValues: options.resolveValues,
     },
     undefined,
     undefined,
@@ -428,6 +483,24 @@ function getSplitStylesFor(
     undefined,
     undefined
   )!
+}
+
+function findLayoutValue(result: ReturnType<typeof getSplitStylesFor>, property: string) {
+  const styleValue = result.style?.[property] ?? result.viewProps?.style?.[property]
+  if (styleValue != null) {
+    return typeof styleValue === 'number' ? `${styleValue}px` : styleValue
+  }
+
+  for (const rule of Object.values(result.rulesToInsert ?? {})) {
+    if ((rule as any)[StyleObjectProperty] === property) {
+      return (rule as any)[StyleObjectValue]
+    }
+  }
+
+  const className = result.classNames?.[property]
+  const match =
+    typeof className === 'string' ? /-(-?\d+(?:\.\d+)?px)$/.exec(className) : null
+  return match?.[1]
 }
 
 function getThemeStylesView(props: Record<string, any>, themeName: string, tag?: string) {

--- a/code/core/core-test/getSplitStyles.web.test.tsx
+++ b/code/core/core-test/getSplitStyles.web.test.tsx
@@ -44,6 +44,71 @@ describe('getSplitStyles', () => {
     expect(styles.classNames).toEqual({ color: '_col-red' })
   })
 
+  test(`size spread variants resolve true through settings.defaultSize`, () => {
+    let seenSize: unknown
+    const SizedView = styled(View, {
+      variants: {
+        size: {
+          '...size': (val) => {
+            seenSize = val
+            return {
+              width: val,
+            }
+          },
+        },
+      } as const,
+    })
+
+    simplifiedGetSplitStyles(SizedView, {
+      size: true,
+    })
+
+    expect(seenSize).toBe('$4')
+  })
+
+  test(`size spread variants resolve $true through settings.defaultSize`, () => {
+    let seenSize: unknown
+    const SizedView = styled(View, {
+      variants: {
+        size: {
+          '...size': (val) => {
+            seenSize = val
+            return {
+              width: val,
+            }
+          },
+        },
+      } as const,
+    })
+
+    simplifiedGetSplitStyles(SizedView, {
+      size: '$true',
+    })
+
+    expect(seenSize).toBe('$4')
+  })
+
+  test(`direct $true style tokens resolve through settings.defaultSize`, () => {
+    const out = simplifiedGetSplitStyles(View, {
+      padding: '$true',
+      borderRadius: '$true',
+    })
+
+    const byProp: Record<string, string> = {}
+    for (const rule of Object.values(out.rulesToInsert)) {
+      byProp[rule[StyleObjectProperty] as string] = rule[StyleObjectValue] as string
+    }
+
+    expect(byProp.paddingTop).toBe('var(--t-space-4)')
+    expect(byProp.paddingRight).toBe('var(--t-space-4)')
+    expect(byProp.paddingBottom).toBe('var(--t-space-4)')
+    expect(byProp.paddingLeft).toBe('var(--t-space-4)')
+    expect(byProp.borderTopLeftRadius).toBe('var(--t-radius-4)')
+    expect(byProp.borderTopRightRadius).toBe('var(--t-radius-4)')
+    expect(byProp.borderBottomRightRadius).toBe('var(--t-radius-4)')
+    expect(byProp.borderBottomLeftRadius).toBe('var(--t-radius-4)')
+  })
+
   test(`prop "aria-required" is passed through`, () => {
     const { viewProps } = simplifiedGetSplitStyles(
       View,

--- a/code/core/font-size/src/getFontSize.ts
+++ b/code/core/font-size/src/getFontSize.ts
@@ -1,5 +1,5 @@
 import type { FontSizeTokens, FontTokens, Variable } from '@tamagui/core'
-import { getConfig, isVariable } from '@tamagui/core'
+import { getConfig, isVariable, resolveDefaultSizeToken } from '@tamagui/core'
 
 type GetFontSizeOpts = {
   relativeSize?: number
@@ -7,7 +7,7 @@ type GetFontSizeOpts = {
 }
 
 export const getFontSize = (
-  inSize: FontSizeTokens | null | undefined,
+  inSize: FontSizeTokens | true | null | undefined,
   opts?: GetFontSizeOpts
 ): number => {
   const res = getFontSizeVariable(inSize, opts)
@@ -18,7 +18,7 @@ export const getFontSize = (
 }
 
 export const getFontSizeVariable = (
-  inSize: FontSizeTokens | null | undefined,
+  inSize: FontSizeTokens | true | null | undefined,
   opts?: GetFontSizeOpts
 ): FontSizeTokens | Variable<string> | null | undefined => {
   const token = getFontSizeToken(inSize, opts)
@@ -31,7 +31,7 @@ export const getFontSizeVariable = (
 }
 
 export const getFontSizeToken = (
-  inSize: FontSizeTokens | null | undefined,
+  inSize: FontSizeTokens | true | null | undefined,
   opts?: GetFontSizeOpts
 ): FontSizeTokens | null => {
   if (typeof inSize === 'number') {
@@ -45,11 +45,9 @@ export const getFontSizeToken = (
     font?.size ||
     // fallback to size tokens
     conf.tokensParsed.size
-  const size =
-    (inSize === '$true' && !('$true' in fontSize) ? '$4' : inSize) ??
-    ('$true' in fontSize ? '$true' : '$4')
+  const size = resolveDefaultSizeToken(inSize ?? true, conf)
 
-  const sizeTokens = Object.keys(fontSize)
+  const sizeTokens = Object.keys(fontSize).filter((key) => key !== '$true')
 
   let foundIndex = sizeTokens.indexOf(size)
   if (foundIndex === -1) {

--- a/code/core/font-size/src/getFontSize.ts
+++ b/code/core/font-size/src/getFontSize.ts
@@ -27,7 +27,7 @@ export const getFontSizeVariable = (
   }
   const conf = getConfig()
   const font = conf.fontsParsed[opts?.font || conf.defaultFontToken]
-  return font?.size[token] as Variable<string>
+  return font?.size[token as string] as Variable<string>
 }
 
 export const getFontSizeToken = (
@@ -45,7 +45,7 @@ export const getFontSizeToken = (
     font?.size ||
     // fallback to size tokens
     conf.tokensParsed.size
-  const size = resolveDefaultSizeToken(inSize ?? true, conf)
+  const size = resolveDefaultSizeToken(inSize ?? true, conf) as string
 
   const sizeTokens = Object.keys(fontSize).filter((key) => key !== '$true')
 

--- a/code/core/font-size/types/getFontSize.d.ts
+++ b/code/core/font-size/types/getFontSize.d.ts
@@ -3,9 +3,9 @@ type GetFontSizeOpts = {
 	relativeSize?: number;
 	font?: FontTokens;
 };
-export declare const getFontSize: (inSize: FontSizeTokens | null | undefined, opts?: GetFontSizeOpts) => number;
-export declare const getFontSizeVariable: (inSize: FontSizeTokens | null | undefined, opts?: GetFontSizeOpts) => FontSizeTokens | Variable<string> | null | undefined;
-export declare const getFontSizeToken: (inSize: FontSizeTokens | null | undefined, opts?: GetFontSizeOpts) => FontSizeTokens | null;
+export declare const getFontSize: (inSize: FontSizeTokens | true | null | undefined, opts?: GetFontSizeOpts) => number;
+export declare const getFontSizeVariable: (inSize: FontSizeTokens | true | null | undefined, opts?: GetFontSizeOpts) => FontSizeTokens | Variable<string> | null | undefined;
+export declare const getFontSizeToken: (inSize: FontSizeTokens | true | null | undefined, opts?: GetFontSizeOpts) => FontSizeTokens | null;
 export {};
 
 //# sourceMappingURL=getFontSize.d.ts.map

--- a/code/core/get-button-sized/src/index.ts
+++ b/code/core/get-button-sized/src/index.ts
@@ -1,5 +1,9 @@
 import { getSpace } from '@tamagui/get-token'
-import type { SizeTokens, VariantSpreadExtras } from '@tamagui/web'
+import {
+  resolveDefaultSizeToken,
+  type SizeTokens,
+  type VariantSpreadExtras,
+} from '@tamagui/web'
 
 export const getButtonSized = (
   val: SizeTokens | number,
@@ -15,11 +19,12 @@ export const getButtonSized = (
       borderRadius: props.circular ? 100_000 : val * 0.2,
     }
   }
-  const xSize = getSpace(val)
-  const radiusToken = tokens.radius[val] ?? tokens.radius['$true']
+  const sizeToken = resolveDefaultSizeToken(val)
+  const xSize = getSpace(sizeToken)
+  const radiusToken = tokens.radius[sizeToken] ?? sizeToken
   return {
     paddingHorizontal: xSize,
-    height: val,
+    height: sizeToken,
     borderRadius: props.circular ? 100_000 : radiusToken,
   }
 }

--- a/code/core/get-button-sized/types/index.d.ts
+++ b/code/core/get-button-sized/types/index.d.ts
@@ -1,11 +1,11 @@
-import type { SizeTokens, VariantSpreadExtras } from '@tamagui/web';
+import { type SizeTokens, type VariantSpreadExtras } from '@tamagui/web';
 export declare const getButtonSized: (val: SizeTokens | number, { tokens, props }: VariantSpreadExtras<any>) => {
     paddingHorizontal: number;
     height: number | import("@tamagui/web").UnionableNumber;
     borderRadius: number;
 } | {
     paddingHorizontal: import("@tamagui/web").Variable<number>;
-    height: `$${string}.${string}` | `$${string}.${number}` | import("@tamagui/web").UnionableString;
+    height: string | import("@tamagui/web").UnionableString;
     borderRadius: any;
 } | undefined;
 //# sourceMappingURL=index.d.ts.map

--- a/code/core/get-font-sized/src/index.ts
+++ b/code/core/get-font-sized/src/index.ts
@@ -1,15 +1,14 @@
 import { isClient } from '@tamagui/constants'
 import type {
   FontSizeTokens,
-  GenericFont,
   TextProps,
   TextStyle,
   VariantSpreadFunction,
 } from '@tamagui/web'
-import { getTokens, styled, Text } from '@tamagui/web'
+import { resolveDefaultSizeToken, styled, Text } from '@tamagui/web'
 
 export const getFontSized: VariantSpreadFunction<TextProps, FontSizeTokens> = (
-  sizeTokenIn = '$true',
+  sizeTokenIn = true,
   { font, fontFamily, props }
 ) => {
   if (!font) {
@@ -18,7 +17,7 @@ export const getFontSized: VariantSpreadFunction<TextProps, FontSizeTokens> = (
     }
   }
 
-  const sizeToken = sizeTokenIn === '$true' ? getDefaultSizeToken(font) : sizeTokenIn
+  const sizeToken = resolveDefaultSizeToken(sizeTokenIn) as Exclude<FontSizeTokens, true>
 
   const style: TextStyle = {}
 
@@ -78,40 +77,6 @@ export const SizableText = styled(Text, {
   } as const,
 
   defaultVariants: {
-    size: '$true',
+    size: true,
   },
 })
-
-const cache = new WeakMap<any, FontSizeTokens>()
-
-function getDefaultSizeToken(font: GenericFont) {
-  if (typeof font === 'object' && cache.has(font)) {
-    return cache.get(font)!
-  }
-
-  // use either font.size if it has true set, or fallback to tokens.size mapping to the same
-  const tokens = getTokens()
-  const sizeTokens = '$true' in font.size ? font.size : tokens?.size
-  if (!sizeTokens) {
-    return Object.keys(font.size)[3]
-  }
-  const sizeDefault = sizeTokens['$true']
-  const sizeDefaultSpecific = sizeDefault
-    ? Object.keys(sizeTokens).find(
-        (x) => x !== '$true' && sizeTokens[x]['val'] === sizeDefault['val']
-      )
-    : null
-
-  if (!sizeDefault || !sizeDefaultSpecific) {
-    if (process.env.NODE_ENV === 'development') {
-      console.warn(`No default size is set in your tokens for the "true" key, fonts will be inconsistent.
-
-      Fix this by having consistent tokens across fonts and sizes and setting a true key for your size tokens, or
-      set true keys for all your font tokens: "size", "lineHeight", "fontStyle", etc.`)
-    }
-    return Object.keys(font.size)[3]
-  }
-
-  cache.set(font, sizeDefaultSpecific as FontSizeTokens)
-  return sizeDefaultSpecific
-}

--- a/code/core/get-token/src/index.ts
+++ b/code/core/get-token/src/index.ts
@@ -1,8 +1,8 @@
 import type { Variable, VariableValGeneric } from '@tamagui/web'
-import { getTokens, isVariable } from '@tamagui/web'
+import { getDefaultSizeToken, getTokens, isVariable } from '@tamagui/web'
 
 // technically number | undefined just for compat with the generic VariableVal
-type GetTokenBase = Variable | string | number | undefined | VariableValGeneric
+type GetTokenBase = Variable | string | number | boolean | undefined | VariableValGeneric
 
 type GetTokenOptions = {
   shift?: number
@@ -39,6 +39,12 @@ export const stepTokenUpOrDown = (
   options: GetTokenOptions = defaultOptions
 ): Variable<number> => {
   const tokens = getTokens({ prefixed: true })[type] as Record<string, Variable>
+  const currentResolved =
+    current === true || current === '$true'
+      ? getDefaultSizeToken()
+      : isVariable(current) && current.key === '$true'
+        ? tokens[getDefaultSizeToken()] || current
+        : current
 
   if (!(type in cacheVariables)) {
     cacheKeys[type] = []
@@ -47,6 +53,7 @@ export const stepTokenUpOrDown = (
     cacheWholeVariables[type] = []
 
     const sorted = Object.keys(tokens)
+      .filter((key) => key !== '$true')
       .map((k) => tokens[k])
       .sort((a, b) => a.val - b.val)
 
@@ -62,7 +69,7 @@ export const stepTokenUpOrDown = (
     }
   }
 
-  const isString = typeof current === 'string'
+  const isString = typeof currentResolved === 'string'
   const cache = options.excludeHalfSteps
     ? isString
       ? cacheWholeKeys
@@ -75,19 +82,13 @@ export const stepTokenUpOrDown = (
 
   const min = options.bounds?.[0] ?? 0
   const max = options.bounds?.[1] ?? tokensOrdered.length - 1
-  const currentIndex = tokensOrdered.indexOf(current as any)
-
-  let shift = options.shift || 0
-  if (shift) {
-    if (current === '$true' || (isVariable(current) && current.name === 'true')) {
-      shift += shift > 0 ? 1 : -1
-    }
-  }
+  const currentIndex = tokensOrdered.indexOf(currentResolved as any)
+  const shift = options.shift || 0
 
   const index = Math.min(max, Math.max(min, currentIndex + shift))
   const found = tokensOrdered[index]
 
-  const result = (typeof found === 'string' ? tokens[found] : found) || tokens['$true']
+  const result = typeof found === 'string' ? tokens[found] : found
 
   // console.log('found', { current, shift, index, found, result })
 

--- a/code/core/get-token/types/index.d.ts
+++ b/code/core/get-token/types/index.d.ts
@@ -1,5 +1,5 @@
 import type { Variable, VariableValGeneric } from '@tamagui/web';
-type GetTokenBase = Variable | string | number | undefined | VariableValGeneric;
+type GetTokenBase = Variable | string | number | boolean | undefined | VariableValGeneric;
 type GetTokenOptions = {
     shift?: number;
     bounds?: [number] | [number, number];

--- a/code/core/web/src/config.ts
+++ b/code/core/web/src/config.ts
@@ -12,6 +12,8 @@ import type {
 
 export type StyleCompat = 'legacy' | 'react-native' | 'web'
 
+export const DEFAULT_SIZE_TOKEN = '$4'
+
 let conf: TamaguiInternalConfig | null
 let setConfigCalledByThisInstance = false
 
@@ -74,6 +76,21 @@ export const getSetting = <Key extends keyof GenericTamaguiSettings>(
     // @ts-expect-error
     config[key]
   )
+}
+
+type DefaultSizeConfig = Pick<TamaguiInternalConfig, 'settings'>
+
+export const getDefaultSizeToken = (
+  config: DefaultSizeConfig | null = getConfigFromGlobalOrLocal()
+): string => {
+  return config?.settings.defaultSize || DEFAULT_SIZE_TOKEN
+}
+
+export const resolveDefaultSizeToken = <Val>(
+  val: Val,
+  config?: DefaultSizeConfig | null
+): Exclude<Val, true> | string => {
+  return val === true || val === '$true' ? getDefaultSizeToken(config) : (val as any)
 }
 
 export function getStyleCompat(): StyleCompat {

--- a/code/core/web/src/createTamagui.ts
+++ b/code/core/web/src/createTamagui.ts
@@ -1,4 +1,4 @@
-import { getConfigMaybe, setConfig, setTokens } from './config'
+import { DEFAULT_SIZE_TOKEN, getConfigMaybe, setConfig, setTokens } from './config'
 import type { DeepVariableObject } from './createVariables'
 import { createVariables } from './createVariables'
 import { defaultAnimationDriver } from './helpers/defaultAnimationDriver'
@@ -51,6 +51,37 @@ function shouldTokenCategoryHaveUnits(category: string): boolean {
 function initializeTamaguiConfig(config: TamaguiInternalConfig) {
   setConfig(config)
   configureMedia(config)
+}
+
+function normalizeDefaultSize(defaultSize: string | undefined) {
+  if (!defaultSize) return DEFAULT_SIZE_TOKEN
+  return defaultSize[0] === '$' ? defaultSize : `$${defaultSize}`
+}
+
+function validateDefaultSize(config: TamaguiInternalConfig) {
+  const defaultSize = config.settings.defaultSize || DEFAULT_SIZE_TOKEN
+  const missing: string[] = []
+
+  if (!config.tokensParsed.size?.[defaultSize]) {
+    missing.push(`tokens.size.${defaultSize}`)
+  }
+  if (!config.tokensParsed.space?.[defaultSize]) {
+    missing.push(`tokens.space.${defaultSize}`)
+  }
+
+  for (const fontName in config.fontsParsed) {
+    if (!config.fontsParsed[fontName]?.size?.[defaultSize]) {
+      missing.push(`fonts.${fontName}.size.${defaultSize}`)
+    }
+  }
+
+  if (missing.length) {
+    throw new Error(
+      `settings.defaultSize must point to an existing size token; missing ${missing.join(
+        ', '
+      )}`
+    )
+  }
 }
 
 export function createTamagui<Conf extends CreateTamaguiProps>(
@@ -124,6 +155,7 @@ export function createTamagui<Conf extends CreateTamaguiProps>(
   }
 
   const specificTokens = {}
+  const defaultSize = normalizeDefaultSize(configIn.settings?.defaultSize)
 
   const themeConfig = (() => {
     // populate specificTokens (needed for runtime)
@@ -147,7 +179,7 @@ export function createTamagui<Conf extends CreateTamaguiProps>(
     // CSS generation (tree-shaken when TAMAGUI_DID_OUTPUT_CSS is set)
     const declarations = createTokenCSS(tokens as any, shouldTokenCategoryHaveUnits)
     const fontDeclarations = createFontCSS(fontsParsed, registerFontVariables)
-    const cssRuleSets = buildCSSRuleSets(declarations, fontDeclarations)
+    const cssRuleSets = buildCSSRuleSets(declarations, fontDeclarations, defaultSize)
 
     const themesIn = configIn.themes as ThemesLikeObject
     const dedupedThemes = foundThemes ?? getThemesDeduped(themesIn, tokens.color)
@@ -228,6 +260,7 @@ export function createTamagui<Conf extends CreateTamaguiProps>(
     settings: {
       webContainerType: 'inline-size',
       ...configIn.settings,
+      defaultSize,
     },
     tokens: tokens as any,
     // vite made this into a function if it wasn't set
@@ -249,6 +282,10 @@ export function createTamagui<Conf extends CreateTamaguiProps>(
     defaultFontToken,
     // const tokens = [...getToken(tokens.size[0])]
     // .spacer-sm + ._dsp_contents._dsp-sm-hidden { margin-left: -var(--${}) }
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    validateDefaultSize(config)
   }
 
   initializeTamaguiConfig(config)

--- a/code/core/web/src/helpers/createDesignSystem.ts
+++ b/code/core/web/src/helpers/createDesignSystem.ts
@@ -1,5 +1,6 @@
 import { isWeb } from '@tamagui/constants'
 import type { CreateTamaguiProps, Variable } from '../types'
+import { DEFAULT_SIZE_TOKEN } from '../config'
 import { getVariableVariable, isVariable } from '../createVariable'
 import { autoVariables, registerCSSVariable, variableToCSS } from './registerCSSVariable'
 import { getThemeCSSRules } from './getThemeCSSRules'
@@ -13,7 +14,7 @@ type ThemeConfig = {
 // helper to get font property CSS declarations
 function getFontPropertyDeclarations(
   fontParsed: any,
-  tokenKey: string = '$true'
+  tokenKey: string = DEFAULT_SIZE_TOKEN
 ): string[] {
   const props: string[] = ['font-family: var(--f-family)']
 
@@ -118,7 +119,7 @@ export function buildCSSRuleSets(
     string,
     { name: string; declarations: string[]; language?: string; fontParsed: any }
   >,
-  defaultFontToken: string = '$true'
+  defaultSizeToken: string = DEFAULT_SIZE_TOKEN
 ): string[] {
   if (!process.env.TAMAGUI_DID_OUTPUT_CSS) {
     const cssRuleSets: string[] = []
@@ -154,7 +155,7 @@ export function buildCSSRuleSets(
       if (firstFont?.fontParsed) {
         const fontProps = getFontPropertyDeclarations(
           firstFont.fontParsed,
-          defaultFontToken
+          defaultSizeToken
         )
         const sharedSelectors = [...fontSelectors, '.is_View'].join(', ')
         cssRuleSets.push(`${sharedSelectors} {${fontProps.join('; ')}}`)

--- a/code/core/web/src/helpers/getTokenForKey.ts
+++ b/code/core/web/src/helpers/getTokenForKey.ts
@@ -1,5 +1,5 @@
 import { tokenCategories } from '@tamagui/helpers'
-import { getConfig } from '../config'
+import { getConfig, resolveDefaultSizeToken } from '../config'
 import { isVariable } from '../createVariable'
 import type {
   GetStyleState,
@@ -76,6 +76,8 @@ export const getTokenForKey = (
   const { theme, conf = getConfig(), context, fontFamily, staticConfig } = styleState
 
   const themeValue = theme ? theme[value] || theme[value.slice(1)] : undefined
+  const defaultSizeValue =
+    value === '$true' ? resolveDefaultSizeToken(value, conf) : value
 
   const tokensParsed = conf.tokensParsed
   let valOrVar: any
@@ -83,7 +85,8 @@ export const getTokenForKey = (
 
   const customTokenAccept = staticConfig?.accept?.[key]
   if (customTokenAccept) {
-    const val = themeValue ?? tokensParsed[customTokenAccept]?.[value]
+    const tokenValue = customTokenAccept === 'color' ? value : defaultSizeValue
+    const val = themeValue ?? tokensParsed[customTokenAccept]?.[tokenValue]
     if (val != null) {
       resolveAs = 'value' // always resolve custom tokens as values
       valOrVar = val
@@ -107,7 +110,7 @@ export const getTokenForKey = (
     }
     hasSet = true
   } else {
-    if (value in conf.specificTokens) {
+    if (value !== '$true' && value in conf.specificTokens) {
       hasSet = true
       valOrVar = conf.specificTokens[value]
     } else {
@@ -131,7 +134,7 @@ export const getTokenForKey = (
               ? getFontsForLanguage(conf.fontsParsed, context.language)
               : conf.fontsParsed
             const font = fontsParsed[fam] || fontsParsed[conf.defaultFontToken]
-            valOrVar = font?.[fontShorthand[key] || key]?.[value] || value
+            valOrVar = font?.[fontShorthand[key] || key]?.[defaultSizeValue] || value
             hasSet = true
           }
           break
@@ -139,7 +142,8 @@ export const getTokenForKey = (
       }
       const cat = tokenCategoryByKey[key]
       if (cat !== undefined) {
-        const res = tokensParsed[cat]?.[value]
+        const tokenValue = cat === 'color' ? value : defaultSizeValue
+        const res = tokensParsed[cat]?.[tokenValue]
 
         if (res != null) {
           valOrVar = res
@@ -175,7 +179,7 @@ export const getTokenForKey = (
     }
 
     if (!hasSet) {
-      const spaceVar = tokensParsed.space[value]
+      const spaceVar = tokensParsed.space[defaultSizeValue]
       if (spaceVar != null) {
         valOrVar = spaceVar
         hasSet = true

--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -1,4 +1,5 @@
 import { isAndroid } from '@tamagui/constants'
+import { resolveDefaultSizeToken } from '../config'
 import { getVariableValue, isVariable } from '../createVariable'
 import type {
   GetStyleState,
@@ -173,7 +174,11 @@ const resolveVariants: StyleResolver = (
   const { variants } = staticConfig
   if (!variants) return
 
-  let variantValue = getVariantDefinition(variants[key], value, conf, styleState)
+  const variant = variants[key]
+  if (value === true || value === '$true') {
+    value = resolveVariantSizeValue(variant, value, conf)
+  }
+  let variantValue = getVariantDefinition(variant, value, conf, styleState)
 
   if (process.env.NODE_ENV === 'development' && debug === 'verbose') {
     console.groupCollapsed(`♦️♦️♦️ resolve variant ${key}`)
@@ -431,6 +436,19 @@ const tokenCats = ['size', 'color', 'radius', 'space', 'zIndex'].map((name) => (
   name,
   spreadName: `...${name}`,
 }))
+
+function resolveVariantSizeValue(variant: any, value: any, conf: TamaguiInternalConfig) {
+  if (!variant || typeof variant === 'function') {
+    return value
+  }
+  if (Object.prototype.hasOwnProperty.call(variant, value)) {
+    return value
+  }
+  if ('...size' in variant || '...space' in variant || '...fontSize' in variant) {
+    return resolveDefaultSizeToken(value, conf)
+  }
+  return value
+}
 
 // goes through specificity finding best matching variant function
 function getVariantDefinition(

--- a/code/core/web/src/index.ts
+++ b/code/core/web/src/index.ts
@@ -57,6 +57,7 @@ export { createRefComponent, type RefProp } from '@tamagui/compose-refs'
 
 export {
   getConfig,
+  getDefaultSizeToken,
   getSetting,
   getStyleCompat,
   getThemes,
@@ -64,9 +65,11 @@ export {
   getTokens,
   getTokenValue,
   loadAnimationDriver,
+  resolveDefaultSizeToken,
   setConfig,
   setupDev,
   updateConfig,
+  DEFAULT_SIZE_TOKEN,
   type StyleCompat,
 } from './config'
 

--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -1229,6 +1229,13 @@ export interface GenericTamaguiSettings {
   defaultFont?: string
 
   /**
+   * Define the token used when a component size is set to true.
+   *
+   * @default '$4'
+   */
+  defaultSize?: string
+
+  /**
    * Web-only: define CSS text-selection styles
    */
   selectionStyles?: (theme: Record<string, string>) => null | {
@@ -1748,6 +1755,7 @@ export type SizeTokens =
   | SpecificTokensSpecial
   | ThemeValueFallbackSize
   | GetTokenString<keyof Tokens['size']>
+  | true
 
 export type SpaceTokens =
   | SpecificTokensSpecial
@@ -1825,6 +1833,7 @@ export type FontSizeTokens =
   | GetTokenString<GetTokenFontKeysFor<'size'>>
   | number
   | RemString
+  | true
 export type FontLineHeightTokens =
   | `$${GetTokenFontKeysFor<'lineHeight'>}`
   | number

--- a/code/core/web/types/config.d.ts
+++ b/code/core/web/types/config.d.ts
@@ -1,6 +1,10 @@
 import type { AnimationDriver, GenericTamaguiSettings, TamaguiInternalConfig, Token, Tokens, TokensMerged } from './types';
 export type StyleCompat = 'legacy' | 'react-native' | 'web';
+export declare const DEFAULT_SIZE_TOKEN = "$4";
 export declare const getSetting: <Key extends keyof GenericTamaguiSettings>(key: Key) => GenericTamaguiSettings[Key];
+type DefaultSizeConfig = Pick<TamaguiInternalConfig, 'settings'>;
+export declare const getDefaultSizeToken: (config?: DefaultSizeConfig | null) => string;
+export declare const resolveDefaultSizeToken: <Val>(val: Val, config?: DefaultSizeConfig | null) => Exclude<Val, true> | string;
 export declare function getStyleCompat(): StyleCompat;
 export declare const setConfig: (next: TamaguiInternalConfig) => void;
 export declare const setConfigFont: (name: string, font: any, fontParsed: any) => void;

--- a/code/core/web/types/helpers/createDesignSystem.d.ts
+++ b/code/core/web/types/helpers/createDesignSystem.d.ts
@@ -26,7 +26,7 @@ export declare function buildCSSRuleSets(declarations: string[], fontDeclaration
     declarations: string[];
     language?: string;
     fontParsed: any;
-}>, defaultFontToken?: string): string[];
+}>, defaultSizeToken?: string): string[];
 /**
  * Generates theme CSS rules
  */

--- a/code/core/web/types/index.d.ts
+++ b/code/core/web/types/index.d.ts
@@ -50,7 +50,7 @@ export type * from './interfaces/TamaguiComponentEvents';
 export type * from './types';
 export * from './interfaces/GetRef';
 export { createRefComponent, type RefProp } from '@tamagui/compose-refs';
-export { getConfig, getSetting, getStyleCompat, getThemes, getToken, getTokens, getTokenValue, loadAnimationDriver, setConfig, setupDev, updateConfig, type StyleCompat, } from './config';
+export { getConfig, getDefaultSizeToken, getSetting, getStyleCompat, getThemes, getToken, getTokens, getTokenValue, loadAnimationDriver, resolveDefaultSizeToken, setConfig, setupDev, updateConfig, DEFAULT_SIZE_TOKEN, type StyleCompat, } from './config';
 export { setNonce } from './helpers/insertStyleRule';
 export * from './constants/constants';
 export * from './hooks/useIsTouchDevice';

--- a/code/core/web/types/types.d.ts
+++ b/code/core/web/types/types.d.ts
@@ -705,6 +705,12 @@ export interface GenericTamaguiSettings {
      */
     defaultFont?: string;
     /**
+     * Define the token used when a component size is set to true.
+     *
+     * @default '$4'
+     */
+    defaultSize?: string;
+    /**
      * Web-only: define CSS text-selection styles
      */
     selectionStyles?: (theme: Record<string, string>) => null | {
@@ -1002,7 +1008,7 @@ export type SpecificTokens<Record = Tokens, RK extends keyof Record = keyof Reco
 export type SpecificTokensSpecial = TamaguiSettings extends {
     autocompleteSpecificTokens: infer Val;
 } ? Val extends 'except-special' | undefined ? never : SpecificTokens : SpecificTokens;
-export type SizeTokens = SpecificTokensSpecial | ThemeValueFallbackSize | GetTokenString<keyof Tokens['size']>;
+export type SizeTokens = SpecificTokensSpecial | ThemeValueFallbackSize | GetTokenString<keyof Tokens['size']> | true;
 export type SpaceTokens = SpecificTokensSpecial | GetTokenString<keyof Tokens['space']> | ThemeValueFallbackSpace;
 type ColorTokenBase = SpecificTokensSpecial | GetTokenString<keyof Tokens['color']> | GetTokenString<keyof ThemeParsed>;
 type TokenWithOpacity = `$${string}/${number}`;
@@ -1020,7 +1026,7 @@ export type Font = ParseFont<Fonts>;
 export type GetTokenFontKeysFor<A extends 'size' | 'weight' | 'letterSpacing' | 'family' | 'lineHeight' | 'transform' | 'style' | 'color'> = keyof TamaguiConfig['fonts']['body'][A];
 export type FontTokens = GetTokenString<keyof TamaguiConfig['fonts']>;
 export type FontFamilyTokens = GetTokenString<GetTokenFontKeysFor<'family'>>;
-export type FontSizeTokens = GetTokenString<GetTokenFontKeysFor<'size'>> | number | RemString;
+export type FontSizeTokens = GetTokenString<GetTokenFontKeysFor<'size'>> | number | RemString | true;
 export type FontLineHeightTokens = `$${GetTokenFontKeysFor<'lineHeight'>}` | number | RemString;
 export type FontWeightValues = `${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9}00` | 'bold' | 'normal';
 export type FontWeightTokens = `$${GetTokenFontKeysFor<'weight'>}` | FontWeightValues;

--- a/code/demos/package.json
+++ b/code/demos/package.json
@@ -27,7 +27,7 @@
       "default": "./dist/esm/index.mjs"
     },
     "./demo/*": {
-      "types": "./types/*.d.ts",
+      "types": "./src/*.tsx",
       "react-native": "./dist/esm/*.native.js",
       "browser": "./dist/esm/*.mjs",
       "module": "./dist/esm/*.mjs",

--- a/code/demos/package.json
+++ b/code/demos/package.json
@@ -27,7 +27,7 @@
       "default": "./dist/esm/index.mjs"
     },
     "./demo/*": {
-      "types": "./src/*.tsx",
+      "types": "./types/*.d.ts",
       "react-native": "./dist/esm/*.native.js",
       "browser": "./dist/esm/*.mjs",
       "module": "./dist/esm/*.mjs",

--- a/code/kitchen-sink/src/features/home/TestBuildAButton.tsx
+++ b/code/kitchen-sink/src/features/home/TestBuildAButton.tsx
@@ -5,6 +5,7 @@ import {
   View,
   Text,
   createStyledContext,
+  resolveDefaultSizeToken,
   styled,
   useTheme,
   withStaticProperties,
@@ -48,11 +49,13 @@ export const ButtonFrame = styled(View, {
   variants: {
     size: {
       '...size': (name, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(name) as Exclude<SizeTokens, true>
+
         return {
-          height: tokens.size[name],
-          borderRadius: tokens.radius[name],
-          gap: tokens.space[name].val * 0.2,
-          paddingHorizontal: getSpace(name, {
+          height: tokens.size[sizeToken],
+          borderRadius: tokens.radius[sizeToken],
+          gap: tokens.space[sizeToken].val * 0.2,
+          paddingHorizontal: getSpace(sizeToken, {
             shift: -1,
           }),
         }
@@ -75,9 +78,13 @@ export const ButtonText = styled(Text, {
 
   variants: {
     size: {
-      '...fontSize': (name, { font }) => ({
-        fontSize: font?.size[name],
-      }),
+      '...fontSize': (name, { font }) => {
+        const sizeToken = resolveDefaultSizeToken(name) as Exclude<typeof name, true>
+
+        return {
+          fontSize: font?.size[sizeToken],
+        }
+      },
     },
   } as const,
 })

--- a/code/kitchen-sink/src/usecases/StyledButtonAnimationAuto.tsx
+++ b/code/kitchen-sink/src/usecases/StyledButtonAnimationAuto.tsx
@@ -5,6 +5,7 @@ import {
   View,
   Text,
   createStyledContext,
+  resolveDefaultSizeToken,
   styled,
   useTheme,
   withStaticProperties,
@@ -31,10 +32,12 @@ export const ButtonFrame = styled(View, {
   variants: {
     size: {
       '...size': (name, { tokens }) => {
-        return {
-          height: tokens.size[name],
+        const sizeToken = resolveDefaultSizeToken(name) as Exclude<SizeTokens, true>
 
-          borderRadius: tokens.radius[name],
+        return {
+          height: tokens.size[sizeToken],
+
+          borderRadius: tokens.radius[sizeToken],
 
           // note the getSpace and getSize helpers will let you shift down/up token sizes
 
@@ -42,9 +45,9 @@ export const ButtonFrame = styled(View, {
 
           // this is a stylistic choice, and depends on your design system values
 
-          gap: tokens.space[name].val * 0.2,
+          gap: tokens.space[sizeToken].val * 0.2,
 
-          paddingHorizontal: getSpace(name, {
+          paddingHorizontal: getSpace(sizeToken, {
             shift: -1,
           }),
         }
@@ -64,9 +67,13 @@ export const ButtonText = styled(Text, {
   userSelect: 'none',
   variants: {
     size: {
-      '...fontSize': (name, { font }) => ({
-        fontSize: font?.size[name],
-      }),
+      '...fontSize': (name, { font }) => {
+        const sizeToken = resolveDefaultSizeToken(name) as Exclude<typeof name, true>
+
+        return {
+          fontSize: font?.size[sizeToken],
+        }
+      },
     },
   } as const,
 })

--- a/code/kitchen-sink/tests/BuildAButton.test.tsx
+++ b/code/kitchen-sink/tests/BuildAButton.test.tsx
@@ -5,6 +5,7 @@ import {
   View,
   Text,
   createStyledContext,
+  resolveDefaultSizeToken,
   styled,
   useTheme,
   withStaticProperties,
@@ -33,14 +34,16 @@ export const ButtonFrame = styled(View, {
   variants: {
     size: {
       '...size': (name, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(name) as Exclude<SizeTokens, true>
+
         return {
-          height: tokens.size[name],
-          borderRadius: tokens.radius[name],
+          height: tokens.size[sizeToken],
+          borderRadius: tokens.radius[sizeToken],
           // note the getSpace and getSize helpers will let you shift down/up token sizes
           // whereas with gap we just multiply by 0.2
           // this is a stylistic choice, and depends on your design system values
-          gap: tokens.space[name].val * 0.2,
-          paddingHorizontal: getSpace(name, {
+          gap: tokens.space[sizeToken].val * 0.2,
+          paddingHorizontal: getSpace(sizeToken, {
             shift: -1,
           }),
         }
@@ -61,9 +64,13 @@ export const ButtonText = styled(Text, {
 
   variants: {
     size: {
-      '...fontSize': (name, { font }) => ({
-        fontSize: font?.size[name],
-      }),
+      '...fontSize': (name, { font }) => {
+        const sizeToken = resolveDefaultSizeToken(name) as Exclude<typeof name, true>
+
+        return {
+          fontSize: font?.size[sizeToken],
+        }
+      },
     },
   } as const,
 })

--- a/code/ui/card/src/Card.tsx
+++ b/code/ui/card/src/Card.tsx
@@ -1,6 +1,11 @@
 import { YStack } from '@tamagui/stacks'
 import type { GetProps, SizeTokens } from '@tamagui/web'
-import { createStyledContext, styled, withStaticProperties } from '@tamagui/web'
+import {
+  createStyledContext,
+  resolveDefaultSizeToken,
+  styled,
+  withStaticProperties,
+} from '@tamagui/web'
 
 const CardContext = createStyledContext({
   size: '$true' as SizeTokens,
@@ -21,8 +26,10 @@ export const CardFrame = styled(YStack, {
 
     size: {
       '...size': (val, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(val)
+
         return {
-          borderRadius: tokens.radius[val] ?? val,
+          borderRadius: tokens.radius[sizeToken] ?? sizeToken,
         }
       },
     },
@@ -48,8 +55,10 @@ export const CardHeader = styled(YStack, {
 
     size: {
       '...size': (val, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(val)
+
         return {
-          padding: tokens.space[val] ?? val,
+          padding: tokens.space[sizeToken] ?? sizeToken,
         }
       },
     },

--- a/code/ui/group/src/Group.tsx
+++ b/code/ui/group/src/Group.tsx
@@ -1,5 +1,10 @@
 import type { GetProps } from '@tamagui/core'
-import { createStyledHOC, mergeSlotStyleProps, styled } from '@tamagui/core'
+import {
+  createStyledHOC,
+  mergeSlotStyleProps,
+  resolveDefaultSizeToken,
+  styled,
+} from '@tamagui/core'
 import type { Scope } from '@tamagui/create-context'
 import { createContextScope } from '@tamagui/create-context'
 import { withStaticProperties } from '@tamagui/helpers'
@@ -29,7 +34,8 @@ export const GroupFrame = styled(YStack, {
     },
 
     size: (val, { tokens }) => {
-      const borderRadius = tokens.radius[val] ?? val ?? tokens.radius['$true']
+      const sizeToken = resolveDefaultSizeToken(val ?? true)
+      const borderRadius = tokens.radius[sizeToken] ?? sizeToken
       return {
         borderRadius,
       }

--- a/code/ui/label/types/Label.d.ts
+++ b/code/ui/label/types/Label.d.ts
@@ -1,17 +1,17 @@
-import type { FontSizeTokens, GetProps } from '@tamagui/web';
+import type { GetProps } from '@tamagui/web';
 export declare const LabelFrame: import("@tamagui/web").TamaguiComponent<import("@tamagui/web").TamaDefer, import("@tamagui/web").TamaguiTextElement, import("@tamagui/web").TextNonStyleProps, import("@tamagui/web").TextStylePropsBase, {
     unstyled?: boolean | undefined;
-    size?: import("@tamagui/web").SizeTokens | FontSizeTokens | undefined;
+    size?: number | true | `$${string}` | `$${string}.${string}` | `$${string}.${number}` | `${number}rem` | import("@tamagui/web").UnionableNumber | import("@tamagui/web").UnionableString | `$${number}` | undefined;
 }, import("@tamagui/web").StaticConfigPublic>;
 export type LabelProps = GetProps<typeof LabelFrame> & {
     htmlFor?: string;
 };
 export declare const Label: import("@tamagui/web").TamaguiComponent<import("@tamagui/web").GetFinalProps<import("@tamagui/web").TextNonStyleProps, import("@tamagui/web").TextStylePropsBase, {
     unstyled?: boolean | undefined;
-    size?: import("@tamagui/web").SizeTokens | FontSizeTokens | undefined;
+    size?: number | true | `$${string}` | `$${string}.${string}` | `$${string}.${number}` | `${number}rem` | import("@tamagui/web").UnionableNumber | import("@tamagui/web").UnionableString | `$${number}` | undefined;
 }>, import("@tamagui/web").TamaguiTextElement, import("@tamagui/web").TextNonStyleProps & void, import("@tamagui/web").TextStylePropsBase, {
     unstyled?: boolean | undefined;
-    size?: import("@tamagui/web").SizeTokens | FontSizeTokens | undefined;
+    size?: number | true | `$${string}` | `$${string}.${string}` | `$${string}.${number}` | `${number}rem` | import("@tamagui/web").UnionableNumber | import("@tamagui/web").UnionableString | `$${number}` | undefined;
 }, import("@tamagui/web").StaticConfigPublic>;
 export declare const useLabelContext: (element?: HTMLElement | null) => string | undefined;
 //# sourceMappingURL=Label.d.ts.map

--- a/code/ui/list-item/src/ListItem.tsx
+++ b/code/ui/list-item/src/ListItem.tsx
@@ -6,7 +6,13 @@ import { getIcon, useCurrentColor } from '@tamagui/helpers-tamagui'
 import { YStack } from '@tamagui/stacks'
 import { SizableText, wrapChildrenInText } from '@tamagui/text'
 import type { ColorTokens, FontSizeTokens, GetProps, SizeTokens } from '@tamagui/web'
-import { createStyledHOC, createStyledContext, styled, View } from '@tamagui/web'
+import {
+  createStyledContext,
+  createStyledHOC,
+  resolveDefaultSizeToken,
+  styled,
+  View,
+} from '@tamagui/web'
 import type { FunctionComponent, JSX, ReactNode } from 'react'
 
 type IconProp = JSX.Element | FunctionComponent<{ color?: any; size?: any }> | null
@@ -92,10 +98,11 @@ const ListItemFrame = styled(View, {
 
     size: {
       '...size': (val: SizeTokens, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(val)
         return {
-          minHeight: tokens.size[val],
-          paddingHorizontal: tokens.space[val],
-          paddingVertical: getSpace(tokens.space[val], {
+          minHeight: tokens.size[sizeToken],
+          paddingHorizontal: tokens.space[sizeToken],
+          paddingVertical: getSpace(tokens.space[sizeToken], {
             shift: -4,
           }),
         }

--- a/code/ui/list-item/types/ListItem.d.ts
+++ b/code/ui/list-item/types/ListItem.d.ts
@@ -80,7 +80,7 @@ export declare const ListItem: FunctionComponent<Omit<import("@tamagui/web").Get
         unstyled?: boolean | undefined;
     }, import("@tamagui/web").StaticConfigPublic>;
     Subtitle: import("@tamagui/web").TamaguiComponent<import("@tamagui/web").TamaDefer, import("@tamagui/web").TamaguiTextElement, import("@tamagui/web").TextNonStyleProps, import("@tamagui/web").TextStylePropsBase, {
-        size?: SizeTokens | FontSizeTokens | undefined;
+        size?: number | true | `$${string}` | `$${string}.${string}` | `$${string}.${number}` | `${number}rem` | import("@tamagui/web").UnionableNumber | import("@tamagui/web").UnionableString | `$${number}` | undefined;
         unstyled?: boolean | undefined;
     }, import("@tamagui/web").StaticConfigPublic>;
     Icon: (props: {

--- a/code/ui/popper/src/Popper.tsx
+++ b/code/ui/popper/src/Popper.tsx
@@ -11,6 +11,7 @@ import {
   createStyledContext,
   getVariableValue,
   registerLayoutNode,
+  resolveDefaultSizeToken,
   styled,
 } from '@tamagui/core'
 import type { PopupTriggerMap } from '@tamagui/floating'
@@ -652,9 +653,11 @@ export const PopperContentFrame = styled(YStack, {
 
     size: {
       '...size': (val, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(val)
+
         return {
-          padding: tokens.space[val],
-          borderRadius: tokens.radius[val],
+          padding: tokens.space[sizeToken],
+          borderRadius: tokens.radius[sizeToken],
         }
       },
     },

--- a/code/ui/select/src/Select.tsx
+++ b/code/ui/select/src/Select.tsx
@@ -7,6 +7,7 @@ import {
   createRefComponent,
   createStyledContext,
   getVariableValue,
+  resolveDefaultSizeToken,
   styled,
   useEvent,
   useGet,
@@ -257,14 +258,15 @@ const NativeSelectFrame = styled(YStack, {
     size: {
       '...size': (val, extras) => {
         const { tokens } = extras
-        const paddingHorizontal = getVariableValue(tokens.space[val])
+        const sizeToken = resolveDefaultSizeToken(val)
+        const paddingHorizontal = getVariableValue(tokens.space[sizeToken])
 
         return {
-          borderRadius: tokens.radius[val] ?? val,
-          minHeight: tokens.size[val],
+          borderRadius: tokens.radius[sizeToken] ?? sizeToken,
+          minHeight: tokens.size[sizeToken],
           paddingRight: paddingHorizontal + 20,
           paddingLeft: paddingHorizontal,
-          paddingVertical: getSpace(val, {
+          paddingVertical: getSpace(sizeToken, {
             shift: -3,
           }),
         }
@@ -370,9 +372,11 @@ const SelectLabelFrame = styled(SizableText, {
 
     size: {
       '...size': (val: SizeTokens, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(val)
+
         return {
-          paddingHorizontal: tokens.space[val],
-          paddingVertical: getSpace(tokens.space[val], {
+          paddingHorizontal: tokens.space[sizeToken],
+          paddingVertical: getSpace(tokens.space[sizeToken], {
             shift: -4,
           }),
         }

--- a/code/ui/select/src/SelectViewport.tsx
+++ b/code/ui/select/src/SelectViewport.tsx
@@ -2,7 +2,7 @@ import { AdaptPortalContents, useAdaptIsActive } from '@tamagui/adapt'
 import { AnimatePresence } from '@tamagui/animate-presence'
 import { useComposedRefs } from '@tamagui/compose-refs'
 import { isWeb, useIsomorphicLayoutEffect } from '@tamagui/constants'
-import { createStyledHOC, styled } from '@tamagui/core'
+import { createStyledHOC, resolveDefaultSizeToken, styled } from '@tamagui/core'
 import { needsPortalRepropagation } from '@tamagui/portal'
 import { ThemeableStack, YStack } from '@tamagui/stacks'
 import { startTransition } from '@tamagui/start-transition'
@@ -38,8 +38,10 @@ export const SelectViewportFrame = styled(ThemeableStack, {
 
     size: {
       '...size': (val, { tokens }) => {
+        const sizeToken = resolveDefaultSizeToken(val)
+
         return {
-          borderRadius: tokens.radius[val] ?? val,
+          borderRadius: tokens.radius[sizeToken] ?? sizeToken,
         }
       },
     },

--- a/code/ui/select/types/Select.d.ts
+++ b/code/ui/select/types/Select.d.ts
@@ -26,7 +26,7 @@ export declare const SelectGroupFrame: import("@tamagui/core").TamaguiComponent<
 }, import("@tamagui/core").StaticConfigPublic>;
 type SelectGroupProps = SelectScopedProps<GetProps<typeof SelectGroupFrame>>;
 declare const SelectLabelFrame: import("@tamagui/core").TamaguiComponent<import("@tamagui/core").TamaDefer, import("@tamagui/core").TamaguiTextElement, import("@tamagui/core").TextNonStyleProps, import("@tamagui/core").TextStylePropsBase, {
-    size?: SizeTokens | FontSizeTokens | undefined;
+    size?: number | true | `$${string}` | `$${string}.${string}` | `$${string}.${number}` | `${number}rem` | import("@tamagui/core").UnionableNumber | import("@tamagui/core").UnionableString | `$${number}` | undefined;
     unstyled?: boolean | undefined;
 }, import("@tamagui/core").StaticConfigPublic>;
 export type SelectLabelProps = SelectScopedProps<GetProps<typeof SelectLabelFrame>>;
@@ -74,14 +74,14 @@ export declare const Select: (<Value extends string = string>(props: SelectScope
         unstyled?: boolean | undefined;
     }, import("@tamagui/core").StaticConfigPublic>;
     Label: import("@tamagui/core").TamaguiComponent<Omit<import("@tamagui/core").GetFinalProps<import("@tamagui/core").TextNonStyleProps, import("@tamagui/core").TextStylePropsBase, {
-        size?: SizeTokens | FontSizeTokens | undefined;
+        size?: number | true | `$${string}` | `$${string}.${string}` | `$${string}.${number}` | `${number}rem` | import("@tamagui/core").UnionableNumber | import("@tamagui/core").UnionableString | `$${number}` | undefined;
         unstyled?: boolean | undefined;
     }>, "scope"> & {
         scope?: any;
     }, import("@tamagui/core").TamaguiTextElement, import("@tamagui/core").TextNonStyleProps & {
         scope?: any;
     }, import("@tamagui/core").TextStylePropsBase, {
-        size?: SizeTokens | FontSizeTokens | undefined;
+        size?: number | true | `$${string}` | `$${string}.${string}` | `$${string}.${number}` | `${number}rem` | import("@tamagui/core").UnionableNumber | import("@tamagui/core").UnionableString | `$${number}` | undefined;
         unstyled?: boolean | undefined;
     }, import("@tamagui/core").StaticConfigPublic>;
     ScrollDownButton: import("@tamagui/compose-refs").RefComponent<TamaguiElement, import("./types").SelectScrollButtonProps>;

--- a/code/ui/shapes/src/getShapeSize.tsx
+++ b/code/ui/shapes/src/getShapeSize.tsx
@@ -1,12 +1,14 @@
 import type { SizableStackProps } from '@tamagui/stacks'
 import type { SizeVariantSpreadFunction } from '@tamagui/web'
+import { resolveDefaultSizeToken } from '@tamagui/web'
 
 export const getShapeSize: SizeVariantSpreadFunction<SizableStackProps> = (
   size,
   { tokens }
 ) => {
-  const width = tokens.size[size] ?? size
-  const height = tokens.size[size] ?? size
+  const sizeToken = resolveDefaultSizeToken(size)
+  const width = tokens.size[sizeToken] ?? sizeToken
+  const height = tokens.size[sizeToken] ?? sizeToken
   return {
     width,
     height,

--- a/code/ui/slider/src/Slider.tsx
+++ b/code/ui/slider/src/Slider.tsx
@@ -13,6 +13,7 @@ import {
   createRefComponent,
   getTokens,
   getVariableValue,
+  resolveDefaultSizeToken,
   styled,
   useConfiguration,
   useCreateShallowSetState,
@@ -418,7 +419,7 @@ const getThumbSize = (val?: SizeTokens | number) => {
   const size =
     typeof val === 'number'
       ? val
-      : getSize(tokens.size[val as any] as any, {
+      : getSize(tokens.size[resolveDefaultSizeToken(val ?? true)] as any, {
           shift: -1,
         })
   return {

--- a/code/ui/spacer/src/Spacer.tsx
+++ b/code/ui/spacer/src/Spacer.tsx
@@ -1,8 +1,11 @@
-import { styled, View, type SizeTokens } from '@tamagui/web'
+import { resolveDefaultSizeToken, styled, View, type SizeTokens } from '@tamagui/web'
 
 const getSpacerSize = (size: SizeTokens | number | boolean, { tokens }) => {
-  size = size === true ? '$true' : size
-  const sizePx = tokens.space[size as any] ?? size
+  const sizeToken =
+    typeof size === 'boolean' || typeof size === 'string'
+      ? resolveDefaultSizeToken(size)
+      : size
+  const sizePx = tokens.space[sizeToken as any] ?? sizeToken
   return {
     width: sizePx,
     height: sizePx,

--- a/code/ui/stacks/src/getElevation.tsx
+++ b/code/ui/stacks/src/getElevation.tsx
@@ -4,12 +4,18 @@ import type {
   ViewProps,
   VariantSpreadExtras,
 } from '@tamagui/core'
-import { getVariableValue, isAndroid, isVariable } from '@tamagui/core'
+import {
+  getVariableValue,
+  isAndroid,
+  isVariable,
+  resolveDefaultSizeToken,
+} from '@tamagui/core'
 
 export const getElevation: SizeVariantSpreadFunction<ViewProps> = (size, extras) => {
   if (!size) return
   const { tokens } = extras
-  const token = tokens.size[size]
+  const sizeToken = resolveDefaultSizeToken(size)
+  const token = tokens.size[sizeToken]
   const sizeNum = (isVariable(token) ? +token.val : size) as number
   return getSizedElevation(sizeNum, extras)
 }
@@ -19,15 +25,16 @@ export const getSizedElevation = (
   { theme, tokens }: VariantSpreadExtras<any>
 ) => {
   let num = 0
-  if (val === true) {
-    const val = getVariableValue(tokens.size['true'])
-    if (typeof val === 'number') {
-      num = val
+  if (typeof val === 'number') {
+    num = val
+  } else if (val) {
+    const token = tokens.size[resolveDefaultSizeToken(val)]
+    const tokenValue = getVariableValue(token)
+    if (typeof tokenValue === 'number') {
+      num = tokenValue
     } else {
       num = 10
     }
-  } else {
-    num = +val
   }
   if (num === 0) {
     return

--- a/code/ui/stacks/src/variants.tsx
+++ b/code/ui/stacks/src/variants.tsx
@@ -1,3 +1,4 @@
+import { resolveDefaultSizeToken } from '@tamagui/core'
 import { getElevation } from './getElevation'
 
 export const elevate = {
@@ -24,7 +25,10 @@ export const circular = {
     if (!('size' in props)) {
       return circularStyle
     }
-    const size = typeof props.size === 'number' ? props.size : tokens.size[props.size]
+    const size =
+      typeof props.size === 'number'
+        ? props.size
+        : tokens.size[resolveDefaultSizeToken(props.size)]
     return {
       ...circularStyle,
       width: size,

--- a/code/ui/toggle-group/src/Toggle.tsx
+++ b/code/ui/toggle-group/src/Toggle.tsx
@@ -2,7 +2,7 @@ import { createRefComponent } from '@tamagui/compose-refs'
 import { composeEventHandlers } from '@tamagui/helpers'
 import { useControllableState } from '@tamagui/use-controllable-state'
 import type { GetProps, TamaguiElement, ViewStyle } from '@tamagui/web'
-import { styled, View } from '@tamagui/web'
+import { resolveDefaultSizeToken, styled, View } from '@tamagui/web'
 import * as React from 'react'
 import { context } from './context'
 
@@ -50,9 +50,10 @@ export const ToggleFrame = styled(
       size: {
         '...size': (val, { tokens }) => {
           if (!val) return
+          const sizeToken = resolveDefaultSizeToken(val)
           return {
-            width: tokens.size[val],
-            height: tokens.size[val],
+            width: tokens.size[sizeToken],
+            height: tokens.size[sizeToken],
           }
         },
         ':number': (val) => ({


### PR DESCRIPTION
## Summary

Item 5 T1 core slice for D2.5 default size resolution.

- Adds `settings.defaultSize`, defaulting to `$4`, with dev validation in `createTamagui`.
- Centralizes boolean `true` and existing `$true` size-marker resolution through the configured default size token.
- Updates core style/token/font helpers and direct size helper callsites to resolve through the central path.
- Removes helper-level `$true` special cases like the `get-token` shift hack and `get-font-sized` twin-value search while preserving shipped `$true` token keys for T1.

## T1 sequencing guard

T1 intentionally keeps `$true` token keys in configs and generated tokens so shipped configs keep working while central resolution lands. The `createTokens` hard-error for true-token keys is deferred to T2, paired with removing config/font `true` keys. T3 remains the literal sweep.

No changes to `@tamagui/to-tailwind`, the `render` prop, `next.md`, or planning/source-of-truth docs.

## Validation

Commands run locally on rebased head `1944b9b6a7`:

```sh
bunx turbo run build --filter=tamagui... --concurrency=4 --ui=stream
cd code/core/core-test && bun run test:web
cd code/core/web && bun run test:web
cd code/compiler/static-tests && bun run test:babel:web
cd code/core/core-test && bun run test:native
cd code/core/core-test && bun run test:ios
```

All passed.

## Proof matrix

Baseline SHA: `ac0920b8600d9de30838eebdbbee337058771d2c`  
PR SHA: `1944b9b6a7edb919de45adc5eec28804bae92674`

1. Screen sizes and media flip: owned by v3 CI from #4088 on this PR head SHA. Local browser capture intentionally skipped per CTO direction.
2. Web and native: web conformance is owned by v3 CI from #4088. Native device-conformance is N/A-with-reason: `no native-interaction surface touched`. Native proof is core vitest:
   - `/tmp/tamagui-item5-t1-proof/baseline/core-test-native.log`
   - `/tmp/tamagui-item5-t1-proof/pr/core-test-native.log`
   - `/tmp/tamagui-item5-t1-proof/baseline/core-test-ios.log`
   - `/tmp/tamagui-item5-t1-proof/pr/core-test-ios.log`
3. Render-count: v3 CI from #4088 owns render-count on the PR head SHA. Local client proof shows equal counts: frame renders `5 -> 5`, content renders `5 -> 5`, profiler commits `6 -> 6`:
   - `/tmp/tamagui-item5-t1-proof/baseline/client-summary.json`
   - `/tmp/tamagui-item5-t1-proof/pr/client-summary.json`
4. Remount and instance identity: local client proof shows `noSpuriousRemounts: true` for baseline and PR:
   - `/tmp/tamagui-item5-t1-proof/baseline/client-summary.json`
   - `/tmp/tamagui-item5-t1-proof/pr/client-summary.json`
5. Animation, gesture, and handoff: N/A-with-reason: render-tier token-resolution change only. It touches no animation driver, gesture, overlay, portal, Adapt, or handoff surface.
6. Perf and bundle: local runtime/perf/bundle artifacts attached; v3 CI from #4088 owns final bundle-delta gate on the PR head SHA. Local selected-dist bundle delta is `+5340` bytes, `+1158` gzip:
   - `/tmp/tamagui-item5-t1-proof/baseline/perf-summary.json`
   - `/tmp/tamagui-item5-t1-proof/pr/perf-summary.json`
   - `/tmp/tamagui-item5-t1-proof/baseline/bundle-summary.json`
   - `/tmp/tamagui-item5-t1-proof/pr/bundle-summary.json`
7. SSR: v3 CI from #4088 owns SSR render and hydration-diff on the PR head SHA. Local SSR proof shows Select value `Banana` present in server HTML and hydration messages `0 -> 0`:
   - `/tmp/tamagui-item5-t1-proof/baseline/server.html`
   - `/tmp/tamagui-item5-t1-proof/pr/server.html`
   - `/tmp/tamagui-item5-t1-proof/baseline/ssr-summary-short.json`
   - `/tmp/tamagui-item5-t1-proof/pr/ssr-summary-short.json`
   - `/tmp/tamagui-item5-t1-proof/baseline/client-summary.json`
   - `/tmp/tamagui-item5-t1-proof/pr/client-summary.json`

Runtime default-size proof:

- `/tmp/tamagui-item5-t1-proof/baseline/runtime-summary.json`
- `/tmp/tamagui-item5-t1-proof/pr/runtime-summary.json`

Key runtime delta: `settings.defaultSize` becomes `$4`; `getSize(true)`, `getSize('$true')`, `getSpace('$true')`, `getFontSizeToken(true)`, `getFontSizeToken('$true')`, and `getButtonSized(true)` all resolve through `$4` on the PR.
