### PR TITLE
feat(icons): default to font-size sizing, drop usePropsAndStyle from themed

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -816,6 +816,7 @@
       "version": "2.4.2",
       "dependencies": {
         "@tamagui/core": "workspace:*",
+        "@tamagui/font-size": "workspace:*",
         "@tamagui/sizable-context": "workspace:*",
       },
       "devDependencies": {

--- a/code/core/helpers-icon/package.json
+++ b/code/core/helpers-icon/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@tamagui/core": "workspace:*",
+    "@tamagui/font-size": "workspace:*",
     "@tamagui/sizable-context": "workspace:*"
   },
   "devDependencies": {

--- a/code/core/helpers-icon/src/themed.tsx
+++ b/code/core/helpers-icon/src/themed.tsx
@@ -1,10 +1,12 @@
 import {
   getTokenValue,
   getVariable,
-  Text,
-  usePropsAndStyle,
+  isWeb,
+  useTheme,
+  type FontSizeTokens,
   type ResolveVariableAs,
 } from '@tamagui/core'
+import { getFontSize } from '@tamagui/font-size'
 import { SizableContext } from '@tamagui/sizable-context'
 
 import type { FC } from 'react'
@@ -20,14 +22,6 @@ type Options = {
   resolveValues?: ResolveVariableAs
 }
 
-// check if props contain media queries ($sm, $md, etc) or other complex tamagui features
-function needsFullStyleResolution(props: IconProps): boolean {
-  for (const key in props) {
-    if (key[0] === '$') return true
-  }
-  return false
-}
-
 export function themed(Component: FC<IconProps>, optsIn: Options = {}) {
   const opts: Options = {
     defaultThemeColor: process.env.DEFAULT_ICON_THEME_COLOR || '$color',
@@ -39,19 +33,22 @@ export function themed(Component: FC<IconProps>, optsIn: Options = {}) {
 
   const IconWrapper = (propsIn: IconProps) => {
     const styledContext = SizableContext.useStyledContext()
-    const needsMedia = needsFullStyleResolution(propsIn)
+    const theme = useTheme()
 
-    const [props, style, theme] = usePropsAndStyle(propsIn, {
-      ...opts,
-      forComponent: Text,
-      resolveValues: opts.resolveValues,
-      noMedia: !needsMedia,
-    })
+    const {
+      size: sizeProp,
+      strokeWidth: strokeWidthProp,
+      color: colorProp,
+      fill: fillProp,
+      stroke: strokeProp,
+      disableTheme,
+      style,
+      testID,
+      ...rest
+    } = propsIn as any
 
-    const defaultColor = opts.defaultThemeColor
-
-    // resolve theme tokens for fill/stroke (so users can do fill="$color10" etc).
-    // tamagui-isms: leave non-token strings (e.g. "red", "#abc", "none") untouched.
+    // resolve theme tokens for color/fill/stroke (so users can do fill="$color10" etc).
+    // leave non-token strings (e.g. "red", "#abc", "none") untouched.
     const resolveSvgColor = (val: unknown) => {
       if (typeof val !== 'string') return val
       if (val[0] !== '$') return val
@@ -60,36 +57,46 @@ export function themed(Component: FC<IconProps>, optsIn: Options = {}) {
       return getVariable(val, 'color' as any)
     }
 
-    const fillResolved = resolveSvgColor((propsIn as any).fill)
-    const strokeResolved = resolveSvgColor((propsIn as any).stroke)
+    const fillResolved = resolveSvgColor(fillProp)
+    const strokeResolved = resolveSvgColor(strokeProp)
+    const colorResolved = resolveSvgColor(colorProp)
 
     const colorIn =
       strokeResolved ||
-      style.color ||
-      (defaultColor ? theme[defaultColor as string] : undefined) ||
-      (!props.disableTheme ? theme.color : null) ||
+      colorResolved ||
+      (opts.defaultThemeColor ? (theme as any)[opts.defaultThemeColor] : undefined) ||
+      (!disableTheme ? theme.color : null) ||
       opts.fallbackColor
 
     const color = getVariable(colorIn)
 
+    // v3: icon sizes resolve via the current font's size scale (font.size[token]),
+    // so icons visually align with text at each size. raw numbers stay literal.
+    // context size (SizableContext, e.g. from Button/ListItem) resolves the same way.
     const size =
-      typeof props.size === 'string'
-        ? getTokenValue(props.size as any, 'size')
-        : (props.size ?? styledContext.size)
+      typeof sizeProp === 'number'
+        ? sizeProp
+        : typeof sizeProp === 'string'
+          ? getFontSize(sizeProp as FontSizeTokens)
+          : styledContext.size != null
+            ? getFontSize(styledContext.size as FontSizeTokens)
+            : undefined
 
     const strokeWidth =
-      typeof props.strokeWidth === 'string'
-        ? getTokenValue(props.strokeWidth as any, 'size')
-        : (props.strokeWidth ?? `${opts.defaultStrokeWidth}`)
+      typeof strokeWidthProp === 'string'
+        ? getTokenValue(strokeWidthProp as any, 'size')
+        : (strokeWidthProp ?? `${opts.defaultStrokeWidth}`)
 
     const finalProps = {
-      ...props,
+      ...rest,
       color,
       size,
       strokeWidth,
       ...(fillResolved !== undefined ? { fill: fillResolved } : null),
       ...(strokeResolved !== undefined ? { stroke: strokeResolved } : null),
-      style: style as any,
+      ...(style ? { style } : null),
+      // tamagui web maps testID -> data-testid; native keeps testID for react-native-svg
+      ...(testID != null ? (isWeb ? { 'data-testid': testID } : { testID }) : null),
     }
 
     return <Component {...finalProps} />

--- a/code/kitchen-sink/src/usecases/IconFontSizing.tsx
+++ b/code/kitchen-sink/src/usecases/IconFontSizing.tsx
@@ -1,0 +1,20 @@
+import { Moon } from '@tamagui/lucide-icons-2'
+import { Button, YStack } from 'tamagui'
+
+// icons should size to match the button's font size at each size token.
+// the svg width/height should equal the computed font-size of the button text.
+export function IconFontSizing() {
+  return (
+    <YStack gap="$4" padding="$4">
+      <Button size="$2" icon={Moon} testID="btn-2">
+        Small
+      </Button>
+      <Button size="$6" icon={Moon} testID="btn-6">
+        Large
+      </Button>
+      {/* direct icon with a token size resolves via the font size scale */}
+      <Moon size="$2" testID="icon-2" />
+      <Moon size="$8" testID="icon-8" />
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.native.ts
+++ b/code/kitchen-sink/src/usecases/index.native.ts
@@ -136,6 +136,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
   StyledContextTokens: () => require('./StyledContextTokens').StyledContextTokens,
   StyledHOCNamed: () => require('./StyledHOCNamed').StyledHOCNamed,
   StyledIconColor: () => require('./StyledIconColor').StyledIconColor,
+  IconFontSizing: () => require('./IconFontSizing').IconFontSizing,
   StyledInputFocusStyle: () => require('./StyledInputFocusStyle').StyledInputFocusStyle,
   StyledInputOnFocus: () => require('./StyledInputOnFocus').StyledInputOnFocus,
   StyledMediaQueryMerge: () => require('./StyledMediaQueryMerge').StyledMediaQueryMerge,

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -35,6 +35,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
   ButtonCircular: () => require('./ButtonCircular').ButtonCircular,
   ButtonCustom: () => require('./ButtonCustom').ButtonCustom,
   ButtonIconColor: () => require('./ButtonIconColor').ButtonIconColor,
+  IconFontSizing: () => require('./IconFontSizing').IconFontSizing,
   ButtonInverse: () => require('./ButtonInverse').ButtonInverse,
   ButtonUnstyled: () => require('./ButtonUnstyled').ButtonUnstyled,
   CheckboxDisabledOnPress: () =>

--- a/code/kitchen-sink/tests/IconFontSizing.test.tsx
+++ b/code/kitchen-sink/tests/IconFontSizing.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page, { name: 'IconFontSizing', type: 'useCase' })
+})
+
+// width of a nested svg inside a component (e.g. Button)
+async function nestedSvgWidth(page: any, testId: string) {
+  const el = page.getByTestId(testId)
+  await expect(el).toBeVisible()
+  const svg = el.locator('svg').first()
+  return Number(await svg.getAttribute('width'))
+}
+
+// width of a direct icon (testID lands on the svg itself)
+async function directSvgWidth(page: any, testId: string) {
+  const el = page.getByTestId(testId)
+  await expect(el).toBeVisible()
+  return Number(await el.getAttribute('width'))
+}
+
+// computed font-size (px) of the text inside a component
+async function fontSizePx(page: any, testId: string) {
+  return await page.getByTestId(testId).evaluate((el: HTMLElement) => {
+    const spans = [...el.querySelectorAll('span')]
+    const t = spans.find((s) => s.textContent && /\S/.test(s.textContent))
+    return t ? parseFloat(getComputedStyle(t).fontSize) : NaN
+  })
+}
+
+test('button icon size matches the button font size at each size', async ({ page }) => {
+  // v3: icons resolve via the current font's size scale, so they line up with text
+  expect(await nestedSvgWidth(page, 'btn-2')).toBe(await fontSizePx(page, 'btn-2'))
+  expect(await nestedSvgWidth(page, 'btn-6')).toBe(await fontSizePx(page, 'btn-6'))
+})
+
+test('direct icon token size resolves via the font size scale, not size tokens', async ({
+  page,
+}) => {
+  // font.body.size.$2 === 12 (size token $2 === 28)
+  expect(await directSvgWidth(page, 'icon-2')).toBe(12)
+  // font.body.size.$8 === 23 (size token $8 === 84)
+  expect(await directSvgWidth(page, 'icon-8')).toBe(23)
+})

--- a/next.md
+++ b/next.md
@@ -7,6 +7,7 @@ v3 release plan:
 - composable structure audit: ListItem alignment, Select dead-code sweep + Select.Separator, FocusScope (display:contents wrapper, render-prop removed, new `noFocus` zero-focus mode threaded through Dialog/Popover/Select), Dialog (dead-code sweep, RemoveScroll gated to open modal dialogs, parts own presence, driver-level `onDidAnimate` completion), Sheet (scoped context, Frame => Container + Background split with codemod, Overlay must be direct child)
 - Adapt live slot core + dialog<->sheet handoff (exit animations play through media flips)
 - notable fixes along the way: boolean size-shorthand tokens inside variant styles, animated-driver custom component preservation (render-as-string clobbering), slider visible track/fill, dialog exit releases pointer-events locks (body lock, overlay, focus trap)
+- icons: sizing now defaults to font sizes instead of size tokens (`themed()` resolves token sizes via the current font's `font.size[token]` scale, so icons line up with text at every size), and `usePropsAndStyle` was removed from `themed()` (icons now resolve theme color/fill/stroke via `useTheme()` and build a minimal style object instead of running full style resolution on every render)
 
 migration notes so far:
 
@@ -15,10 +16,11 @@ migration notes so far:
 - FocusScope no longer supports function-as-children/render-prop; pass JSX children directly.
 - Select's unused `name` and `autoComplete` props were removed; they never backed form or autofill behavior.
 - Sheet.Frame => Sheet.Container + Sheet.Background (codemod: scripts/codemods/sheet-frame-to-container.js). Container no longer clips with overflow hidden. Sheet.Overlay must be a direct child of Sheet.
+- icon token sizes now resolve through the current font's size scale (`font.size[token]`) rather than the `size` token scale, so e.g. `<Icon size="$4" />` matches `$4` text instead of the `$4` space/size value. Raw numeric sizes are unchanged.
+- icon components no longer accept media/pseudo props directly (e.g. `$sm`, `hoverStyle`) — `themed()` dropped `usePropsAndStyle` and no longer runs full style resolution. Wrap an icon in a styled `View` if you need responsive/pseudo styling around it. Color/fill/stroke theme tokens, `size`, `strokeWidth`, `style`, and `testID` still work as before.
 
 ## active work (v3-gating)
 
-- icons: remove `usePropsAndStyle` from `themed` (replace the pattern) and default icon sizing to font sizes instead of size tokens — both are clear wins
 - remove `getToken` / shift weirdness in default styling (under investigation, proposal pending)
 - line height as multiplier: decided valid, but only for direct numeric values (that work already landed). Remaining: support "px" string values; move v5 config font tokens to "px" values so behavior is backwards compatible; v6 config then defines this logically right, ideally aligned to tailwind's scale.
 - remove RN entirely from web: eject Input and ScrollView by moving the "lite" implementations into the actual tamagui components; `lite` then re-exports from those packages
@@ -221,7 +223,6 @@ and cant put another View next to Content and have it show
   - then we can get rid of defaultProps
   - then get rid of expensive statiConfig.defaultProps merging every render
 - always dynamic optimize no need for special "components"
-- remove `usePropsAndStyle` from icon `themed` somehow / pattern for that
 - remove getToken + shift weirdness in general
 - react compiler on internals / concurrent friendly internals
 - eject from floating-ui if possible (its huge)


### PR DESCRIPTION
## What changed

Two v3 icon changes in `@tamagui/helpers-icon`'s `themed()`:

### 1. Icons default to font sizes instead of size tokens
Icon token sizes now resolve through the current font's size scale (`font.size[token]`) instead of the `size` token scale. A string `size="$4"` (and SizableContext-driven sizing from Button/ListItem/etc.) now resolves via `getFontSize`, so icons line up with text at every size. Raw numeric sizes stay literal.

Button/ListItem/checkbox already resolved via `getFontSize` on v3-beta (through `getThemedIconSize`), so this closes the gap for icons used directly and via `SizableContext`. No parallel resolver was added — it reuses the existing `getFontSize` from `@tamagui/font-size` (added as a dependency of `helpers-icon`). Per the repo's one-path rule, there is no `iconSizing` config toggle; font-size sizing is the only behavior.

### 2. Removed `usePropsAndStyle` from `themed()`
`themed()` no longer runs full style resolution on every icon render. It now uses `useTheme()` directly for color/fill/stroke token resolution and builds a minimal style object. This drops the `needsFullStyleResolution` media branch. `styled(SomeIcon)` still works (the `isHOC` staticConfig marker is preserved). The exported `themed()` API is unchanged. `testID` is still mapped to `data-testid` on web (native keeps `testID` for react-native-svg).

## Migration notes
- Icon token sizes now resolve through the font's size scale (`font.size[token]`), not the `size` token scale — e.g. `<Icon size="$4" />` matches `$4` text instead of the `$4` size value. Numeric sizes unchanged.
- Icon components no longer accept media/pseudo props directly (`$sm`, `hoverStyle`, etc.) since full style resolution was dropped. Wrap the icon in a styled `View` for responsive/pseudo styling. Color/fill/stroke theme tokens, `size`, `strokeWidth`, `style`, and `testID` still work.

## Testing
- `bun run build` clean at root.
- Existing icon tests pass: `ButtonIconColor`, `ButtonCustom`, `ButtonUnstyled`, `StyledIconColor`.
- New `IconFontSizing` test/usecase asserts icon size matches font size at two button sizes ($2, $6) and that direct token sizes resolve via the font scale ($2 -> 12px, $8 -> 23px) rather than size tokens ($2 -> 28px, $8 -> 84px). The direct-icon assertions fail against the old behavior, confirming the change.
- Screenshots of Button / ListItem / Inputs demos and the IconFontSizing usecase verified icons scale with text and colors resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
