### PR TITLE
fix(core): resolve boolean size-shorthand tokens in variant styles (v3 base integration fix)

### DIFF
--- a/code/core/web/src/helpers/propMapper.ts
+++ b/code/core/web/src/helpers/propMapper.ts
@@ -387,6 +387,19 @@ const resolveTokensAndVariants: StyleResolver<object> = (
       continue
     }
 
+    // boolean token shorthand (borderRadius: true etc) inside variant styles —
+    // mirrors the direct-prop gate in map(); without this the raw `true` reaches
+    // drivers (rn driver throws constructing Animated.Value(true))
+    if (val === true && subKey in defaultSizeTokenKeys) {
+      res[subKey] = getTokenForKey(
+        subKey,
+        resolveDefaultSizeToken(val, conf),
+        styleProps,
+        styleState
+      )
+      continue
+    }
+
     if (typeof val === 'string') {
       const fVal =
         val[0] === '$'


### PR DESCRIPTION
Fixes the v3-beta integration-test breakage (the base itself was red — proven by empty-diff probe #4103 failing 30 integration tests with zero changes). Unblocks the entire component-refactor wave.

## root cause (runtime-proven end to end)
An item-5 `$true`-token-removal miss. The boolean-shorthand gate (`value === true` -> `resolveDefaultSizeToken` -> `getTokenForKey`) was added ONLY to propMapper's direct-prop `map()` path. Styles returned from VARIANTS go through `resolveTokensAndVariants`, which handled variables/strings/objects but let booleans fall through RAW.

`DialogContentFrame`'s `unstyled.false { borderRadius: true, padding: true }` therefore expanded raw `true` per-corner (`borderTopLeftRadius` etc), which reached the react-native animation driver (the `[default]` integration project runs `animationDriver=native`), where `new Animated.Value(true)` THROWS and kills the entire React tree on every dialog page. The wedged pages (DialogNested, DialogOpenControlled's 50s mount-timeout, DialogScoped) then burn the shard budget, which is the whole alphabetical poisoning cascade (DOMNodeAPIs, RenderProp, StyleValidation, Menu, Popover... everything after "Dialog"). css/motion/reanimated projects never construct AnimatedValues from these keys, which is why only `[default]` was red and why it never reproduced locally.

## fix
The mirror-image boolean gate in `resolveTokensAndVariants`, before the string branch (13 lines).

## proof
Reproduced the 50s mount-wedge on the bare base; captured the crash (`AnimatedValue: Attempting to set value to undefined`, in `useAnimations` at DialogContent); probed the driver (`valIn=true` for all four corner keys) and the propMapper gate (never fired = bypass confirmed). Post-fix on the rebuilt package: the 3 previously-failing Dialog spec files are 7/7 green (verify-fails-first: same harness produced 6 failures pre-fix), and cascade-victims StyleValidation + Menu are 28/28 green. `DialogOpenControlled` is itself the regression test (it failed for exactly this).

RCA + fix by Fable (reviewer of record). Follow-up (non-blocking): a focused unit test on `resolveTokensAndVariants` boolean handling in core-test.