### PR TITLE
fix(sheet): size spring rest detection for px moves so adapt handoff teardown runs on real completion (deflake DialogSheetAdaptHandoff reanimated)

### DIFF
--- a/code/kitchen-sink/src/usecases/DialogSheetAdaptHandoffCase.tsx
+++ b/code/kitchen-sink/src/usecases/DialogSheetAdaptHandoffCase.tsx
@@ -102,6 +102,13 @@ export function DialogSheetAdaptHandoffCase() {
             snapPointsMode="fit"
             dismissOnSnapToBottom
             unmountChildrenWhenHidden
+            onAnimationComplete={(info) => {
+              // expose sheet animation completion so tests can wait for the
+              // enter spring to settle before interrupting it (deterministic
+              // signal instead of timing assumptions)
+              const events = ((globalThis as any).__dialogAdaptSheetAnim ||= [])
+              events.push({ open: info.open, t: performance.now() })
+            }}
           >
             <Sheet.Overlay
               testID="dialog-adapt-sheet-overlay"

--- a/code/kitchen-sink/tests/DialogSheetAdaptHandoff.animated.test.tsx
+++ b/code/kitchen-sink/tests/DialogSheetAdaptHandoff.animated.test.tsx
@@ -11,6 +11,22 @@ async function openAdaptedDialog(page: Page) {
     timeout: 5000,
   })
   await expect.poll(() => getSheetState(page), { timeout: 5000 }).toBe('open')
+  // wait for the sheet's enter animation to fully settle before acting. without
+  // this, under CPU starvation the enter spring may not have advanced a single
+  // frame when a close/flip starts the exit spring - the exit then begins at its
+  // own target value and completes instantly, so the handoff releases the
+  // adapted content with no exit window at all (the flake this guards against)
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          ((globalThis as any).__dialogAdaptSheetAnim ?? []).some(
+            (event: { open: boolean }) => event.open
+          )
+        ),
+      { timeout: 10_000 }
+    )
+    .toBe(true)
 }
 
 async function getSheetState(page: Page) {

--- a/code/ui/adapt/src/Adapt.tsx
+++ b/code/ui/adapt/src/Adapt.tsx
@@ -207,7 +207,10 @@ export const AdaptParent = ({
   open,
   onOpenChange,
   state,
-  exitLatchTimeout = 1_000,
+  // safety net only: must comfortably exceed the slowest real exit animation
+  // (spring drivers report completion at ~0.8s for sheet-sized moves; before
+  // the sheet defaulted rest thresholds they settled as late as ~1.7s)
+  exitLatchTimeout = 3_000,
 }: AdaptParentProps) => {
   const id = useId()
   const portalName = `AdaptPortal${scope}${id}`

--- a/code/ui/sheet/src/SheetImplementationCustom.tsx
+++ b/code/ui/sheet/src/SheetImplementationCustom.tsx
@@ -498,14 +498,34 @@ export const SheetImplementationCustom = createRefComponent<View, SheetProps>(
         return
       }
 
-      animatedNumber.setValue(
-        toValue,
-        animationOverride || {
-          type: 'spring',
-          ...transitionConfig,
-        },
-        animationCompleteCallback
-      )
+      const resolvedConfig = animationOverride || {
+        type: 'spring',
+        ...transitionConfig,
+      }
+
+      // the sheet position spring moves hundreds of px. the spring drivers'
+      // default rest detection is tuned for tiny values (react-native Animated:
+      // 0.001px thresholds; reanimated 4: relative energyThreshold 6e-9), so for
+      // a sheet-sized move completion fires 1.4-1.7s after the animation is
+      // visually done - it always lost to Adapt's exit fallback latch and the
+      // sheet's own 1s opacity fallback, making every adapted close timer-driven
+      // (with a dev warning). default rest detection sized for px transforms:
+      // sub-pixel, invisible, but completes when the motion actually ends.
+      // user config still wins via spread order; each driver ignores the other
+      // driver's keys.
+      const springConfig =
+        !resolvedConfig.type || resolvedConfig.type === 'spring'
+          ? {
+              // react-native Animated (absolute px)
+              restDisplacementThreshold: 1,
+              restSpeedThreshold: 10,
+              // reanimated 4 (relative energy): ~0.3% of travel amplitude
+              energyThreshold: 1e-5,
+              ...resolvedConfig,
+            }
+          : resolvedConfig
+
+      animatedNumber.setValue(toValue, springConfig, animationCompleteCallback)
     })
 
     useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
Deflakes `DialogSheetAdaptHandoff.animated.test.tsx` on the reanimated driver ("close during media handoff releases the adapted content after exit" and "reopen during sheet exit keeps the adapted content instance alive", CI integration shard 3/3), and fixes two real bugs found while root-causing it.

## Root cause (probed, not guessed)

Instrumented Adapt, Sheet, and the reanimated driver's `useAnimatedNumber` with console probes and reproduced under CPU load. Two distinct findings:

**1. The flake: exit spring completes instantly when the enter spring never advanced a frame.**

The tests act as soon as the sheet frame reports `data-state="open"`, but that flips at mount, before the enter spring has moved anything. Under CPU starvation, zero animation frames run between the enter spring starting (900 → 659) and the close/flip starting the exit spring. The shared value is then still exactly 900 — the exit spring's own target — so `withSpring` reports `finished=true` in the same tick it starts:

```
[PROBE] animateTo t=917 position=-1 ... at=659            <- exit starts (bookkeeping says 659)
[PROBE] reanimated setValue cb t=918 finished=true next=900  <- real value was still 900: instant "completion"
[PROBE] handoff.onAnimationComplete t=919 infoOpen=false openRef=true rawActiveRef=false
```

Adapt then legitimately releases the handoff with no exit window at all: `targetFullyHidden` flips, the latch releases, the sheet unmounts its children (`unmountChildrenWhenHidden`), and the adapted content remounts (`instance: 1` → `instance: 3` — one remount, doubled by StrictMode). Both failing assertions ("content survives 250ms of early exit", "instance stays the same across close→reopen at 80ms") are timing assumptions that a genuinely-instant exit violates.

**2. A real bug underneath: sheet spring completion never beat the fallback timers.**

Even in passing runs, the sheet's exit spring completion callback never fired before teardown. The spring drivers' rest detection is tuned for tiny values — react-native Animated's thresholds are 0.001px, reanimated 4's relative `energyThreshold` default is 6e-9 — so a sheet-sized (~250-900px) move only reports completion ~1.35s (reanimated) / ~1.65s (native) after it is visually done. Adapt's exit fallback latch (1000ms) and the sheet's own 1s opacity fallback always won, so **every adapted close was timer-driven and logged the dev warning** ("Adapt target did not report exit animation completion within 1000ms") on both spring drivers:

```
[PROBE] reanimated setValue t=947 next=900 type=spring hasOnFinish=true
Adapt target did not report exit animation completion within 1000ms; releasing the presence latch.
[PROBE] reanimated setValue cb t=1966 finished=false next=900   <- cancelled by unmount, never completed
```

## Fix

- **`Sheet` (`animateTo`)**: default the position spring's rest detection to values sized for px transforms — `restDisplacementThreshold: 1` / `restSpeedThreshold: 10` (react-native Animated) and `energyThreshold: 1e-5` (reanimated 4, ~0.3% of travel amplitude). Sub-pixel, invisible, but completion now fires when the motion actually ends (~750ms for the kitchen-sink `medium` spring, was ~1350ms). User config still wins via spread order; each driver ignores the other's keys. Adapted closes are now driven by real driver completion on all four drivers, no warnings, no timer teardown.
- **`Adapt`**: recalibrate `exitLatchTimeout` default 1000ms → 3000ms so the latch is a true safety net instead of firing within ~25% of a normal spring's completion.
- **Test synchronization** (`DialogSheetAdaptHandoffCase` + test): the use case exposes the sheet's `onAnimationComplete` events, and `openAdaptedDialog` now waits for the enter animation to actually settle before acting — a deterministic signal instead of the `data-state="open"` timing assumption. The instance-identity assertion is unchanged and now meaningfully guards close→reopen against a genuinely running exit.

## Validation

- `DialogSheetAdaptHandoff` on **reanimated**: `--repeat-each=5 --retries=0` → 20/20, and 20/20 again with 6 CPU-burner processes saturating all cores (the original failure reproduced reliably under this load before the fix, including `instance: 3`).
- `DialogSheetAdaptHandoff` on **css / native / motion**: `--repeat-each=5` → 20/20 each.
- Adjacent suites green post-rebase on #4114: `DialogSheetAdaptUnmount`, `DialogPresenceCompletion`, `PopoverAdaptSheetUnmount`, `SelectAdaptSheetUnmount` (all four drivers), `SheetAnimation`, `SheetOnAnimationComplete`, `SheetDrag`, `SheetSnapPointsFit`, plus the non-animated `DialogSheetAdapt` / `AdaptLiveSlotSpike` / `DialogSheetAdaptResize` / `SheetOverlayStyle`.
- `bun run lint` clean; `tsc --noEmit` clean for sheet and adapt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
