### PR TITLE
fix(core): keep animated driver component when render prop is a string

### DIFF
--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -696,7 +696,11 @@ export function createComponent<
 
     if (process.env.NODE_ENV === 'development' && time) time`theme`
 
-    elementType = element || elementType
+    // don't replace the animated driver component (set above) with the base element,
+    // the render string is forwarded to it via viewProps.render instead
+    if (!isAnimatedCustomComponent) {
+      elementType = element || elementType
+    }
     const isStringElement = typeof elementType === 'string'
 
     const mediaState = useMedia(componentContext, debugProp)
@@ -1612,9 +1616,10 @@ export function createComponent<
       }
 
       if (!content) {
-        // web-only, handle render === string passing to custom animated component
-        if (isRenderPropString) {
-          viewProps.render === renderProp
+        // web-only, forward render string to custom animated driver components
+        // (they render the tag themselves, see acceptRenderProp in drivers)
+        if (isRenderPropString && elementType['acceptRenderProp']) {
+          viewProps.render = renderProp
         }
 
         content = React.createElement(elementType, viewProps, content || children)

--- a/code/kitchen-sink/tests/SwitchStyled.test.tsx
+++ b/code/kitchen-sink/tests/SwitchStyled.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+// regression test: the styled Switch (SwitchFrame uses render="button") crashed
+// when animated ("Failed to set an indexed property [0] on 'CSSStyleDeclaration'")
+// because createComponent replaced the animation driver's custom component with
+// the raw render tag string, passing a react-native style array to a DOM element
+
+let pageErrors: Error[]
+
+test.beforeEach(async ({ page }) => {
+  pageErrors = []
+  page.on('pageerror', (error) => pageErrors.push(error))
+  await setupPage(page, { name: 'Switch', type: 'demo' })
+})
+
+test('styled Switch demo renders and toggles without errors', async ({ page }) => {
+  const switches = page.locator('[role="switch"]')
+  await expect(switches.first()).toBeVisible()
+  expect(await switches.count()).toBe(6)
+
+  const first = switches.first()
+  await expect(first).toHaveAttribute('aria-checked', 'false')
+  await first.click()
+  await expect(first).toHaveAttribute('aria-checked', 'true')
+
+  expect(pageErrors).toHaveLength(0)
+})


### PR DESCRIPTION
## Root cause

The styled Switch (`SwitchFrame` uses `render: 'button'`) crashed on web when animated with `TypeError: Failed to set an indexed property [0] on 'CSSStyleDeclaration'`. In `createComponent`, the tag→render migration changed `elementType = Component || elementType` to `elementType = element || elementType`, where `element` now includes the render string, so it clobbered the animation driver's custom component (set earlier when `needsCustomComponent`) with the raw `'button'` tag. React DOM then received the driver's react-native style array as the `style` prop on a plain DOM element and iterated its indices. Additionally, the intended render-string forwarding was a typo, `viewProps.render === renderProp` (a comparison, not an assignment), so drivers that accept the render prop never received it.

This restores the v2 `tag`/`acceptTagProp` behavior: keep the driver's custom component as the element type, and forward the render string via `viewProps.render` gated on the driver component's `acceptRenderProp` (set by the reanimated/motion/moti drivers).

## Validation

- `?demo=Switch` renders and toggles across css, motion, reanimated (renders `button[role=switch]`) and native (renders `div[role=switch]`, matching v2 since RNW Animated.View never accepted the tag prop) drivers
- `?demo=SwitchUnstyled`, `?demo=SwitchHeadless`, `?demo=Button`, `?demo=Checkbox` unaffected
- New regression test `code/kitchen-sink/tests/SwitchStyled.test.tsx` verified fail-before/pass-after the fix
- `RenderProp`, `ToggleGroup`, `ButtonUnstyled`, `StyledCheckboxTheme` and `AnimationBehavior`/`AnimatedByProp` (reanimated) suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)