### PR TITLE
test(input): cover DOM ref forwarding

### DIFF
--- a/code/kitchen-sink/src/usecases/InputRefCase.tsx
+++ b/code/kitchen-sink/src/usecases/InputRefCase.tsx
@@ -1,0 +1,150 @@
+import { Input, TextArea } from '@tamagui/input'
+import React from 'react'
+import { Button, Dialog, Paragraph, Popover, YStack, styled } from 'tamagui'
+
+const StyledInput = styled(Input, {
+  name: 'InputRefCaseStyledInput',
+})
+
+const StyledTextArea = styled(TextArea, {
+  name: 'InputRefCaseStyledTextArea',
+})
+
+const DoubleStyledInput = styled(
+  styled(Input, {
+    name: 'InputRefCaseDoubleStyledInputBase',
+  }),
+  {
+    name: 'InputRefCaseDoubleStyledInput',
+  }
+)
+
+const DoubleStyledTextArea = styled(
+  styled(TextArea, {
+    name: 'InputRefCaseDoubleStyledTextAreaBase',
+  }),
+  {
+    name: 'InputRefCaseDoubleStyledTextArea',
+  }
+)
+
+function ImperativeStyledInput(props: React.ComponentProps<typeof StyledInput>) {
+  const { ref, ...rest } = props
+  const innerRef = React.useRef<any>(null)
+
+  React.useImperativeHandle(ref, () => innerRef.current, [])
+
+  return <StyledInput {...rest} ref={innerRef} />
+}
+
+type RefProbeProps = {
+  Component: React.ElementType
+  callback?: boolean
+  children?: React.ReactNode
+  componentProps?: Record<string, unknown>
+  focusOnLayout?: boolean
+  id: string
+}
+
+function RefProbe({
+  Component,
+  callback,
+  children,
+  componentProps,
+  focusOnLayout,
+  id,
+}: RefProbeProps) {
+  const objectRef = React.useRef<any>(null)
+  const [callbackNode, setCallbackNode] = React.useState<any>(null)
+  const callbackRef = React.useCallback((node: any) => setCallbackNode(node), [])
+  const [tagName, setTagName] = React.useState('NULL')
+
+  React.useLayoutEffect(() => {
+    const current = callback ? callbackNode : objectRef.current
+    if (!current) return
+
+    if (focusOnLayout) {
+      current.focus()
+    }
+    setTagName(current.tagName ?? 'NULL')
+  }, [callback, callbackNode, focusOnLayout])
+
+  return (
+    <YStack gap="$2">
+      <Component {...componentProps} id={id} ref={callback ? callbackRef : objectRef}>
+        {children}
+      </Component>
+      <Paragraph testID={`${id}-tag`}>{tagName}</Paragraph>
+      <Button
+        testID={`${id}-focus`}
+        onPress={() => (callback ? callbackNode : objectRef.current)?.focus()}
+      >
+        Focus {id}
+      </Button>
+    </YStack>
+  )
+}
+
+export function InputRefCase() {
+  const [dialogOpen, setDialogOpen] = React.useState(false)
+  const [popoverOpen, setPopoverOpen] = React.useState(false)
+
+  return (
+    <YStack gap="$3" padding="$4">
+      <RefProbe Component={Input} id="input-ref-plain" />
+      <RefProbe Component={StyledInput} id="input-ref-styled" />
+      <RefProbe
+        Component={TextArea}
+        componentProps={{ multiline: true, rows: 5 }}
+        id="textarea-ref-plain"
+      />
+      <RefProbe
+        Component={StyledTextArea}
+        componentProps={{ multiline: true, rows: 5 }}
+        id="textarea-ref-styled"
+      />
+
+      <RefProbe callback Component={StyledInput} id="input-ref-callback" />
+      <RefProbe callback Component={StyledTextArea} id="textarea-ref-callback" />
+      <RefProbe Component={DoubleStyledInput} id="input-ref-double-styled" />
+      <RefProbe Component={DoubleStyledTextArea} id="textarea-ref-double-styled" />
+      <RefProbe
+        Component={ImperativeStyledInput}
+        focusOnLayout
+        id="input-ref-imperative"
+      />
+      <RefProbe
+        Component={Input}
+        componentProps={{ asChild: true }}
+        id="input-ref-as-child"
+      >
+        <input />
+      </RefProbe>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen} modal={false}>
+        <Dialog.Trigger asChild>
+          <Button testID="input-ref-dialog-open">Open ref dialog</Button>
+        </Dialog.Trigger>
+        <Dialog.Portal>
+          <Dialog.Content>
+            <Dialog.Title>Input ref dialog</Dialog.Title>
+            <Dialog.Description>Portal ref coverage</Dialog.Description>
+            <RefProbe Component={StyledInput} id="input-ref-dialog" />
+            <Dialog.Close asChild>
+              <Button testID="input-ref-dialog-close">Close ref dialog</Button>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
+
+      <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+        <Popover.Trigger asChild>
+          <Button testID="textarea-ref-popover-open">Open ref popover</Button>
+        </Popover.Trigger>
+        <Popover.Content>
+          <RefProbe Component={StyledTextArea} id="textarea-ref-popover" />
+        </Popover.Content>
+      </Popover>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.native.ts
+++ b/code/kitchen-sink/src/usecases/index.native.ts
@@ -77,6 +77,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
   IconFillStroke: () => require('./IconFillStroke').IconFillStroke,
   ImageObjectFit: () => require('./ImageObjectFit').ImageObjectFit,
   ImageTokenStyle: () => require('./ImageTokenStyle').ImageTokenStyle,
+  InputRefCase: () => require('./InputRefCase').InputRefCase,
   ThemedListItem: () => require('./ListItem').ThemedListItem,
   NewInputBasic: () => require('./NewInputBasic').NewInputBasic,
   InputTextShorthand: () => require('./InputTextShorthand').InputTextShorthand,

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -139,6 +139,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
     require('./InputAutoFocusAfterMenuCase').InputAutoFocusAfterMenuCase,
   InputAutoFocusStyledCase: () =>
     require('./InputAutoFocusStyledCase').InputAutoFocusStyledCase,
+  InputRefCase: () => require('./InputRefCase').InputRefCase,
   ThemedListItem: () => require('./ListItem').ThemedListItem,
   NewInputBasic: () => require('./NewInputBasic').NewInputBasic,
   InputTextShorthand: () => require('./InputTextShorthand').InputTextShorthand,

--- a/code/kitchen-sink/tests/InputRef.test.tsx
+++ b/code/kitchen-sink/tests/InputRef.test.tsx
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+import { setupPage } from './test-utils'
+
+const cases = [
+  { prefix: 'input-ref-plain', tagName: 'INPUT' },
+  { prefix: 'input-ref-styled', tagName: 'INPUT' },
+  { prefix: 'textarea-ref-plain', tagName: 'TEXTAREA' },
+  { prefix: 'textarea-ref-styled', tagName: 'TEXTAREA' },
+  { prefix: 'input-ref-callback', tagName: 'INPUT' },
+  { prefix: 'textarea-ref-callback', tagName: 'TEXTAREA' },
+  { prefix: 'input-ref-double-styled', tagName: 'INPUT' },
+  { prefix: 'textarea-ref-double-styled', tagName: 'TEXTAREA' },
+  { prefix: 'input-ref-imperative', tagName: 'INPUT' },
+  { prefix: 'input-ref-as-child', tagName: 'INPUT' },
+] as const
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page, { name: 'InputRefCase', type: 'useCase' })
+})
+
+test('Input and TextArea refs resolve to their DOM elements and can focus them', async ({
+  page,
+}) => {
+  for (const refCase of cases) {
+    await expect(page.getByTestId(`${refCase.prefix}-tag`)).toHaveText(refCase.tagName)
+
+    await page
+      .getByTestId(`${refCase.prefix}-focus`)
+      .evaluate((element: HTMLElement) => element.click())
+    await expect(page.locator(`#${refCase.prefix}`)).toBeFocused()
+  }
+
+  await page.getByTestId('input-ref-dialog-open').click()
+  await expect(page.getByTestId('input-ref-dialog-tag')).toHaveText('INPUT')
+  await page
+    .getByTestId('input-ref-dialog-focus')
+    .evaluate((element: HTMLElement) => element.click())
+  await expect(page.locator('#input-ref-dialog')).toBeFocused()
+  await page.getByTestId('input-ref-dialog-close').click()
+
+  await page.getByTestId('textarea-ref-popover-open').click()
+  await expect(page.getByTestId('textarea-ref-popover-tag')).toHaveText('TEXTAREA')
+  await page
+    .getByTestId('textarea-ref-popover-focus')
+    .evaluate((element: HTMLElement) => element.click())
+  await expect(page.locator('#textarea-ref-popover')).toBeFocused()
+
+  await expect(page.locator('#textarea-ref-plain')).toHaveAttribute('rows', '5')
+  await expect(page.locator('#textarea-ref-styled')).toHaveAttribute('rows', '5')
+})


### PR DESCRIPTION
The reported ref failure does not reproduce on current v3-beta or main/v2.4.3: direct and styled Input/TextArea refs resolve to the underlying DOM node and focus correctly. This adds kitchen-sink coverage for object and callback refs, nested styled wrappers, rows/multiline, imperative layout access, asChild, and Dialog/Popover portal mounts. The test asserts both the concrete INPUT/TEXTAREA tag and ref-driven focus behavior.