### PR TITLE
test(kitchen-sink): fix native Adapt live-slot Detox suites

### DIFF
--- a/code/kitchen-sink/e2e/AdaptLiveSlotSpike.test.ts
+++ b/code/kitchen-sink/e2e/AdaptLiveSlotSpike.test.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert'
 import { by, device, element, expect as detoxExpect, waitFor } from 'detox'
 import { remountDirectUseCase } from './utils/navigation'
 import { safeLaunchApp, withSync } from './utils/detox'
@@ -15,6 +16,15 @@ const toSlotCount = (value: string) => value.replace(/^v2 /, 'slot ')
 async function getText(id: string) {
   const attributes = (await testElement(id).getAttributes()) as any
   return attributes.text as string
+}
+
+// the case is taller than a phone screen; scroll an element into view before
+// tapping it (web tests get this for free via Playwright auto-scroll)
+async function scrollIntoView(id: string) {
+  await waitFor(testElement(id))
+    .toBeVisible()
+    .whileElement(by.id('adapt-live-slot-scroll'))
+    .scroll(250, 'down')
 }
 
 describe('AdaptLiveSlotSpike', () => {
@@ -54,6 +64,7 @@ describe('AdaptLiveSlotSpike', () => {
     )
     await detoxExpect(element(by.label('No portal sheet live slot panel'))).toExist()
 
+    await scrollIntoView('sheet-live-slot-button')
     await withSync(() => testElement('sheet-live-slot-button').tap())
     await detoxExpect(testElement('sheet-live-slot-press-count')).toHaveText(
       'sheet press-count: 1'
@@ -75,7 +86,9 @@ describe('AdaptLiveSlotSpike', () => {
     await detoxExpect(testElement('live-slot-context')).toHaveText(
       'dialog-context: dialog-parent-ok; portal-context: portal-wrapper-ok; target-context: target-context-ok; revision: 1'
     )
-    expect(await getText('live-slot-instance')).toBe(instanceBefore)
+    // note: the global `expect` is Detox's matcher expect (exposeGlobals), so
+    // plain value assertions must use node assert
+    assert.strictEqual(await getText('live-slot-instance'), instanceBefore)
   })
 
   it('state preservation characterization matches the measured v2 baseline', async () => {
@@ -92,15 +105,20 @@ describe('AdaptLiveSlotSpike', () => {
       measuredV2StateBaseline.countAfterReturn
     )
 
+    await scrollIntoView('slot-state-increment')
     await withSync(() => testElement('slot-state-increment').tap())
     await detoxExpect(testElement('slot-state-count')).toHaveText('slot count: 1')
     const slotInstanceBefore = await getText('slot-state-instance')
 
+    // the toggle sits just above the panels and stays co-visible with the
+    // increment button once the panels are scrolled into view
+    await waitFor(testElement('slot-state-toggle')).toBeVisible().withTimeout(5000)
     await withSync(() => testElement('slot-state-toggle').tap())
     await waitFor(testElement('slot-state-content')).toExist().withTimeout(10000)
     const slotCountAfterAdapt = await getText('slot-state-count')
     const slotInstanceAfterAdapt = await getText('slot-state-instance')
 
+    await waitFor(testElement('slot-state-toggle')).toBeVisible().withTimeout(5000)
     await withSync(() => testElement('slot-state-toggle').tap())
     await waitFor(testElement('slot-state-content')).toExist().withTimeout(10000)
     const slotCountAfterReturn = await getText('slot-state-count')
@@ -118,9 +136,13 @@ describe('AdaptLiveSlotSpike', () => {
       })
     )
 
-    expect(slotInstanceAfterAdapt).not.toBe(slotInstanceBefore)
-    expect(slotCountAfterAdapt).toBe(toSlotCount(measuredV2StateBaseline.countAfterAdapt))
-    expect(slotCountAfterReturn).toBe(
+    assert.notStrictEqual(slotInstanceAfterAdapt, slotInstanceBefore)
+    assert.strictEqual(
+      slotCountAfterAdapt,
+      toSlotCount(measuredV2StateBaseline.countAfterAdapt)
+    )
+    assert.strictEqual(
+      slotCountAfterReturn,
       toSlotCount(measuredV2StateBaseline.countAfterReturn)
     )
   })

--- a/code/kitchen-sink/e2e/DialogSheetAdaptHandoff.test.ts
+++ b/code/kitchen-sink/e2e/DialogSheetAdaptHandoff.test.ts
@@ -1,3 +1,4 @@
+import * as assert from 'assert'
 import { by, device, element, expect as detoxExpect, waitFor } from 'detox'
 import { safeLaunchApp, withSync } from './utils/detox'
 import { remountDirectUseCase } from './utils/navigation'
@@ -39,7 +40,9 @@ describe('DialogSheetAdaptHandoff', () => {
 
     await withSync(() => testElement('dialog-adapt-update').tap())
     await detoxExpect(testElement('dialog-adapt-revision')).toHaveText('revision: 1')
-    expect(await getText('dialog-adapt-instance')).toBe(instanceBefore)
+    // note: the global `expect` is Detox's matcher expect (exposeGlobals), so
+    // plain value assertions must use node assert
+    assert.strictEqual(await getText('dialog-adapt-instance'), instanceBefore)
 
     await withSync(() => testElement('dialog-adapt-close').tap())
     await waitFor(testElement('dialog-adapt-content'))
@@ -54,7 +57,7 @@ describe('DialogSheetAdaptHandoff', () => {
     await withSync(() => testElement('dialog-adapt-reopen-during-exit').tap())
 
     await waitFor(testElement('dialog-adapt-content')).toExist().withTimeout(10000)
-    expect(await getText('dialog-adapt-instance')).toBe(instanceBefore)
+    assert.strictEqual(await getText('dialog-adapt-instance'), instanceBefore)
     await detoxExpect(testElement('dialog-adapt-revision')).toHaveText('revision: 0')
   })
 

--- a/code/kitchen-sink/src/usecases/AdaptLiveSlotSpikeCase.tsx
+++ b/code/kitchen-sink/src/usecases/AdaptLiveSlotSpikeCase.tsx
@@ -5,6 +5,7 @@ import {
   H2 as H2Raw,
   Input as InputRaw,
   Paragraph as ParagraphRaw,
+  ScrollView as ScrollViewRaw,
   Sheet as SheetRaw,
   Text as TextRaw,
   XStack as XStackRaw,
@@ -18,6 +19,7 @@ const FocusScope = FocusScopeRaw as React.ComponentType<any>
 const H2 = H2Raw as React.ComponentType<any>
 const Input = InputRaw as React.ComponentType<any>
 const Paragraph = ParagraphRaw as React.ComponentType<any>
+const ScrollView = ScrollViewRaw as React.ComponentType<any>
 const Sheet = SheetRaw as any
 const Text = TextRaw as React.ComponentType<any>
 const XStack = XStackRaw as React.ComponentType<any>
@@ -151,52 +153,61 @@ export function AdaptLiveSlotSpikeCase() {
   const [slotAdapted, setSlotAdapted] = React.useState(false)
 
   return (
-    <YStack p="$4" gap="$5" maxW={760}>
-      <YStack gap="$3">
-        <H2 size="$7">Adapt live slot spike</H2>
-        <Paragraph size="$3">
-          Local PR-A proof harness. It does not change Adapt core.
-        </Paragraph>
-        <XStack gap="$3" flexWrap="wrap">
-          <Button
-            {...testProps('live-slot-toggle')}
-            onPress={() => setLiveActive((x) => !x)}
-          >
-            live slot active: {liveActive ? 'yes' : 'no'}
-          </Button>
-          <Button
-            {...testProps('live-slot-update-prop')}
-            onPress={() => setLiveRevision((x) => x + 1)}
-          >
-            update published prop
-          </Button>
-        </XStack>
+    // scrollable root: the case is far taller than a phone screen, and the
+    // native Detox tests must be able to scroll each section into view (the
+    // web tests get this for free via Playwright auto-scroll)
+    <ScrollView {...testProps('adapt-live-slot-scroll')} flex={1}>
+      <YStack p="$4" gap="$5" maxW={760}>
+        <YStack gap="$3">
+          <H2 size="$7">Adapt live slot spike</H2>
+          <Paragraph size="$3">
+            Local PR-A proof harness. It does not change Adapt core.
+          </Paragraph>
+          <XStack gap="$3" flexWrap="wrap">
+            <Button
+              {...testProps('live-slot-toggle')}
+              onPress={() => setLiveActive((x) => !x)}
+            >
+              live slot active: {liveActive ? 'yes' : 'no'}
+            </Button>
+            <Button
+              {...testProps('live-slot-update-prop')}
+              onPress={() => setLiveRevision((x) => x + 1)}
+            >
+              update published prop
+            </Button>
+          </XStack>
+        </YStack>
+
+        <LiveSlotProof active={liveActive} revision={liveRevision} />
+
+        <YStack gap="$3">
+          <H2 size="$6">State preservation characterization</H2>
+          <Paragraph size="$3">
+            Measured v2 Adapt baseline vs the candidate live slot across inactive/active
+            moves.
+          </Paragraph>
+          <XStack gap="$3" flexWrap="wrap">
+            <Button
+              {...testProps('slot-state-toggle')}
+              onPress={() => setSlotAdapted((x) => !x)}
+            >
+              slot adapted: {slotAdapted ? 'yes' : 'no'}
+            </Button>
+          </XStack>
+
+          <XStack gap="$4" flexWrap="wrap">
+            <MeasuredV2StateBaselinePanel />
+            <SlotStatePanel adapted={slotAdapted} />
+          </XStack>
+        </YStack>
+
+        {/* keep the always-open native Sheet proof last: its absolutely
+            positioned content must not share the viewport with the state
+            panels while the Detox test scrolls/taps them */}
+        <LiveSlotSheetTouchProof />
       </YStack>
-
-      <LiveSlotProof active={liveActive} revision={liveRevision} />
-      <LiveSlotSheetTouchProof />
-
-      <YStack gap="$3">
-        <H2 size="$6">State preservation characterization</H2>
-        <Paragraph size="$3">
-          Measured v2 Adapt baseline vs the candidate live slot across inactive/active
-          moves.
-        </Paragraph>
-        <XStack gap="$3" flexWrap="wrap">
-          <Button
-            {...testProps('slot-state-toggle')}
-            onPress={() => setSlotAdapted((x) => !x)}
-          >
-            slot adapted: {slotAdapted ? 'yes' : 'no'}
-          </Button>
-        </XStack>
-
-        <XStack gap="$4" flexWrap="wrap">
-          <MeasuredV2StateBaselinePanel />
-          <SlotStatePanel adapted={slotAdapted} />
-        </XStack>
-      </YStack>
-    </YStack>
+    </ScrollView>
   )
 }
 
@@ -432,7 +443,8 @@ function MeasuredV2StateBaselinePanel() {
       borderWidth={1}
       borderColor="$orange8"
       rounded="$4"
-      minW={300}
+      flex={1}
+      minW={140}
     >
       <Text fontWeight="700">measured v2 Adapt baseline</Text>
       <Text {...testProps('v2-measured-before')}>{measuredV2StateBaseline.before}</Text>
@@ -456,7 +468,8 @@ function SlotStatePanel({ adapted }: { adapted: boolean }) {
       borderWidth={1}
       borderColor="$purple8"
       rounded="$4"
-      minW={300}
+      flex={1}
+      minW={140}
     >
       <Text fontWeight="700">candidate live slot</Text>
       <LiveSlotProvider>


### PR DESCRIPTION
Fixes the 5 native (iOS Detox) failures in `e2e/AdaptLiveSlotSpike.test.ts` and `e2e/DialogSheetAdaptHandoff.test.ts` that have been red since the Adapt live-slot feature landed. All failures were test-harness bugs; the product live-slot behavior on native is correct (verified locally: prop updates live-publish without remounting, instance stays alive across close-interrupted-by-reopen, sheet slot touch coordinates work).

## Root causes

**1. `expect(value).toBe(...)` can never pass under Detox (3 tests)**
`.detoxrc.js` sets `behavior.init.exposeGlobals: true`, which replaces the global `expect` with Detox's matcher-only expect. The tests aliased `expect as detoxExpect` on import but still used the bare global for plain value assertions, which throws `"<value>" is not a Detox matcher` unconditionally:
- AdaptLiveSlotSpike: "candidate live-publish updates props while active without remounting"
- DialogSheetAdaptHandoff: "live-publishes adapted Dialog prop updates without remounting content"
- DialogSheetAdaptHandoff: "keeps the adapted Dialog content instance alive when close is interrupted by reopen"

Fix: node `assert.strictEqual`/`notStrictEqual`, the existing convention in this e2e suite (see GroupPressNative etc). With that fixed, the underlying instance-stability assertions pass on native as-is.

**2. Elements below the fold with no way to scroll (2 tests)**
`AdaptLiveSlotSpikeCase` is ~2x taller than a phone screen and `DirectUseCaseHost` renders cases bare, so `sheet-live-slot-button` and `slot-state-increment` sat below the window bounds (`View is obscured by its window bounds`, view bounds y=1660 on a ~850pt screen). The web tests pass because Playwright auto-scrolls; Detox taps never scroll:
- AdaptLiveSlotSpike: "renders slot content as plain children inside a no-portal Sheet target with working touch coordinates"
- AdaptLiveSlotSpike: "state preservation characterization matches the measured v2 baseline"

Fix: wrap the case in a `ScrollView` and scroll elements into view in the native test (`waitFor(...).toBeVisible().whileElement(...).scroll(...)`). Two layout adjustments keep the interactions deterministic:
- the always-open native Sheet proof moved to the end of the case: its absolutely-positioned translated content must not share the viewport with the state panels while the test scrolls/taps them (an up-scroll gesture over the sheet region wedged app idle sync and hung the run)
- the two state panels are `flex={1} minW={140}` so they sit side by side on a phone and the toggle + increment buttons are co-visible after a single down-scroll (web layout unchanged: they already fit side by side at 760px)

## Validation

- iOS Detox locally (iPhone 17 Pro sim, `--retries 0`): both files **7/7 passed**, twice in a row, zero in-place jest retries, including after rebasing onto current v3-beta
- state-preservation observation matches the measured v2 baseline: `{"before":"slot instance: 5","adapted":"slot instance: 6","countAfterAdapt":"slot count: 0","countAfterReturn":"slot count: 0"}`
- unrelated Detox file `e2e/ThemeChangeBasic.test.ts`: 3/3 passed (no harness regression)
- web `tests/AdaptLiveSlotSpike.test.tsx` (usecase changed): 3/3 passed on current v3-beta base
- `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)