### PR TITLE
fix(slider): visible track and active fill after backgroundActive token removal

### DIFF
--- a/code/kitchen-sink/tests/SliderStyled.test.tsx
+++ b/code/kitchen-sink/tests/SliderStyled.test.tsx
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+// regression test: the slider track and active fill became invisible after
+// $backgroundActive was removed from themes (the track/fill inherited the
+// page $background so nothing rendered on a plain background)
+
+let pageErrors: Error[]
+
+test.beforeEach(async ({ page }) => {
+  pageErrors = []
+  page.on('pageerror', (error) => pageErrors.push(error))
+  await setupPage(page, { name: 'Slider', type: 'demo' })
+})
+
+test('slider track and active fill render with visible backgrounds', async ({ page }) => {
+  await expect(page.locator('.is_SliderActive').first()).toBeVisible()
+
+  const colors = await page.evaluate(() => {
+    const active = document.querySelector('.is_SliderActive') as HTMLElement
+    const track = active.parentElement as HTMLElement
+    const getBg = (el: HTMLElement) => getComputedStyle(el).backgroundColor
+    return { track: getBg(track), active: getBg(active) }
+  })
+
+  const transparent = new Set(['rgba(0, 0, 0, 0)', 'transparent'])
+  expect(transparent.has(colors.track)).toBe(false)
+  expect(transparent.has(colors.active)).toBe(false)
+  // the fill must stand out from the rail
+  expect(colors.active).not.toBe(colors.track)
+
+  expect(pageErrors).toHaveLength(0)
+})

--- a/code/ui/slider/src/Slider.tsx
+++ b/code/ui/slider/src/Slider.tsx
@@ -309,7 +309,7 @@ export const SliderTrackFrame = styled(SliderFrame, {
       false: {
         height: '100%',
         width: '100%',
-        backgroundColor: '$background',
+        backgroundColor: '$backgroundPress',
         position: 'relative',
         borderRadius: 100_000,
         overflow: 'hidden',
@@ -351,7 +351,7 @@ export const SliderActiveFrame = styled(SliderFrame, {
   variants: {
     unstyled: {
       false: {
-        backgroundColor: '$background',
+        backgroundColor: '$color',
         borderRadius: 100_000,
       },
     },


### PR DESCRIPTION
The `SliderTrack => Slider` rename (92d826a932) changed SliderActive's background from $backgroundActive to $background, and $backgroundActive no longer exists in themes. On any plain $background surface both the rail and the active fill blend into the page, so sliders render as floating thumbs with no track (web and native). Track now uses $backgroundPress and the active fill uses $color, with a kitchen-sink regression test asserting both are visible and distinct.

Verified visually on kitchen-sink web + iOS simulator; same fix landed on v3-beta as 3c3c3593ec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)