### PR TITLE
fix(core): v2 animated custom component + variant token crashes

### DIFF
--- a/code/core/core-test/styledContextTokens.web.test.tsx
+++ b/code/core/core-test/styledContextTokens.web.test.tsx
@@ -1,7 +1,14 @@
 import { beforeAll, describe, expect, test } from 'vitest'
 
 import config from '../config-default'
-import { View, Text, createStyledContext, createTamagui, styled } from '../core/src'
+import {
+  View,
+  Text,
+  createStyledContext,
+  createTamagui,
+  mergeComponentProps,
+  styled,
+} from '../core/src'
 // Stack was removed in v2 - use View instead (same props)
 import { simplifiedGetSplitStyles } from './utils'
 
@@ -29,6 +36,17 @@ beforeAll(() => {
  *   }
  */
 describe('styled context token preservation', () => {
+  test('undefined props preserve styled context tokens', () => {
+    const [props, overriddenContext] = mergeComponentProps(
+      null,
+      { size: '$true' },
+      { placement: 'left', size: undefined }
+    )
+
+    expect(props).toEqual({ size: '$true', placement: 'left' })
+    expect(overriddenContext).toBeNull()
+  })
+
   test('overriddenContextProps should contain original token values not CSS variables', () => {
     const GridContext = createStyledContext({
       gap: '$4',

--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -696,7 +696,11 @@ export function createComponent<
 
     if (process.env.NODE_ENV === 'development' && time) time`theme`
 
-    elementType = element || elementType
+    // don't replace the animated driver component (set above) with the base element,
+    // the render string is forwarded to it via viewProps.render instead
+    if (!isAnimatedCustomComponent) {
+      elementType = element || elementType
+    }
     const isStringElement = typeof elementType === 'string'
 
     const mediaState = useMedia(componentContext, debugProp)
@@ -1613,9 +1617,10 @@ export function createComponent<
       }
 
       if (!content) {
-        // web-only, handle render === string passing to custom animated component
-        if (isRenderPropString) {
-          viewProps.render === renderProp
+        // web-only, forward render string to custom animated driver components
+        // (they render the tag themselves, see acceptRenderProp in drivers)
+        if (isRenderPropString && elementType['acceptRenderProp']) {
+          viewProps.render = renderProp
         }
 
         content = React.createElement(elementType, viewProps, content || children)

--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -1612,7 +1612,13 @@ export function createComponent<
         )
         if (out) {
           viewProps = out.viewProps
-          elementType = out.elementType
+          if (isAnimatedCustomComponent && typeof out.elementType === 'string') {
+            if (elementType['acceptRenderProp']) {
+              viewProps.render = out.elementType
+            }
+          } else {
+            elementType = out.elementType
+          }
         }
       }
 

--- a/code/core/web/src/helpers/mergeProps.ts
+++ b/code/core/web/src/helpers/mergeProps.ts
@@ -75,7 +75,7 @@ export const mergeComponentProps = (
 
   // styled context props go after defaultProps but before props
   for (const key in contextProps) {
-    if (key in props) continue
+    if (props[key] !== undefined) continue
     const contextValue = contextProps[key]
     // don't merge undefined context values to preserve inheritance
     if (contextValue !== undefined) {
@@ -84,6 +84,7 @@ export const mergeComponentProps = (
   }
 
   for (const key in props) {
+    if (contextProps && key in contextProps && props[key] === undefined) continue
     mergeProp(out, defaultProps, props, key)
     if (contextProps && key in contextProps) {
       overriddenContext ||= {}

--- a/code/kitchen-sink/src/usecases/ButtonCustom.tsx
+++ b/code/kitchen-sink/src/usecases/ButtonCustom.tsx
@@ -28,6 +28,9 @@ export const ButtonCustom = Frame.styleable((props, ref) => {
       <ButtonStyled testID="button-styled" width={200}>
         test
       </ButtonStyled>
+      <ButtonStyled testID="button-styled-animated" transition="quick" width={200}>
+        animated
+      </ButtonStyled>
     </>
   ) as any
 })

--- a/code/kitchen-sink/tests/ButtonCustom.animated.test.tsx
+++ b/code/kitchen-sink/tests/ButtonCustom.animated.test.tsx
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+let pageErrors: Error[]
+
+test.beforeEach(async ({ page }) => {
+  pageErrors = []
+  page.on('pageerror', (error) => pageErrors.push(error))
+  await setupPage(page, { name: 'ButtonCustom', type: 'useCase' })
+})
+
+test('styled Button with an element render prop animates without errors', async ({
+  page,
+}) => {
+  await expect(page.getByRole('button', { name: 'animated' })).toBeVisible()
+  expect(pageErrors).toHaveLength(0)
+})

--- a/code/kitchen-sink/tests/SwitchStyled.test.tsx
+++ b/code/kitchen-sink/tests/SwitchStyled.test.tsx
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+// regression test: the styled Switch (SwitchFrame uses render="button") crashed
+// when animated ("Failed to set an indexed property [0] on 'CSSStyleDeclaration'")
+// because createComponent replaced the animation driver's custom component with
+// the raw render tag string, passing a react-native style array to a DOM element
+
+let pageErrors: Error[]
+
+test.beforeEach(async ({ page }) => {
+  pageErrors = []
+  page.on('pageerror', (error) => pageErrors.push(error))
+  await setupPage(page, { name: 'Switch', type: 'demo' })
+})
+
+test('styled Switch demo renders and toggles without errors', async ({ page }) => {
+  const switches = page.locator('[role="switch"]')
+  await expect(switches.first()).toBeVisible()
+  expect(await switches.count()).toBe(6)
+
+  const first = switches.first()
+  await expect(first).toHaveAttribute('aria-checked', 'false')
+  await first.click()
+  await expect(first).toHaveAttribute('aria-checked', 'true')
+
+  expect(pageErrors).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary
- keep custom animation-driver components when `render` is a string or an intrinsic React element, forwarding the intrinsic tag to drivers that accept it
- preserve styled-context token values when an explicitly present runtime prop is `undefined`
- add regressions for animated `styled(Button)` and styled-context token inheritance

## Root causes

For animated components, the string `render` path replaced the animation driver before this branch. The remaining `Button` failure used `render={<button />}`: `getCustomRender()` replaced the driver later in the render pipeline, sending an RN style array directly to the DOM button. Intrinsic render elements now retain the animated component; drivers with `acceptRenderProp` receive the tag through `viewProps.render`.

The variant token crash was separate from the v3 boolean-token shorthand fix. `SwitchCustomIcons` passed `size={undefined}`. `mergeComponentProps()` treated that as an override of the Switch styled-context `$true` size token, so the placement functional variant evaluated `tokens.space[undefined].val`. Undefined context props now inherit the context token and are not recorded as overrides.

## Validation
- reproduced Bento crashes on `ButtonPulse`, `IconTitleSwitch`, and `SwitchCustomIcons`
- patched Bento npm dist and confirmed all three pages render and interact with zero page errors via Playwright screenshots
- `@tamagui/web`: 61 tests passed, no type errors
- styled-context token regression: 4 tests passed
- animated styled Button regression: CSS, native, reanimated, and motion drivers passed
- existing styled Switch regression passed
- root `bun run build`: 162/162 package builds passed