### PR TITLE
fix(button): don't clobber user-passed tabIndex

### DIFF
--- a/code/ui/button/src/Button.tsx
+++ b/code/ui/button/src/Button.tsx
@@ -342,7 +342,6 @@ const ButtonComponent = Frame.styleable<ButtonExtraProps>((propsIn, ref) => {
           {...(isNested && { render: 'span' })}
           // pass resolved size to circular variant when no explicit size provided
           {...(props.circular && !propsIn.size && { size })}
-          tabIndex={0}
         >
           {themedIcon}
           {wrappedChildren}


### PR DESCRIPTION
Button hardcoded `tabIndex={0}` after spreading `{...props}` onto Frame, so a user-passed `tabIndex` could never win. The Frame styled config already defaults `tabIndex: 0`, so the explicit override is redundant and removing it restores normal prop precedence.

Found while implementing roving tabindex (calendar grid) in Bento: all 42 day buttons rendered `tabindex="0"` despite passing `tabIndex={focused ? 0 : -1}`, creating 42 tab stops. Same clobber prevents removing disabled buttons from the tab order.

Validated at runtime by applying the equivalent patch to the built dist in the bento repo: roving tabindex then renders exactly one `tabindex="0"` day, defaults stay `0` for buttons that don't pass the prop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)