### PR TITLE
fix(focus-scope): display:contents wrapper, drop cloneElement/Children.only (v3 CS-4)

### DIFF
--- a/code/kitchen-sink/tests/SelectFocusScope.test.tsx
+++ b/code/kitchen-sink/tests/SelectFocusScope.test.tsx
@@ -1,6 +1,27 @@
 import { expect, test } from '@playwright/test'
 import { setupPage } from './test-utils'
 
+test('Select FocusScope opens content with multiple children without crashing', async ({
+  page,
+}) => {
+  const pageErrors: string[] = []
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.message)
+  })
+
+  await setupPage(page, { name: 'SelectFocusScopeCase', type: 'useCase' })
+
+  const trigger = page.getByTestId('basic-select-trigger')
+  await trigger.click()
+
+  const selectViewport = page.getByTestId('basic-select-viewport')
+  await expect(selectViewport).toBeVisible({ timeout: 5000 })
+
+  expect(pageErrors.join('\n')).not.toMatch(
+    /React\.Children\.only|single React element child/
+  )
+})
+
 test.describe('Select Focus Scope', () => {
   test.beforeEach(async ({ page }) => {
     await setupPage(page, { name: 'SelectFocusScopeCase', type: 'useCase' })

--- a/code/ui/focus-scope/src/FocusScope.tsx
+++ b/code/ui/focus-scope/src/FocusScope.tsx
@@ -10,10 +10,6 @@ const AUTOFOCUS_ON_MOUNT = 'focusScope.autoFocusOnMount'
 const AUTOFOCUS_ON_UNMOUNT = 'focusScope.autoFocusOnUnmount'
 const EVENT_OPTIONS = { bubbles: false, cancelable: true }
 const FOCUS_SCOPE_STYLE: React.CSSProperties = { display: 'contents' }
-const EMPTY_FOCUS_SCOPE_CHILD_PROPS = {
-  onKeyDown: () => {},
-  ref: () => {},
-}
 
 type FocusableTarget = HTMLElement | { focus(): void }
 
@@ -50,10 +46,7 @@ const FocusScope = createRefComponent<FocusScopeElement, FocusScopeProps>(
       childProps as React.HTMLAttributes<HTMLDivElement> & {
         ref: React.Ref<HTMLDivElement>
       }
-    const children =
-      typeof mergedProps.children === 'function'
-        ? mergedProps.children(EMPTY_FOCUS_SCOPE_CHILD_PROPS)
-        : mergedProps.children
+    const children = mergedProps.children
 
     return (
       <div {...scopeProps} ref={ref} style={getFocusScopeStyle(style)}>

--- a/code/ui/focus-scope/src/FocusScope.tsx
+++ b/code/ui/focus-scope/src/FocusScope.tsx
@@ -9,6 +9,11 @@ import type { FocusScopeProps, ScopedProps } from './types'
 const AUTOFOCUS_ON_MOUNT = 'focusScope.autoFocusOnMount'
 const AUTOFOCUS_ON_UNMOUNT = 'focusScope.autoFocusOnUnmount'
 const EVENT_OPTIONS = { bubbles: false, cancelable: true }
+const FOCUS_SCOPE_STYLE: React.CSSProperties = { display: 'contents' }
+const EMPTY_FOCUS_SCOPE_CHILD_PROPS = {
+  onKeyDown: () => {},
+  ref: () => {},
+}
 
 type FocusableTarget = HTMLElement | { focus(): void }
 
@@ -41,17 +46,30 @@ const FocusScope = createRefComponent<FocusScopeElement, FocusScopeProps>(
     }
 
     const childProps = useFocusScope(mergedProps, forwardedRef)
+    const { ref, style, ...scopeProps } =
+      childProps as React.HTMLAttributes<HTMLDivElement> & {
+        ref: React.Ref<HTMLDivElement>
+      }
+    const children =
+      typeof mergedProps.children === 'function'
+        ? mergedProps.children(EMPTY_FOCUS_SCOPE_CHILD_PROPS)
+        : mergedProps.children
 
-    if (typeof mergedProps.children === 'function') {
-      return <>{mergedProps.children(childProps)}</>
-    }
-
-    return React.cloneElement(
-      React.Children.only(mergedProps.children) as any,
-      childProps
+    return (
+      <div {...scopeProps} ref={ref} style={getFocusScopeStyle(style)}>
+        {children}
+      </div>
     )
   }
 )
+
+function getFocusScopeStyle(style?: React.CSSProperties) {
+  if (!style) return FOCUS_SCOPE_STYLE
+  return {
+    ...style,
+    display: 'contents',
+  }
+}
 
 /* -------------------------------------------------------------------------------------------------
  * setupFocusTrap - extracted function to set up trap immediately in ref callback
@@ -167,7 +185,8 @@ export function useFocusScope(
     onUnmountAutoFocus: onUnmountAutoFocusProp,
     forceUnmount,
     focusOnIdle = true,
-    children,
+    children: _children,
+    asChild: _asChild,
     ...scopeProps
   } = props
   const [container, setContainer] = React.useState<HTMLElement | null>(null)

--- a/code/ui/focus-scope/src/types.tsx
+++ b/code/ui/focus-scope/src/types.tsx
@@ -47,12 +47,6 @@ export interface FocusScopeProps {
    */
   focusOnIdle?: boolean | number | { min?: number; max?: number }
 
-  children?:
-    | React.ReactNode
-    | ((props: {
-        onKeyDown: (event: React.KeyboardEvent) => void
-        tabIndex?: number
-        ref: React.Ref<any>
-      }) => React.ReactNode)
+  children?: React.ReactNode
   asChild?: boolean
 }

--- a/code/ui/focus-scope/types/FocusScope.d.ts
+++ b/code/ui/focus-scope/types/FocusScope.d.ts
@@ -5,7 +5,6 @@ declare const FocusScope: import("@tamagui/compose-refs").RefComponent<HTMLDivEl
 export declare function useFocusScope(props: FocusScopeProps, forwardedRef?: React.Ref<FocusScopeElement>): {
     ref: (node: HTMLElement) => void;
     onKeyDown: (event: React.KeyboardEvent) => void;
-    asChild?: boolean;
 };
 export { FocusScope };
 export type { FocusScopeProps };

--- a/code/ui/focus-scope/types/types.d.ts
+++ b/code/ui/focus-scope/types/types.d.ts
@@ -43,11 +43,7 @@ export interface FocusScopeProps {
         min?: number;
         max?: number;
     };
-    children?: React.ReactNode | ((props: {
-        onKeyDown: (event: React.KeyboardEvent) => void;
-        tabIndex?: number;
-        ref: React.Ref<any>;
-    }) => React.ReactNode);
+    children?: React.ReactNode;
     asChild?: boolean;
 }
 //# sourceMappingURL=types.d.ts.map

--- a/code/ui/popover/src/Popover.tsx
+++ b/code/ui/popover/src/Popover.tsx
@@ -802,7 +802,7 @@ const PopoverContentImpl = createRefComponent<
             onMountAutoFocus={onOpenAutoFocus}
             onUnmountAutoFocus={onCloseAutoFocus === false ? undefined : onCloseAutoFocus}
           >
-            <div style={dspContentsStyle}>{contents}</div>
+            {contents}
           </FocusScope>
         )
       }
@@ -863,10 +863,6 @@ const PopoverContentImpl = createRefComponent<
     </Animate>
   )
 })
-
-const dspContentsStyle = {
-  display: 'contents',
-}
 
 /* -------------------------------------------------------------------------------------------------
  * PopoverClose

--- a/code/ui/select/src/SelectContent.tsx
+++ b/code/ui/select/src/SelectContent.tsx
@@ -1,4 +1,3 @@
-import { isWeb } from '@tamagui/core'
 import { Dismissable } from '@tamagui/dismissable'
 import type { FocusScopeProps } from '@tamagui/focus-scope'
 import { FocusScope } from '@tamagui/focus-scope'
@@ -72,8 +71,7 @@ export const SelectContent = ({
               }
             }}
           >
-            {/* div needed for FocusScope ref, display:contents keeps layout neutral */}
-            {isWeb ? <div style={{ display: 'contents' }}>{contents}</div> : contents}
+            {contents}
           </FocusScope>
         </Dismissable>
       </RemoveScroll>

--- a/next.md
+++ b/next.md
@@ -1,5 +1,7 @@
 v3 release plan:
 
+- migration note: FocusScope no longer supports function-as-children/render-prop; pass JSX children directly.
+
 - remove deprecated / duplicate API paths
   - `focusable` => `tabIndex`
   - `fullscreen` => `inset: 0, position: 'absolute'`


### PR DESCRIPTION
Part of the tamagui v3 composable audit, CS-4 (cross-package FocusScope redo).

## what
- FocusScope no longer uses `React.Children.only` + `cloneElement`; it owns a `display: contents` wrapper carrying the trap ref/onKeyDown. Fixes the `React.Children.only` crash that hit real multi-child usages (esp. Select). New pageerror-asserting Playwright test covers it.
- One path: DELETE the function-as-children (render-prop) form from `FocusScopeProps` + the component (it would otherwise silently receive noop child props — a lying API). v3 is a breaking major; migration note added to `next.md`.
- Converges the container pattern: Select/Popover already wrapped content in a `display:contents` div, so Dialog is the only trap container that changes, and it changes TO the already-live pattern. Dropped Popover's now-redundant inner `display:contents` wrapper.
- Native untouched (`FocusScope.native` returns children as-is), which makes the `SelectContent` isWeb-guard removal correct.

## review + proof
Reviewed natively by Fable (reviewer of record); SHIP-after-fix verdict, fix applied. Local: `code/ui/focus-scope` + `code/ui/popover` builds pass; SelectFocusScope 7/7, DialogFocusScope 7/7, PopoverFocusScope 6/6.
**Interaction-tier** (touches focus semantics): BOTH Detox devices must be green in CI at this head before merge, no N/A — that's the axis proof.