### PR TITLE
test: update true token export snapshot

### DIFF
--- a/code/tests/next-webpack/tests/__snapshots__/exports.unit.test.ts.snap
+++ b/code/tests/next-webpack/tests/__snapshots__/exports.unit.test.ts.snap
@@ -228,7 +228,7 @@ export function SelectDemoItem(props: SelectProps & {
           </Select.Group>
           {/* Native gets an extra icon */}
           {props.native && <__ReactNativeView pointerEvents={"none"} style={_sheet["4"]}>
-              <ChevronDown size={getFontSize((props.size as FontSizeTokens) ?? true)} />
+              <ChevronDown size={getFontSize(props.size as FontSizeTokens ?? true)} />
             </__ReactNativeView>}
         </Select.Viewport>
 
@@ -560,7 +560,7 @@ export function SelectDemoItem(props: SelectProps & {
           </Select.Group>
           {/* Native gets an extra icon */}
           {props.native && <div className={_cn5}>
-              <ChevronDown size={getFontSize((props.size as FontSizeTokens) ?? true)} />
+              <ChevronDown size={getFontSize(props.size as FontSizeTokens ?? true)} />
             </div>}
         </Select.Viewport>
 
@@ -928,7 +928,7 @@ export function SelectDemoItem(props: SelectProps & {
           </Select.Group>
           {/* Native gets an extra icon */}
           {props.native && <__ReactNativeView pointerEvents={"none"} style={_sheet["4"]}>
-              <ChevronDown size={getFontSize((props.size as FontSizeTokens) ?? true)} />
+              <ChevronDown size={getFontSize(props.size as FontSizeTokens ?? true)} />
             </__ReactNativeView>}
         </Select.Viewport>
 
@@ -1193,7 +1193,7 @@ export function SelectDemoItem(props: SelectProps & {
           </Select.Group>
           {/* Native gets an extra icon */}
           {props.native && <div className={_cn5}>
-              <ChevronDown size={getFontSize((props.size as FontSizeTokens) ?? true)} />
+              <ChevronDown size={getFontSize(props.size as FontSizeTokens ?? true)} />
             </div>}
         </Select.Viewport>
 


### PR DESCRIPTION
## Summary

- Updates the next-webpack export snapshots to match the optimized output from #4097.
- This is snapshot-only fallout from #4097 being merged before the unit job surfaced the generated-output diff.

## Validation

- `cd code/tests/next-webpack && PATH="$PWD/node_modules/.bin:$PATH" bun run test:web tests/exports.unit.test.ts` with a local symlink to `code/core/cli/dist/index.cjs` for the missing workspace bin
- `rg -n '\$true' code library --glob '!**/dist/**' --glob '!**/node_modules/**'` -> no matches
