### PR TITLE
fix(to-tailwind): borderWidth={1} emits bare `border`, not dangling `border-`

### DIFF
--- a/code/core/to-tailwind/src/__tests__/transform.test.ts
+++ b/code/core/to-tailwind/src/__tests__/transform.test.ts
@@ -39,6 +39,13 @@ describe('tamaguiToTailwind', () => {
       expect(output).toContain('opacity-50')
     })
 
+    test('borderWidth 1 emits bare `border`, not `border-`', () => {
+      const output = tamaguiToTailwind(`<View borderWidth={1} borderColor="$borderColor" />`)
+      expect(output).toContain('border border-borderColor')
+      // regression: the 1px default must not leave a dangling `border-`
+      expect(output).not.toMatch(/border-(?=\s|")/)
+    })
+
     test('token reference strips $', () => {
       const input = `<View backgroundColor="$blue5" />`
       const output = tamaguiToTailwind(input)

--- a/code/core/to-tailwind/src/__tests__/transform.test.ts
+++ b/code/core/to-tailwind/src/__tests__/transform.test.ts
@@ -40,7 +40,9 @@ describe('tamaguiToTailwind', () => {
     })
 
     test('borderWidth 1 emits bare `border`, not `border-`', () => {
-      const output = tamaguiToTailwind(`<View borderWidth={1} borderColor="$borderColor" />`)
+      const output = tamaguiToTailwind(
+        `<View borderWidth={1} borderColor="$borderColor" />`
+      )
       expect(output).toContain('border border-borderColor')
       // regression: the 1px default must not leave a dangling `border-`
       expect(output).not.toMatch(/border-(?=\s|")/)

--- a/code/core/to-tailwind/src/__tests__/transform.test.ts
+++ b/code/core/to-tailwind/src/__tests__/transform.test.ts
@@ -48,6 +48,19 @@ describe('tamaguiToTailwind', () => {
       expect(output).not.toMatch(/border-(?=\s|")/)
     })
 
+    test('directional borderWidth 1 emits bare `border-t`, not `border-t-`', () => {
+      expect(tamaguiToTailwind(`<View borderTopWidth={1} />`)).toContain(
+        'className="border-t"'
+      )
+      expect(tamaguiToTailwind(`<View borderBottomWidth={1} />`)).toContain(
+        'className="border-b"'
+      )
+      // non-1 widths still get the numeric suffix
+      expect(tamaguiToTailwind(`<View borderTopWidth={2} />`)).toContain(
+        'className="border-t-2"'
+      )
+    })
+
     test('token reference strips $', () => {
       const input = `<View backgroundColor="$blue5" />`
       const output = tamaguiToTailwind(input)

--- a/code/core/to-tailwind/src/transform.ts
+++ b/code/core/to-tailwind/src/transform.ts
@@ -211,7 +211,9 @@ function propValueToClass(
   // some props use standalone classes (like `flex-1`)
   if (prefix === '') return modifier ? `${modifier}:${tailwindValue}` : tailwindValue
 
-  const cls = `${prefix}-${tailwindValue}`
+  // an empty tailwindValue means the bare prefix IS the class (e.g. tailwind's
+  // `border` = 1px), so don't emit a dangling `border-`
+  const cls = tailwindValue === '' ? prefix : `${prefix}-${tailwindValue}`
   return modifier ? `${modifier}:${cls}` : cls
 }
 


### PR DESCRIPTION
## what

The `@tamagui/to-tailwind` converter emitted a dangling `border-` class for
`borderWidth={1}` (Tailwind's `border` = 1px). Root cause: `transform.ts`
`propValueToClass` joins `${prefix}-${tailwindValue}`, and the 1px case returns
an empty `tailwindValue`, producing `border-` instead of the bare `border`.

## reproduction (before)

```
<View borderWidth={1} />                          => className="border-"
<View borderWidth={1} borderColor="$borderColor" /> => className="border- border-borderColor"
```

## after

```
<View borderWidth={1} />                          => className="border"
<View borderWidth={1} borderColor="$borderColor" /> => className="border border-borderColor"
<View borderWidth={2} />                          => className="border-2"   (unchanged)
```

## fix

When `tailwindValue` is empty, emit the bare `prefix` (the prefix itself is the
class) instead of `${prefix}-`.

## proof

- Added a regression test asserting `border border-borderColor` and no dangling
  `border-`.
- `@tamagui/to-tailwind` `test:web`: **40/40 pass**.

## context

Surfaced while converting Soot's `templates/app` to Tailwind against the v3
beta: across all 70 template `.tsx`, this was the sole source of dangling
classes; with the fix, the bulk codemod produces **zero** dangling classes.