### PR TITLE
test(kitchen-sink): wait for sheet settle before in-sheet clicks in SheetDragResist (deflake chromium tap-scroll)

### DIFF
--- a/code/kitchen-sink/tests/SheetDragResist.animated.test.tsx
+++ b/code/kitchen-sink/tests/SheetDragResist.animated.test.tsx
@@ -46,6 +46,40 @@ async function dragSheet(
   await page.mouse.up()
 }
 
+/**
+ * wait for the sheet frame to be fully settled (no transform movement) before
+ * interacting with content inside it.
+ *
+ * clicking an element inside the sheet while the frame is still animating in -
+ * or has only just stopped - makes chromium (mobile emulation) scroll the
+ * tapped element to the top of the enclosing ScrollView. this is browser
+ * behavior around taps on recently-transformed content, not sheet code: it
+ * reproduces with zero drags, on a non-focusable paragraph click, with the
+ * sheet's scroll lock never engaging, and tracks the enter animation rather
+ * than any app state. a fixed post-open timeout leaves the click racing the
+ * enter spring on slow machines, so wait for real box stability instead.
+ */
+async function waitForSheetSettled(page: Page, frameTestId: string) {
+  await expect
+    .poll(
+      async () => {
+        const read = () =>
+          page.evaluate(
+            (testId) =>
+              document.querySelector(`[data-testid="${testId}"]`)?.getBoundingClientRect()
+                .top ?? Number.NaN,
+            frameTestId
+          )
+        const before = await read()
+        await page.waitForTimeout(300)
+        const after = await read()
+        return Math.abs(after - before)
+      },
+      { timeout: 15_000 }
+    )
+    .toBeLessThan(0.5)
+}
+
 test.describe('Bug #3: Sheet without ScrollView - drag up resistance', () => {
   /**
    * When at top snap point, dragging up should apply resistance
@@ -100,7 +134,9 @@ test.describe('Bug #3: Sheet without ScrollView - drag up resistance', () => {
       'Current snap point: 0'
     )
 
-    // reset tracking
+    // reset tracking (settle first: clicking into a still-animating sheet
+    // triggers a spurious chromium tap-scroll, see waitForSheetSettled)
+    await waitForSheetSettled(page, 'no-scroll-frame')
     await page.getByTestId('no-scroll-reset').click()
 
     // get frame position for dragging on content
@@ -172,7 +208,8 @@ test.describe('Bug #1: Sheet with non-scrollable ScrollView', () => {
     const frame = page.getByTestId('non-scrollable-frame')
     await expect(frame).toBeVisible({ timeout: 5000 })
 
-    // reset counters
+    // reset counters (settle first, see waitForSheetSettled)
+    await waitForSheetSettled(page, 'non-scrollable-frame')
     await page.getByTestId('non-scrollable-reset').click()
 
     // verify we start at position 0
@@ -260,7 +297,8 @@ test.describe('Bug #2: Sheet with scrollable ScrollView - drag up resistance', (
     const frame = page.getByTestId('scrollable-frame')
     await expect(frame).toBeVisible({ timeout: 5000 })
 
-    // reset tracking
+    // reset tracking (settle first, see waitForSheetSettled)
+    await waitForSheetSettled(page, 'scrollable-frame')
     await page.getByTestId('scrollable-reset').click()
 
     // ensure we're at scroll top and position 0


### PR DESCRIPTION
Deflakes `SheetDragResist.animated.test.tsx` "should show resistance when dragging up at scroll top and sheet top" (animated-reanimated, Linux CI, failed all retries twice after #4116).

## Root cause (probed, and it is not the scroll lock)

Instrumented the page with capture-phase scroll/focus/input listeners plus patched `scrollTop`/`scrollTo`/`scrollIntoView`/`focus` to capture stacks, and reproduced at will (locally ~50-90% failure rate at v3-beta HEAD). The failing `At scroll top: NO` comes from the ScrollView sitting at `scrollTop=104` at the end — and that scroll happens **before the drag even starts**:

```
[P] focusin t=907 el=scrollable-reset          <- the test's "reset tracking" click
[P] scrollevent t=920 el=scrollable-scrollview scrollTop=104   <- 104 = the button's offsetTop
[P] drag-start ...                             <- drag was never involved
```

Isolation matrix (each independently verified):

- **No drag needed**: the reset click alone reproduces it.
- **No focus needed**: clicking a non-focusable `Paragraph` inside the ScrollView also scrolls (`scrollTop=18` = that element's offset). The browser aligns the *tapped* element to the top of the enclosing scroller.
- **No app code involved**: zero calls through `scrollTop`/`scrollTo`/`scrollIntoView`/`focus`; no DOM mutations in the sheet subtree between click and scroll; the sheet's scroll lock (`scrollBridge.setScrollEnabled` / overflow toggling in `useSheetScrollViewGestures`) never engages during the sequence (it only acts on touch gestures on the scroll node).
- **Tracks the enter animation**: with `transition="lazy"` (settles ~4s) a click at ~905ms mid-animation scrolls, while clicks at 2.6s/3.6s/4.6s are clean. Raw `page.mouse.click` (bypassing Playwright's pre-click CDP pipeline) at the same mid-animation moments is always clean.

So this is Chromium (mobile emulation) tap handling scrolling the tapped element to the top of its scroller when the tap goes through Playwright's actionability/click pipeline while the sheet's transform has recently been animating. The sheet's scroll-lock release ordering is provably fine — the phantom scroll fires with the lock never touched and with no gesture at all.

Why it surfaced now: before #4116 the enter spring kept sub-pixel motion running until ~1.4s, so Playwright's own stability gate deferred the reset click well past the risky period on fast machines (Linux CI's dropped frames could let the click through mid-motion — the historical CI-only flake). After #4116 the spring parks dead at ~0.8s, the stability gate passes right away, and the test's fixed 600ms wait put the click squarely in the risky window, making the flake frequent.

## Fix

Test synchronization, per the invariant the test actually needs: don't click inside the sheet until the frame is genuinely settled. Added `waitForSheetSettled` (polls the frame's `getBoundingClientRect().top` across 300ms windows until stable) and applied it before the three in-sheet reset-button clicks. Handle drags use raw `page.mouse` and are unaffected. The instance/scroll assertions are unchanged.

## Validation

- Previously failing test: 8/8 on reanimated (was ~50% fail), `--retries=0`.
- Full `SheetDragResist` file: 27/27 on reanimated, css, native; 24/24 + 3 skipped on motion (`--repeat-each=3 --retries=0`).
- Fixed flow probed under CDP `Emulation.setCPUThrottlingRate` 10x and 20x: 6/6 clean (the unfixed flow reproduces the phantom scroll reliably).
- Regression: `SheetDragResist` + `SheetScrollLock.animated` + `SheetDrag.animated` on reanimated under 6-core CPU-burner load: 44 passed, `--repeat-each=2 --retries=0`.
- `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
