### PR TITLE
fix(toast): clear close timer on unmount so replaced toasts can't hide the current one

### DIFF
--- a/code/ui/toast/src/ToastImpl.tsx
+++ b/code/ui/toast/src/ToastImpl.tsx
@@ -252,6 +252,11 @@ const ToastImpl = React.forwardRef<TamaguiElement, ToastImplProps>(
       if (open && !context.isClosePausedRef.current) {
         startTimer(duration)
       }
+      // clear on unmount: a replaced toast's stale timer would otherwise
+      // fire later and hide() whatever toast is currently showing
+      return () => {
+        clearTimeout(closeTimerRef.current)
+      }
     }, [open, duration, context.isClosePausedRef, startTimer])
 
     React.useEffect(() => {


### PR DESCRIPTION
When a toast is replaced (imperative `toast.show` while another toast is visible), the replaced `ToastImpl` unmounts but its `closeTimerRef` timeout keeps running. When it fires, `handleClose` runs on the unmounted instance and calls the controller `hide()`, which hides whatever toast is currently showing.

Repro (found in Bento's ToastPromise demo): show toast A (default duration), replace it with toast B before A's timer fires → B disappears when A's stale timer fires, regardless of B's own (longer) duration. Measured: an error toast with `duration: 8000` died ~200ms after mounting.

Fix: return a cleanup from the timer effect clearing `closeTimerRef.current` on unmount/dep change. Pause/resume behavior is untouched since those paths re-arm the timer while mounted.

Validated at runtime by applying the equivalent patch to the built dist in the bento repo: with the cleanup, the replacing toast lives out its own duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)