### PR TITLE
fix(animations): avoid forwarding nativeID to DOM

### DIFF
--- a/code/core/animations-moti/src/createAnimations.tsx
+++ b/code/core/animations-moti/src/createAnimations.tsx
@@ -91,8 +91,9 @@ function createTamaguiAnimatedComponent(defaultTag = 'div') {
       const props = result?.viewProps || {}
       const Element = render
       const transformedProps = hooks.usePropsTransform?.(render, props, stateRef, false)
+      const { nativeID, ...webProps } = transformedProps ?? props
 
-      return <Element {...transformedProps} ref={composedRefs} />
+      return <Element {...webProps} ref={composedRefs} />
     })
   )
   Component['acceptRenderProp'] = true

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -313,8 +313,9 @@ function createWebAnimatedComponent(defaultTag: 'div' | 'span') {
         stateRef as any,
         false
       )
+      const { nativeID, ...webProps } = transformedProps ?? viewProps
 
-      return <Element {...transformedProps} ref={composedRefs} />
+      return <Element {...webProps} ref={composedRefs} />
     })
   )
   ;(Component as any).acceptRenderProp = true

--- a/code/kitchen-sink/src/usecases/AnimatedDOMPropsCase.tsx
+++ b/code/kitchen-sink/src/usecases/AnimatedDOMPropsCase.tsx
@@ -1,0 +1,13 @@
+import { YStack } from 'tamagui'
+
+export function AnimatedDOMPropsCase() {
+  return (
+    <YStack
+      testID="animated-dom-props"
+      nativeID="animated-dom-props-native"
+      transition="200ms"
+      bg="$color1"
+      p="$4"
+    />
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -29,6 +29,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
   RawAnimatedValueCase: () => require('./RawAnimatedValueCase').RawAnimatedValueCase,
   AnimationsWithMediaQueriesCase: () =>
     require('./AnimationsWithMediaQueriesCase').AnimationsWithMediaQueriesCase,
+  AnimatedDOMPropsCase: () => require('./AnimatedDOMPropsCase').AnimatedDOMPropsCase,
   ThemeMediaAnimationCase: () =>
     require('./ThemeMediaAnimationCase').ThemeMediaAnimationCase,
   Benchmark: () => require('./Benchmark').Benchmark,

--- a/code/kitchen-sink/tests/AnimatedDOMProps.animated.test.tsx
+++ b/code/kitchen-sink/tests/AnimatedDOMProps.animated.test.tsx
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test'
+import { setupPage } from './test-utils'
+
+test('Reanimated web wrapper does not forward nativeID', async ({ page }, testInfo) => {
+  test.skip(
+    testInfo.project.name !== 'animated-reanimated',
+    'Only the Reanimated project uses the tested custom web wrapper'
+  )
+
+  const messages: string[] = []
+  page.on('console', (message) => messages.push(message.text()))
+
+  await setupPage(page, {
+    name: 'AnimatedDOMPropsCase',
+    type: 'useCase',
+  })
+
+  const animated = page.getByTestId('animated-dom-props')
+  await expect(animated).not.toHaveAttribute('nativeID')
+  expect(messages.some((message) => message.includes('nativeID'))).toBe(false)
+})


### PR DESCRIPTION
## Root cause

The Moti and Reanimated web drivers transform Tamagui props and then spread the result directly onto a raw `div`/`span`. React Native `nativeID` survives that transform, so React warns and emits a lowercase `nativeid` DOM attribute.

This strips `nativeID` at the raw DOM boundary in both custom wrappers while preserving every other transformed prop.

## Regression coverage

- Adds an animated kitchen-sink case with an explicit `nativeID`.
- Verifies the Reanimated web wrapper emits neither the attribute nor the React console warning.

## Validation

- `PORT=9010 bun run test:web:seq tests/AnimatedDOMProps.animated.test.tsx` — 1 passed, 3 expected driver skips.
- Core web suite — 23 files, 185 tests passed.
- `bun run build` — 162 tasks successful.
- Bento Moti `ButtonPulse` repro — 0 `[nativeID]`/`[nativeid]` nodes and no nativeID console warnings.