### PR TITLE
feat(compiler): evaluate Vite config with ModuleRunner

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -224,7 +224,7 @@
         "@tamagui/proxy-worm": "workspace:*",
         "@tamagui/react-native-svg": "workspace:*",
         "@tamagui/react-native-web-lite": "workspace:*",
-        "@tamagui/static-worker": "workspace:*",
+        "@tamagui/static": "workspace:*",
         "@tamagui/types": "workspace:*",
         "esm-resolve": "^1.0.8",
         "fs-extra": "^11.2.0",
@@ -234,6 +234,7 @@
       "devDependencies": {
         "@tamagui/build": "workspace:*",
         "vite": "^8.0.3",
+        "vitest": "4.0.4",
       },
       "peerDependencies": {
         "vite": "^8.0.3",
@@ -245,6 +246,22 @@
       "dependencies": {
         "@tamagui/vite-plugin": "workspace:*",
       },
+    },
+    "code/compiler/vite-plugin/test/fixtures/module-runner": {
+      "name": "@fixture/module-runner-app",
+      "dependencies": {
+        "@fixture/components": "workspace:*",
+        "@fixture/conditional": "workspace:*",
+      },
+    },
+    "code/compiler/vite-plugin/test/fixtures/module-runner/packages/components": {
+      "name": "@fixture/components",
+      "dependencies": {
+        "@fixture/conditional": "workspace:*",
+      },
+    },
+    "code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional": {
+      "name": "@fixture/conditional",
     },
     "code/core/animation-helpers": {
       "name": "@tamagui/animation-helpers",
@@ -4053,6 +4070,12 @@
     "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
 
     "@fastify/websocket": ["@fastify/websocket@11.2.0", "", { "dependencies": { "duplexify": "^4.1.3", "fastify-plugin": "^5.0.0", "ws": "^8.16.0" } }, "sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w=="],
+
+    "@fixture/components": ["@fixture/components@workspace:code/compiler/vite-plugin/test/fixtures/module-runner/packages/components"],
+
+    "@fixture/conditional": ["@fixture/conditional@workspace:code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional"],
+
+    "@fixture/module-runner-app": ["@fixture/module-runner-app@workspace:code/compiler/vite-plugin/test/fixtures/module-runner"],
 
     "@flatten-js/interval-tree": ["@flatten-js/interval-tree@1.1.4", "", {}, "sha512-o4emRDDvGdkwX18BSVSXH8q27qAL7Z2WDHSN75C8xyRSE4A8UOkig0mWSGoT5M5KaTHZxoLmalFwOTQmbRusUg=="],
 

--- a/code/compiler/static-tests/tests/loadTamagui.web.test.tsx
+++ b/code/compiler/static-tests/tests/loadTamagui.web.test.tsx
@@ -32,6 +32,7 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(tempDir, { recursive: true, force: true })
   vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
 })
 
 describe('resolveWebOrNativeSpecificEntry', () => {
@@ -124,32 +125,84 @@ describe('esbundleTamaguiConfig platform defines', () => {
 })
 
 describe('loadTamaguiFromModules', () => {
-  test('synchronizes media from an already-parsed evaluated config', async () => {
+  test('parses an unparsed config without browser CSS discovery', async () => {
+    const hostCore = createRequire(import.meta.url)(
+      '@tamagui/core'
+    ) as typeof import('@tamagui/core')
+    const previousHostConfig = hostCore.createTamagui(defaultConfig)
+    const rawConfig = {
+      ...defaultConfig,
+      themes: {},
+    }
+
+    try {
+      vi.stubEnv('NODE_ENV', 'production')
+      vi.stubEnv('TAMAGUI_TARGET', 'web')
+      vi.stubGlobal('document', undefined)
+
+      const project = await loadTamaguiFromModules(
+        { platform: 'web', components: [] },
+        { config: { default: rawConfig }, components: [] }
+      )
+
+      expect(project.tamaguiConfig).not.toBe(rawConfig)
+      expect(project.tamaguiConfig.parsed).toBe(true)
+      expect(hostCore.getConfig()).toBe(project.tamaguiConfig)
+    } finally {
+      hostCore.installTamaguiConfig(previousHostConfig)
+    }
+
+    expect(hostCore.getConfig()).toBe(previousHostConfig)
+  })
+
+  test('installs an already-parsed evaluated config without browser CSS discovery', async () => {
     const hostCore = createRequire(import.meta.url)(
       '@tamagui/core'
     ) as typeof import('@tamagui/core')
     const hostMediaQueryConfig = hostCore.mediaQueryConfig
+    const previousHostConfig = hostCore.createTamagui(defaultConfig)
     const evaluatedConfig = createTamagui(defaultConfig)
-    const boundaryMedia = { minWidth: 4321 }
+    const boundaryMedia = { ...evaluatedConfig.media.sm, minWidth: 4321 }
     const parsedConfig = {
       ...evaluatedConfig,
+      themes: {},
       media: {
         ...evaluatedConfig.media,
-        evaluatedBoundary: boundaryMedia,
+        sm: boundaryMedia,
       },
     }
+    const tokenName = Object.keys(parsedConfig.tokens.space)[0]
+    const unprefixedTokenName = tokenName[0] === '$' ? tokenName.slice(1) : tokenName
+    const prefixedTokenName = `$${unprefixedTokenName}`
 
     expect(hostMediaQueryConfig).not.toBe(mediaQueryConfig)
-    expect(hostMediaQueryConfig.evaluatedBoundary).toBeUndefined()
+    expect(hostMediaQueryConfig.sm).not.toEqual(boundaryMedia)
 
-    const project = await loadTamaguiFromModules(
-      { platform: 'web', components: [] },
-      { config: { default: parsedConfig }, components: [] }
-    )
+    try {
+      vi.stubEnv('NODE_ENV', 'production')
+      vi.stubEnv('TAMAGUI_TARGET', 'web')
+      vi.stubGlobal('document', undefined)
 
-    expect(project.tamaguiConfig).toBe(parsedConfig)
-    expect(hostMediaQueryConfig.evaluatedBoundary).toEqual(boundaryMedia)
+      const project = await loadTamaguiFromModules(
+        { platform: 'web', components: [] },
+        { config: { default: parsedConfig }, components: [] }
+      )
 
-    delete hostMediaQueryConfig.evaluatedBoundary
+      const hostTokens = hostCore.getTokens()
+      expect(project.tamaguiConfig).toBe(parsedConfig)
+      expect(hostCore.getConfig()).toBe(parsedConfig)
+      expect(hostMediaQueryConfig.sm).toEqual(boundaryMedia)
+      expect(hostTokens.space[unprefixedTokenName]).toBe(
+        parsedConfig.tokens.space[tokenName]
+      )
+      expect(hostTokens.space[prefixedTokenName]).toBe(
+        parsedConfig.tokensParsed.space[prefixedTokenName]
+      )
+    } finally {
+      hostCore.installTamaguiConfig(previousHostConfig)
+    }
+
+    expect(hostCore.getConfig()).toBe(previousHostConfig)
+    expect(hostMediaQueryConfig.sm).toEqual(previousHostConfig.media.sm)
   })
 })

--- a/code/compiler/static-tests/tests/loadTamagui.web.test.tsx
+++ b/code/compiler/static-tests/tests/loadTamagui.web.test.tsx
@@ -1,8 +1,15 @@
 import { mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { defaultConfig } from '@tamagui/config/v4'
+import { createTamagui, mediaQueryConfig } from '@tamagui/core'
+import {
+  esbundleTamaguiConfig,
+  loadTamaguiFromModules,
+  resolveWebOrNativeSpecificEntry,
+} from '@tamagui/static'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
-import { esbundleTamaguiConfig, resolveWebOrNativeSpecificEntry } from '@tamagui/static'
 
 // regression: vite-plugin doesn't set process.env.TAMAGUI_TARGET (vxrn handles
 // both web and native through the same plugin), so the static extractor must
@@ -113,5 +120,36 @@ describe('esbundleTamaguiConfig platform defines', () => {
     expect(out).toContain('"native"')
     // EXPO_OS shouldn't be inlined for native (ios vs android is ambiguous)
     expect(out).toContain('process.env.EXPO_OS')
+  })
+})
+
+describe('loadTamaguiFromModules', () => {
+  test('synchronizes media from an already-parsed evaluated config', async () => {
+    const hostCore = createRequire(import.meta.url)(
+      '@tamagui/core'
+    ) as typeof import('@tamagui/core')
+    const hostMediaQueryConfig = hostCore.mediaQueryConfig
+    const evaluatedConfig = createTamagui(defaultConfig)
+    const boundaryMedia = { minWidth: 4321 }
+    const parsedConfig = {
+      ...evaluatedConfig,
+      media: {
+        ...evaluatedConfig.media,
+        evaluatedBoundary: boundaryMedia,
+      },
+    }
+
+    expect(hostMediaQueryConfig).not.toBe(mediaQueryConfig)
+    expect(hostMediaQueryConfig.evaluatedBoundary).toBeUndefined()
+
+    const project = await loadTamaguiFromModules(
+      { platform: 'web', components: [] },
+      { config: { default: parsedConfig }, components: [] }
+    )
+
+    expect(project.tamaguiConfig).toBe(parsedConfig)
+    expect(hostMediaQueryConfig.evaluatedBoundary).toEqual(boundaryMedia)
+
+    delete hostMediaQueryConfig.evaluatedBoundary
   })
 })

--- a/code/compiler/static/src/exports.ts
+++ b/code/compiler/static/src/exports.ts
@@ -1,6 +1,6 @@
 export * from './checkDeps'
 export * from './types'
-export { createExtractor } from './extractor/createExtractor'
+export { createExtractor, type Extractor } from './extractor/createExtractor'
 export { literalToAst } from './extractor/literalToAst'
 export * from './constants'
 export * from './extractor/extractToClassNames'

--- a/code/compiler/static/src/extractor/bundleConfig.ts
+++ b/code/compiler/static/src/extractor/bundleConfig.ts
@@ -230,6 +230,9 @@ export function hasBundledConfigChanged() {
 let loadedConfig: TamaguiInternalConfig | null = null
 
 export const getLoadedConfig = () => loadedConfig
+export const setLoadedConfig = (config: TamaguiInternalConfig) => {
+  loadedConfig = config
+}
 
 function getBundleKey(props: TamaguiOptions) {
   return JSON.stringify({
@@ -886,7 +889,7 @@ const esbuildit = (src: string, target?: 'modern') => {
   }).code
 }
 
-function getComponentStaticConfigByName(name: string, exported: any) {
+export function getComponentStaticConfigByName(name: string, exported: any) {
   const components: Record<string, { staticConfig: StaticConfig }> = {}
   try {
     if (!exported || typeof exported !== 'object' || Array.isArray(exported)) {

--- a/code/compiler/static/src/extractor/createExtractor.ts
+++ b/code/compiler/static/src/extractor/createExtractor.ts
@@ -132,7 +132,12 @@ function hasUntilMeasuredAncestor(path: NodePath<any>, groupName: string): boole
 }
 
 export function createExtractor(
-  { logger = console, platform = 'web' }: ExtractorOptions = { logger: console }
+  {
+    logger = console,
+    platform = 'web',
+    loadTamagui: loadTamaguiProject = loadTamagui,
+    loadTamaguiSync: loadTamaguiProjectSync = loadTamaguiSync,
+  }: ExtractorOptions = { logger: console }
 ) {
   const INLINE_EXTRACTABLE = {
     ref: 'ref',
@@ -279,14 +284,17 @@ export function createExtractor(
     if (isFullyDisabled(props)) {
       return null
     }
-    return (projectInfo ||= loadTamaguiSync(props))
+    if (!loadTamaguiProjectSync) {
+      return projectInfo
+    }
+    return (projectInfo ||= loadTamaguiProjectSync(props))
   }
 
   async function load(props: TamaguiOptions) {
     if (isFullyDisabled(props)) {
       return null
     }
-    return (projectInfo ||= await loadTamagui(props))
+    return (projectInfo ||= await loadTamaguiProject(props))
   }
 
   return {
@@ -726,7 +734,11 @@ export function createExtractor(
               )
             }
 
-            const out = loadTamaguiSync({
+            if (!loadTamaguiProjectSync) {
+              return
+            }
+
+            const out = loadTamaguiProjectSync({
               forceExports: true,
               components: [sourcePath],
               cacheKey: version,
@@ -989,7 +1001,11 @@ export function createExtractor(
                     // proactively load the file
                     dynamicLoadingInProgress.add(resolved)
                     try {
-                      const out = loadTamaguiSync({
+                      if (!loadTamaguiProjectSync) {
+                        return
+                      }
+
+                      const out = loadTamaguiProjectSync({
                         forceExports: true,
                         components: [resolved],
                       })

--- a/code/compiler/static/src/extractor/loadTamagui.ts
+++ b/code/compiler/static/src/extractor/loadTamagui.ts
@@ -9,13 +9,15 @@ import * as fsExtra from 'fs-extra'
 
 import { SHOULD_DEBUG } from '../constants'
 import { requireTamaguiCore } from '../helpers/requireTamaguiCore'
-import { getNameToPaths, registerRequire } from '../registerRequire'
+import { getNameToPaths, registerRequire, setRequireResult } from '../registerRequire'
 import {
   type TamaguiProjectInfo,
+  getComponentStaticConfigByName,
   getBundledConfig,
   getLoadedConfig,
   hasBundledConfigChanged,
   loadComponentsSync,
+  setLoadedConfig,
   writeTamaguiCSS,
 } from './bundleConfig'
 import { getTamaguiConfigPathFromOptionsConfig } from './getTamaguiConfigPathFromOptionsConfig'
@@ -84,6 +86,77 @@ export async function loadTamagui(
   } finally {
     isLoadingPromise = null
   }
+}
+
+export type EvaluatedTamaguiModule = {
+  moduleName: string
+  module: Record<string, unknown>
+}
+
+export type EvaluatedTamaguiProject = {
+  config: Record<string, unknown>
+  components: EvaluatedTamaguiModule[]
+}
+
+/**
+ * Load a Tamagui project from modules evaluated by the host bundler.
+ *
+ * Bundler adapters with a module runner use this boundary so aliases, package
+ * conditions, and user plugins are identical between application and compiler
+ * evaluation. Adapters without a module runner continue to use loadTamagui().
+ */
+export async function loadTamaguiFromModules(
+  propsIn: Partial<TamaguiOptions>,
+  evaluated: EvaluatedTamaguiProject
+): Promise<TamaguiProjectInfo> {
+  const props = getFilledOptions(propsIn)
+
+  await generateThemesAndLog(props)
+
+  const configModule = evaluated.config as any
+  let tamaguiConfig = (configModule.default || configModule.config || configModule) as
+    | TamaguiInternalConfig
+    | { config?: TamaguiInternalConfig }
+
+  if ('config' in tamaguiConfig && tamaguiConfig.config && !('tokens' in tamaguiConfig)) {
+    tamaguiConfig = tamaguiConfig.config
+  }
+
+  if (!tamaguiConfig || (tamaguiConfig as any)._isProxyWorm) {
+    throw new Error(`The Vite module runner did not return a valid Tamagui config`)
+  }
+
+  const { createTamagui } = requireTamaguiCore(props.platform || 'web')
+  if (!(tamaguiConfig as TamaguiInternalConfig).parsed) {
+    tamaguiConfig = createTamagui(tamaguiConfig as any) as TamaguiInternalConfig
+  } else {
+    // Module runners can evaluate the config in a separate Tamagui module
+    // instance. Mirror loadTamaguiSync's host-side setup so module-local state
+    // such as mediaQueryConfig matches the evaluated project config.
+    createTamagui(tamaguiConfig as any)
+  }
+
+  setLoadedConfig(tamaguiConfig as TamaguiInternalConfig)
+
+  const components = evaluated.components.map(({ moduleName, module }) => {
+    setRequireResult(moduleName, module)
+    return {
+      moduleName,
+      nameToInfo: getComponentStaticConfigByName(moduleName, module.default ?? module),
+    }
+  })
+
+  const projectInfo = {
+    components,
+    nameToPaths: {},
+    tamaguiConfig: tamaguiConfig as TamaguiInternalConfig,
+  } satisfies TamaguiProjectInfo
+
+  if (props.outputCSS) {
+    await writeTamaguiCSS(props.outputCSS, projectInfo.tamaguiConfig)
+  }
+
+  return projectInfo
 }
 
 // debounce a bit

--- a/code/compiler/static/src/extractor/loadTamagui.ts
+++ b/code/compiler/static/src/extractor/loadTamagui.ts
@@ -126,14 +126,14 @@ export async function loadTamaguiFromModules(
     throw new Error(`The Vite module runner did not return a valid Tamagui config`)
   }
 
-  const { createTamagui } = requireTamaguiCore(props.platform || 'web')
+  const hostCore = requireTamaguiCore(props.platform || 'web')
   if (!(tamaguiConfig as TamaguiInternalConfig).parsed) {
-    tamaguiConfig = createTamagui(tamaguiConfig as any) as TamaguiInternalConfig
+    tamaguiConfig = hostCore.createTamagui(tamaguiConfig as any) as TamaguiInternalConfig
   } else {
     // Module runners can evaluate the config in a separate Tamagui module
-    // instance. Mirror loadTamaguiSync's host-side setup so module-local state
-    // such as mediaQueryConfig matches the evaluated project config.
-    createTamagui(tamaguiConfig as any)
+    // instance. Install the already-parsed config so host module-local state
+    // matches without re-parsing it or running browser-only CSS discovery.
+    hostCore.installTamaguiConfig(tamaguiConfig as TamaguiInternalConfig)
   }
 
   setLoadedConfig(tamaguiConfig as TamaguiInternalConfig)

--- a/code/compiler/static/src/types.ts
+++ b/code/compiler/static/src/types.ts
@@ -5,7 +5,7 @@ import type { StyleObject } from '@tamagui/helpers'
 import type { TamaguiOptions } from '@tamagui/types'
 import type { ViewStyle } from 'react-native'
 
-import type { LoadedComponents } from './extractor/bundleConfig'
+import type { LoadedComponents, TamaguiProjectInfo } from './extractor/bundleConfig'
 
 export type TamaguiPlatform = 'native' | 'web'
 
@@ -34,6 +34,12 @@ export interface Logger {
 export type ExtractorOptions = {
   logger?: Logger
   platform?: TamaguiPlatform
+  loadTamagui?: (props: TamaguiOptions) => Promise<TamaguiProjectInfo | null>
+  loadTamaguiSync?:
+    | false
+    | ((
+        props: Parameters<typeof import('./extractor/loadTamagui').loadTamaguiSync>[0]
+      ) => TamaguiProjectInfo)
 }
 
 export type ExtractedAttrAttr = {

--- a/code/compiler/static/types/exports.d.ts
+++ b/code/compiler/static/types/exports.d.ts
@@ -1,6 +1,6 @@
 export * from './checkDeps';
 export * from './types';
-export { createExtractor } from './extractor/createExtractor';
+export { createExtractor, type Extractor } from './extractor/createExtractor';
 export { literalToAst } from './extractor/literalToAst';
 export * from './constants';
 export * from './extractor/extractToClassNames';

--- a/code/compiler/static/types/extractor/bundleConfig.d.ts
+++ b/code/compiler/static/types/extractor/bundleConfig.d.ts
@@ -38,6 +38,7 @@ export declare const esbuildOptionsWithPlugins: {
 export type BundledConfig = Exclude<Awaited<ReturnType<typeof bundleConfig>>, undefined>;
 export declare function hasBundledConfigChanged(): boolean;
 export declare const getLoadedConfig: () => TamaguiInternalConfig | null;
+export declare const setLoadedConfig: (config: TamaguiInternalConfig) => void;
 export declare function getBundledConfig(props: TamaguiOptions, rebuild?: boolean): Promise<any>;
 export declare function bundleConfig(props: TamaguiOptions): Promise<any>;
 export declare function writeTamaguiCSS(outputCSS: string, config: TamaguiInternalConfig): Promise<void>;
@@ -45,5 +46,8 @@ export declare function loadComponents(props: TamaguiOptions, forceExports?: boo
 export declare function loadComponentsSync(props: TamaguiOptions, forceExports?: boolean): LoadedComponents[];
 export declare function loadComponentsInner(props: TamaguiOptions, forceExports?: boolean): Promise<null | LoadedComponents[]>;
 export declare function loadComponentsInnerSync(props: TamaguiOptions, forceExports?: boolean): null | LoadedComponents[];
+export declare function getComponentStaticConfigByName(name: string, exported: any): Record<string, {
+    staticConfig: StaticConfig;
+}>;
 export {};
 //# sourceMappingURL=bundleConfig.d.ts.map

--- a/code/compiler/static/types/extractor/createExtractor.d.ts
+++ b/code/compiler/static/types/extractor/createExtractor.d.ts
@@ -5,7 +5,7 @@ import type { TamaguiProjectInfo } from './bundleConfig';
 import { cleanupBeforeExit } from './getStaticBindingsForScope';
 export type Extractor = ReturnType<typeof createExtractor>;
 type FileOrPath = NodePath<t.Program> | t.File;
-export declare function createExtractor({ logger, platform }?: ExtractorOptions): {
+export declare function createExtractor({ logger, platform, loadTamagui: loadTamaguiProject, loadTamaguiSync: loadTamaguiProjectSync, }?: ExtractorOptions): {
     options: {
         logger: import("../types").Logger;
     };

--- a/code/compiler/static/types/extractor/loadTamagui.d.ts
+++ b/code/compiler/static/types/extractor/loadTamagui.d.ts
@@ -1,6 +1,22 @@
 import type { CLIResolvedOptions, CLIUserOptions, TamaguiOptions } from '@tamagui/types';
 import { type TamaguiProjectInfo } from './bundleConfig';
 export declare function loadTamagui(propsIn: Partial<TamaguiOptions>): Promise<TamaguiProjectInfo | null>;
+export type EvaluatedTamaguiModule = {
+    moduleName: string;
+    module: Record<string, unknown>;
+};
+export type EvaluatedTamaguiProject = {
+    config: Record<string, unknown>;
+    components: EvaluatedTamaguiModule[];
+};
+/**
+ * Load a Tamagui project from modules evaluated by the host bundler.
+ *
+ * Bundler adapters with a module runner use this boundary so aliases, package
+ * conditions, and user plugins are identical between application and compiler
+ * evaluation. Adapters without a module runner continue to use loadTamagui().
+ */
+export declare function loadTamaguiFromModules(propsIn: Partial<TamaguiOptions>, evaluated: EvaluatedTamaguiProject): Promise<TamaguiProjectInfo>;
 export declare const generateThemesAndLog: (options: TamaguiOptions, force?: boolean) => Promise<void>;
 /**
  * Load tamagui.build.ts config using esbuild-wasm transform

--- a/code/compiler/static/types/types.d.ts
+++ b/code/compiler/static/types/types.d.ts
@@ -4,7 +4,7 @@ import type { PseudoStyles, StaticConfig, TamaguiConfig } from '@tamagui/core';
 import type { StyleObject } from '@tamagui/helpers';
 import type { TamaguiOptions } from '@tamagui/types';
 import type { ViewStyle } from 'react-native';
-import type { LoadedComponents } from './extractor/bundleConfig';
+import type { LoadedComponents, TamaguiProjectInfo } from './extractor/bundleConfig';
 export type TamaguiPlatform = 'native' | 'web';
 export type { TamaguiOptions, TamaguiBuildOptions } from '@tamagui/types';
 export type { StyleObject } from '@tamagui/helpers';
@@ -25,6 +25,8 @@ export interface Logger {
 export type ExtractorOptions = {
     logger?: Logger;
     platform?: TamaguiPlatform;
+    loadTamagui?: (props: TamaguiOptions) => Promise<TamaguiProjectInfo | null>;
+    loadTamaguiSync?: false | ((props: Parameters<typeof import('./extractor/loadTamagui').loadTamaguiSync>[0]) => TamaguiProjectInfo);
 };
 export type ExtractedAttrAttr = {
     type: 'attr';

--- a/code/compiler/vite-plugin/package.json
+++ b/code/compiler/vite-plugin/package.json
@@ -36,7 +36,7 @@
     "@tamagui/proxy-worm": "workspace:*",
     "@tamagui/react-native-svg": "workspace:*",
     "@tamagui/react-native-web-lite": "workspace:*",
-    "@tamagui/static-worker": "workspace:*",
+    "@tamagui/static": "workspace:*",
     "@tamagui/types": "workspace:*",
     "esm-resolve": "^1.0.8",
     "fs-extra": "^11.2.0",
@@ -45,7 +45,8 @@
   },
   "devDependencies": {
     "@tamagui/build": "workspace:*",
-    "vite": "^8.0.3"
+    "vite": "^8.0.3",
+    "vitest": "4.0.4"
   },
   "peerDependencies": {
     "vite": "^8.0.3"

--- a/code/compiler/vite-plugin/src/loadTamagui.ts
+++ b/code/compiler/vite-plugin/src/loadTamagui.ts
@@ -1,94 +1,246 @@
-import * as StaticWorker from '@tamagui/static-worker'
+import Static from '@tamagui/static'
+import type { ExtractedResponse, Extractor, TamaguiProjectInfo } from '@tamagui/static'
 import type { TamaguiOptions } from '@tamagui/types'
+import path from 'node:path'
+import type { RunnableDevEnvironment } from 'vite'
 
-// use globalThis to share state across vite environments (SSR, client, etc.)
-const LOAD_STATE_KEY = '__tamagui_load_state__'
+export const TAMAGUI_EVALUATION_ENVIRONMENT = 'tamagui'
 
-type LoadState = {
-  loadPromise: Promise<TamaguiOptions> | null
-  loadedOptions: TamaguiOptions | null
-  fullConfigLoaded: boolean
-  fullConfigLoadPromise: Promise<void> | null
+type ResolvedEvaluationModule = {
+  moduleName: string
+  id: string
+  module: Record<string, unknown>
 }
 
-function getLoadState(): LoadState {
-  if (!(globalThis as any)[LOAD_STATE_KEY]) {
-    ;(globalThis as any)[LOAD_STATE_KEY] = {
-      loadPromise: null,
-      loadedOptions: null,
-      fullConfigLoaded: false,
-      fullConfigLoadPromise: null,
+type EvaluatedProjectModules = {
+  config: ResolvedEvaluationModule
+  components: ResolvedEvaluationModule[]
+}
+
+export type ViteTamaguiLoader = {
+  getEnvironment(): RunnableDevEnvironment | null
+  getGeneration(): number
+  getLoadPromise(): Promise<TamaguiOptions> | null
+  getTamaguiOptions(): TamaguiOptions | null
+  getEvaluationDependencies(): string[]
+  isEvaluationDependency(id: string): boolean
+  evaluateProjectModules(options: TamaguiOptions): Promise<EvaluatedProjectModules>
+  loadTamaguiBuildConfig(): Promise<TamaguiOptions>
+  setEnvironment(next: RunnableDevEnvironment, options?: { owned?: boolean }): void
+  invalidate(file?: string): void
+  ensureFullConfigLoaded(): Promise<string[]>
+  extractToClassNames(params: {
+    source: string
+    sourcePath: string
+    options: TamaguiOptions
+    shouldPrintDebug: boolean | 'verbose'
+  }): Promise<ExtractedResponse | null>
+  cleanup(): Promise<void>
+}
+
+export function createViteTamaguiLoader(
+  optionsIn: Partial<TamaguiOptions> = {}
+): ViteTamaguiLoader {
+  let environment: RunnableDevEnvironment | null = null
+  let ownsEnvironment = false
+  let loadPromise: Promise<TamaguiOptions> | null = null
+  let loadedOptions: TamaguiOptions | null = null
+  let projectPromise: Promise<TamaguiProjectInfo> | null = null
+  let extractor: Extractor | null = null
+  const evaluationDependencies = new Set<string>()
+  let generation = 0
+
+  const normalizeDependency = (id: string) => id.split('?')[0]
+
+  const captureEvaluationDependencies = (modules: ResolvedEvaluationModule[]) => {
+    for (const { id } of modules) {
+      const dependency = normalizeDependency(id)
+      if (path.isAbsolute(dependency)) {
+        evaluationDependencies.add(dependency)
+      }
+    }
+    if (environment) {
+      for (const module of environment.runner.evaluatedModules.urlToIdModuleMap.values()) {
+        const dependency = normalizeDependency(module.file)
+        if (path.isAbsolute(dependency) && !dependency.includes('/node_modules/')) {
+          evaluationDependencies.add(dependency)
+        }
+      }
     }
   }
-  return (globalThis as any)[LOAD_STATE_KEY]
-}
 
-export function getTamaguiOptions(): TamaguiOptions | null {
-  return getLoadState().loadedOptions
-}
+  const loadTamaguiBuildConfig = async (): Promise<TamaguiOptions> => {
+    if (loadedOptions) return loadedOptions
+    if (loadPromise) return loadPromise
 
-export function getLoadPromise(): Promise<TamaguiOptions> | null {
-  return getLoadState().loadPromise
-}
-
-/**
- * Load just the tamagui.build.ts config (lightweight)
- * This doesn't bundle the full tamagui config - call ensureFullConfigLoaded() for that
- */
-export async function loadTamaguiBuildConfig(
-  optionsIn?: Partial<TamaguiOptions>
-): Promise<TamaguiOptions> {
-  const state = getLoadState()
-  if (state.loadedOptions) return state.loadedOptions
-  if (state.loadPromise) return state.loadPromise
-
-  state.loadPromise = (async () => {
-    const options = await StaticWorker.loadTamaguiBuildConfig({
+    loadPromise = Static.loadTamaguiBuildConfigAsync({
       ...optionsIn,
       platform: 'web',
+    }).then((options) => {
+      loadedOptions = options
+      return options
     })
 
-    state.loadedOptions = options
-    return options
-  })()
+    return loadPromise
+  }
 
-  return state.loadPromise
-}
-
-/**
- * Ensure the full tamagui config is loaded (heavy - bundles config + components)
- * Call this lazily when transform/extraction is actually needed
- */
-export async function ensureFullConfigLoaded(): Promise<void> {
-  const state = getLoadState()
-
-  if (state.fullConfigLoaded) return
-  if (state.fullConfigLoadPromise) return state.fullConfigLoadPromise
-
-  // set promise immediately to prevent race conditions
-  // (don't await loadTamaguiBuildConfig before setting this)
-  state.fullConfigLoadPromise = (async () => {
-    const options = await loadTamaguiBuildConfig()
-
-    // load full tamagui config in worker (asynchronous)
-    if (!options.disableWatchTamaguiConfig && !options.disable) {
-      await StaticWorker.loadTamagui({
-        components: ['tamagui'],
-        platform: 'web',
-        ...options,
-      })
+  const resolveAndImport = async (
+    moduleName: string,
+    root: string,
+    kind: 'config' | 'component'
+  ): Promise<ResolvedEvaluationModule> => {
+    if (!environment) {
+      throw new Error(
+        `The Tamagui Vite evaluation environment is not ready. Config and component evaluation requires Vite's ModuleRunner.`
+      )
     }
-    state.fullConfigLoaded = true
-  })()
 
-  return state.fullConfigLoadPromise
-}
+    const source = path.isAbsolute(moduleName)
+      ? moduleName
+      : kind === 'config' || moduleName.startsWith('.')
+        ? path.resolve(root, moduleName)
+        : moduleName
+    let environmentResolution = await environment.pluginContainer.resolveId(source)
 
-export async function cleanup() {
-  await StaticWorker.destroyPool()
-  const state = getLoadState()
-  state.loadPromise = null
-  state.loadedOptions = null
-  state.fullConfigLoaded = false
-  state.fullConfigLoadPromise = null
+    // Config paths are app-root relative by default, but package/alias config
+    // entries remain supported when no root-relative file resolves.
+    if (!environmentResolution && kind === 'config' && source !== moduleName) {
+      environmentResolution = await environment.pluginContainer.resolveId(moduleName)
+    }
+
+    const resolvedId = environmentResolution?.id
+
+    if (!resolvedId) {
+      throw new Error(
+        `Unable to resolve ${moduleName} in the Tamagui Vite environment (plugins: ${environment.plugins.map((plugin) => plugin.name).join(', ')})`
+      )
+    }
+
+    return {
+      moduleName,
+      id: resolvedId,
+      module: (await environment.runner.import(resolvedId)) as Record<string, unknown>,
+    }
+  }
+
+  const evaluateProjectModules = async (
+    options: TamaguiOptions
+  ): Promise<EvaluatedProjectModules> => {
+    if (!environment) {
+      throw new Error(
+        `Cannot evaluate Tamagui without the ${TAMAGUI_EVALUATION_ENVIRONMENT} Vite environment`
+      )
+    }
+
+    const root = environment.config.root
+    const config = await resolveAndImport(
+      options.config || 'tamagui.config.ts',
+      root,
+      'config'
+    )
+    const components = await Promise.all(
+      (options.components || []).map((name) => resolveAndImport(name, root, 'component'))
+    )
+
+    captureEvaluationDependencies([config, ...components])
+
+    return { config, components }
+  }
+
+  const loadProject = async (options: TamaguiOptions): Promise<TamaguiProjectInfo> => {
+    if (projectPromise) return projectPromise
+
+    projectPromise = (async () => {
+      if (!environment) {
+        throw new Error(
+          `Cannot load Tamagui without the ${TAMAGUI_EVALUATION_ENVIRONMENT} Vite environment`
+        )
+      }
+
+      const evaluated = await evaluateProjectModules({
+        ...options,
+        components: [...new Set(['@tamagui/core', ...(options.components || [])])],
+      })
+
+      return Static.loadTamaguiFromModules(options, {
+        config: evaluated.config.module,
+        components: evaluated.components.map(({ moduleName, module }) => ({
+          moduleName,
+          module,
+        })),
+      })
+    })()
+
+    return projectPromise
+  }
+
+  const getExtractor = () => {
+    return (extractor ||= Static.createExtractor({
+      platform: 'web',
+      loadTamagui: loadProject,
+      loadTamaguiSync: false,
+    }))
+  }
+
+  return {
+    getEnvironment: () => environment,
+    getGeneration: () => generation,
+    getLoadPromise: () => loadPromise,
+    getTamaguiOptions: () => loadedOptions,
+    getEvaluationDependencies: () => [...evaluationDependencies],
+    isEvaluationDependency: (id: string) =>
+      evaluationDependencies.has(normalizeDependency(id)),
+    evaluateProjectModules,
+    loadTamaguiBuildConfig,
+
+    setEnvironment(next: RunnableDevEnvironment, options?: { owned?: boolean }) {
+      if (environment === next) return
+      environment = next
+      ownsEnvironment = options?.owned === true
+      generation++
+      projectPromise = null
+      extractor = null
+    },
+
+    invalidate(file?: string) {
+      if (file && environment) {
+        environment.runner.clearCache()
+      }
+      generation++
+      projectPromise = null
+      extractor = null
+    },
+
+    async ensureFullConfigLoaded() {
+      const options = await loadTamaguiBuildConfig()
+      if (!options.disable) {
+        await loadProject(options)
+      }
+      return [...evaluationDependencies]
+    },
+
+    async extractToClassNames(params: {
+      source: string
+      sourcePath: string
+      options: TamaguiOptions
+      shouldPrintDebug: boolean | 'verbose'
+    }): Promise<ExtractedResponse | null> {
+      return Static.extractToClassNames({
+        extractor: getExtractor(),
+        ...params,
+      })
+    },
+
+    async cleanup() {
+      if (ownsEnvironment && environment) {
+        await environment.close()
+      }
+      environment = null
+      ownsEnvironment = false
+      loadPromise = null
+      loadedOptions = null
+      projectPromise = null
+      extractor = null
+    },
+  }
 }

--- a/code/compiler/vite-plugin/src/loadTamagui.ts
+++ b/code/compiler/vite-plugin/src/loadTamagui.ts
@@ -232,15 +232,18 @@ export function createViteTamaguiLoader(
     },
 
     async cleanup() {
-      if (ownsEnvironment && environment) {
-        await environment.close()
+      try {
+        if (ownsEnvironment && environment) {
+          await environment.close()
+        }
+      } finally {
+        environment = null
+        ownsEnvironment = false
+        loadPromise = null
+        loadedOptions = null
+        projectPromise = null
+        extractor = null
       }
-      environment = null
-      ownsEnvironment = false
-      loadPromise = null
-      loadedOptions = null
-      projectPromise = null
-      extractor = null
     },
   }
 }

--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -29,8 +29,8 @@ const environmentSpecificTransformPluginNames = new Set([
 ])
 
 const oneTsconfigPathsPluginName = 'one:tsconfig-paths'
-const bareTamaguiPackage = /^@tamagui\/[^/?#]+(?:[/?#]|$)/
-const inlineTamaguiPackage = /^@tamagui\/(?:config|core|web)(?:[/?#]|$)/
+const bareTamaguiPackage = /^(?:tamagui|@tamagui\/[^/?#]+)(?:[/?#]|$)/
+const inlineEvaluationTamaguiPackage = /^@tamagui\/(?:config|core|slider|web)(?:[/?#]|$)/
 const externalizablePackageExtensions = new Set(['', '.js', '.mjs', '.cjs'])
 type EvaluationResolveIdHandler = (this: any, source: string, ...args: any[]) => any
 type EvaluationBarePackageResolver = (
@@ -122,13 +122,53 @@ function getInstalledTamaguiPackages(root: string) {
     for (const entry of readdirSync(scopePath, { withFileTypes: true })) {
       if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
       const packageName = `@tamagui/${entry.name}`
-      if (!inlineTamaguiPackage.test(packageName)) {
+      if (!inlineEvaluationTamaguiPackage.test(packageName)) {
         packages.add(packageName)
       }
     }
   }
 
   return packages
+}
+
+function getEvaluationExternalPackages(root: string) {
+  const packages = getInstalledTamaguiPackages(root)
+  if (isInstalled(root, 'tamagui')) {
+    packages.add('tamagui')
+  }
+  return packages
+}
+
+function getEvaluationResolve(
+  resolve: ResolvedConfig['environments'][string]['resolve'],
+  root: string,
+  disableTsconfigPaths: boolean
+) {
+  return {
+    ...resolve,
+    external:
+      resolve.external === true
+        ? (true as const)
+        : [
+            ...new Set([
+              ...(resolve.external || []),
+              ...getEvaluationExternalPackages(root),
+            ]),
+          ],
+    ...(disableTsconfigPaths && { tsconfigPaths: false }),
+  }
+}
+
+function isConfiguredExternalPackage(
+  source: string,
+  external: string[] | true | undefined
+) {
+  if (external === true) return true
+  const cleanSource = source.split(/[?#]/, 1)[0]
+  return external?.some(
+    (packageName) =>
+      cleanSource === packageName || cleanSource.startsWith(`${packageName}/`)
+  )
 }
 
 function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
@@ -143,7 +183,13 @@ function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
     if (!resolved) return
     const cleanResolved = resolved.split(/[?#]/, 1)[0]
     if (
-      inlineTamaguiPackage.test(source) ||
+      !inlineEvaluationTamaguiPackage.test(source) &&
+      isConfiguredExternalPackage(source, evaluationEnvironment.config.resolve.external)
+    ) {
+      return { id: source, external: true }
+    }
+    if (
+      inlineEvaluationTamaguiPackage.test(source) ||
       !normalizePath(cleanResolved).includes('/node_modules/') ||
       !externalizablePackageExtensions.has(path.extname(cleanResolved))
     ) {
@@ -160,21 +206,11 @@ function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
     }
     return []
   })
-  const resolve = plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
-    ? {
-        ...environment.resolve,
-        external:
-          environment.resolve.external === true
-            ? (true as const)
-            : [
-                ...new Set([
-                  ...(environment.resolve.external || []),
-                  ...getInstalledTamaguiPackages(config.root),
-                ]),
-              ],
-        tsconfigPaths: false,
-      }
-    : environment.resolve
+  const resolve = getEvaluationResolve(
+    environment.resolve,
+    config.root,
+    plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
+  )
 
   const evaluationConfig: ResolvedConfig = {
     ...config,
@@ -196,9 +232,11 @@ async function createOwnedEvaluationConfig(config: ResolvedConfig) {
   const plugins = environment.plugins
     .filter(isEvaluationUserPlugin)
     .map((plugin) => createEvaluationPluginFacade(plugin))
-  const resolve = plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
-    ? { ...environment.resolve, tsconfigPaths: false }
-    : environment.resolve
+  const resolve = getEvaluationResolve(
+    environment.resolve,
+    config.root,
+    plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
+  )
   const { createEnvironment: _createEnvironment, ...dev } = environment.dev
 
   // ModuleRunner needs Vite's serve-time core pipeline (especially import
@@ -446,11 +484,12 @@ export function tamaguiPlugin({
       'process.env.TAMAGUI_IS_SERVER': JSON.stringify(true),
       'process.env.TAMAGUI_TARGET': JSON.stringify('web'),
       'process.env.TAMAGUI_ENVIRONMENT': JSON.stringify(TAMAGUI_EVALUATION_ENVIRONMENT),
+      'process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL': JSON.stringify('1'),
     },
     resolve: {
       conditions: [...defaultClientConditions],
       mainFields: [...defaultClientMainFields],
-      noExternal: inlineTamaguiPackage,
+      noExternal: inlineEvaluationTamaguiPackage,
       extensions,
     },
     dev: {
@@ -857,12 +896,6 @@ export function tamaguiPlugin({
         // ensure tamagui is loaded before transform
         const options = await ensureLoaded()
 
-        // evaluate config and components before extraction
-        const evaluationDependencies = await tamaguiLoader.ensureFullConfigLoaded()
-        for (const dependency of evaluationDependencies) {
-          this.addWatchFile(dependency)
-        }
-
         // fully disabled = no extraction AND no debug attrs
         if (options?.disable) {
           return
@@ -875,6 +908,14 @@ export function tamaguiPlugin({
         const [validId] = id.split('?')
         if (!validId.endsWith('.tsx')) {
           return
+        }
+
+        // Evaluate config and components only for files that can be extracted.
+        // Register their dependency graph on the candidate transform so config
+        // edits still invalidate compilation without taxing every package module.
+        const evaluationDependencies = await tamaguiLoader.ensureFullConfigLoaded()
+        for (const dependency of evaluationDependencies) {
+          this.addWatchFile(dependency)
         }
         transformedModuleIds.add(validId)
 

--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -1,10 +1,12 @@
 import Static from '@tamagui/static'
 import type { ExtractedResponse, TamaguiOptions } from '@tamagui/static'
 import { createHash } from 'node:crypto'
+import { existsSync, readdirSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import {
+  createIdResolver,
   createRunnableDevEnvironment,
   defaultClientConditions,
   defaultClientMainFields,
@@ -28,9 +30,23 @@ const environmentSpecificTransformPluginNames = new Set([
 
 const oneTsconfigPathsPluginName = 'one:tsconfig-paths'
 const bareTamaguiPackage = /^@tamagui\/[^/?#]+(?:[/?#]|$)/
+const inlineTamaguiPackage = /^@tamagui\/(?:config|core|web)(?:[/?#]|$)/
+const externalizablePackageExtensions = new Set(['', '.js', '.mjs', '.cjs'])
 type EvaluationResolveIdHandler = (this: any, source: string, ...args: any[]) => any
+type EvaluationBarePackageResolver = (
+  environment: Environment,
+  source: string,
+  importer?: string
+) =>
+  | Promise<string | { id: string; external: true } | undefined>
+  | string
+  | { id: string; external: true }
+  | undefined
 
-function createEvaluationResolveId(plugin: Plugin): Plugin['resolveId'] {
+function createEvaluationResolveId(
+  plugin: Plugin,
+  resolveBarePackage?: EvaluationBarePackageResolver
+): Plugin['resolveId'] {
   const resolveId = plugin.resolveId
   if (plugin.name !== oneTsconfigPathsPluginName || !resolveId) {
     return resolveId
@@ -44,7 +60,10 @@ function createEvaluationResolveId(plugin: Plugin): Plugin['resolveId'] {
     // directory fallbacks before Vite can apply the package exports map. Keep
     // user TS aliases in this resolver, but let Tamagui packages use Vite's
     // normal package resolution and externalization policy.
-    if (bareTamaguiPackage.test(source)) return
+    if (bareTamaguiPackage.test(source)) {
+      const importer = typeof args[0] === 'string' ? args[0] : undefined
+      return resolveBarePackage?.(this.environment, source, importer)
+    }
     return Reflect.apply(handler, this, [source, ...args])
   }
 
@@ -53,11 +72,14 @@ function createEvaluationResolveId(plugin: Plugin): Plugin['resolveId'] {
     : evaluationHandler
 }
 
-function createEvaluationPluginFacade(plugin: Plugin): Plugin {
+function createEvaluationPluginFacade(
+  plugin: Plugin,
+  resolveBarePackage?: EvaluationBarePackageResolver
+): Plugin {
   return {
     name: plugin.name,
     enforce: plugin.enforce,
-    resolveId: createEvaluationResolveId(plugin),
+    resolveId: createEvaluationResolveId(plugin, resolveBarePackage),
     load: plugin.load,
     transform: environmentSpecificTransformPluginNames.has(plugin.name)
       ? undefined
@@ -82,11 +104,98 @@ function isEvaluationUserPlugin(plugin: Plugin) {
   )
 }
 
+function isEvaluationCorePlugin(plugin: Plugin) {
+  return (
+    plugin.name === 'alias' ||
+    plugin.name.startsWith('vite:') ||
+    plugin.name.startsWith('builtin:vite-')
+  )
+}
+
+function getInstalledTamaguiPackages(root: string) {
+  const packageRequire = createRequire(path.join(root, 'package.json'))
+  const packages = new Set<string>()
+
+  for (const modulePath of packageRequire.resolve.paths('@tamagui/core') || []) {
+    const scopePath = path.join(modulePath, '@tamagui')
+    if (!existsSync(scopePath)) continue
+    for (const entry of readdirSync(scopePath, { withFileTypes: true })) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
+      const packageName = `@tamagui/${entry.name}`
+      if (!inlineTamaguiPackage.test(packageName)) {
+        packages.add(packageName)
+      }
+    }
+  }
+
+  return packages
+}
+
+function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
+  const environment = config.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
+  let packageResolver: ReturnType<typeof createIdResolver> | undefined
+  const resolveBarePackage: EvaluationBarePackageResolver = async (
+    evaluationEnvironment,
+    source,
+    importer
+  ) => {
+    const resolved = await packageResolver?.(evaluationEnvironment, source, importer)
+    if (!resolved) return
+    const cleanResolved = resolved.split(/[?#]/, 1)[0]
+    if (
+      inlineTamaguiPackage.test(source) ||
+      !normalizePath(cleanResolved).includes('/node_modules/') ||
+      !externalizablePackageExtensions.has(path.extname(cleanResolved))
+    ) {
+      return resolved
+    }
+    return { id: source, external: true }
+  }
+  const plugins = environment.plugins.flatMap((plugin) => {
+    if (isEvaluationCorePlugin(plugin)) {
+      return [plugin]
+    }
+    if (isEvaluationUserPlugin(plugin)) {
+      return [createEvaluationPluginFacade(plugin, resolveBarePackage)]
+    }
+    return []
+  })
+  const resolve = plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
+    ? {
+        ...environment.resolve,
+        external:
+          environment.resolve.external === true
+            ? (true as const)
+            : [
+                ...new Set([
+                  ...(environment.resolve.external || []),
+                  ...getInstalledTamaguiPackages(config.root),
+                ]),
+              ],
+        tsconfigPaths: false,
+      }
+    : environment.resolve
+
+  const evaluationConfig: ResolvedConfig = {
+    ...config,
+    environments: {
+      ...config.environments,
+      [TAMAGUI_EVALUATION_ENVIRONMENT]: {
+        ...environment,
+        plugins,
+        resolve,
+      },
+    },
+  }
+  packageResolver = createIdResolver(evaluationConfig)
+  return evaluationConfig
+}
+
 async function createOwnedEvaluationConfig(config: ResolvedConfig) {
   const environment = config.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
   const plugins = environment.plugins
     .filter(isEvaluationUserPlugin)
-    .map(createEvaluationPluginFacade)
+    .map((plugin) => createEvaluationPluginFacade(plugin))
   const resolve = plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
     ? { ...environment.resolve, tsconfigPaths: false }
     : environment.resolve
@@ -94,8 +203,9 @@ async function createOwnedEvaluationConfig(config: ResolvedConfig) {
 
   // ModuleRunner needs Vite's serve-time core pipeline (especially import
   // analysis), but user plugin selection must remain the already-resolved
-  // build pipeline. The facades retain only evaluation hooks, so resolving this
-  // owned config cannot replay user configuration or build lifecycles.
+  // pipeline for the outer command. The facades retain only evaluation hooks,
+  // so resolving this owned config cannot replay user configuration or outer
+  // lifecycles.
   return resolveConfig(
     {
       configFile: false,
@@ -340,12 +450,13 @@ export function tamaguiPlugin({
     resolve: {
       conditions: [...defaultClientConditions],
       mainFields: [...defaultClientMainFields],
-      noExternal: /^@tamagui\/(?:config|core|web)(?:\/|$)/,
+      noExternal: inlineTamaguiPackage,
       extensions,
     },
     dev: {
       createEnvironment(name, resolved) {
-        return createRunnableDevEnvironment(name, resolved)
+        const evaluationConfig = createServeEvaluationConfig(resolved)
+        return createRunnableDevEnvironment(name, evaluationConfig)
       },
       moduleRunnerTransform: true,
     },

--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -29,7 +29,7 @@ const environmentSpecificTransformPluginNames = new Set([
 ])
 
 const oneTsconfigPathsPluginName = 'one:tsconfig-paths'
-const bareTamaguiPackage = /^(?:tamagui|@tamagui\/[^/?#]+)(?:[/?#]|$)/
+const bareTamaguiPackage = /^@tamagui\/[^/?#]+(?:[/?#]|$)/
 const inlineEvaluationTamaguiPackage = /^@tamagui\/(?:config|core|slider|web)(?:[/?#]|$)/
 const externalizablePackageExtensions = new Set(['', '.js', '.mjs', '.cjs'])
 type EvaluationResolveIdHandler = (this: any, source: string, ...args: any[]) => any
@@ -112,7 +112,38 @@ function isEvaluationCorePlugin(plugin: Plugin) {
   )
 }
 
-function getInstalledTamaguiPackages(root: string) {
+function isConfiguredEvaluationPackage(source: string, packages: Set<string>) {
+  const cleanSource = source.split(/[?#]/, 1)[0]
+  return [...packages].some(
+    (packageName) =>
+      cleanSource === packageName || cleanSource.startsWith(`${packageName}/`)
+  )
+}
+
+function getEvaluationPackageName(source: string | undefined) {
+  if (!source) return
+  const cleanSource = source.split(/[?#]/, 1)[0]
+  if (
+    !cleanSource ||
+    cleanSource.startsWith('.') ||
+    cleanSource.startsWith('#') ||
+    cleanSource.startsWith('\0') ||
+    path.isAbsolute(cleanSource)
+  ) {
+    return
+  }
+  if (cleanSource.startsWith('@')) {
+    const [scope, name] = cleanSource.split('/')
+    return scope && name ? `${scope}/${name}` : undefined
+  }
+  const [name] = cleanSource.split('/')
+  return name && !path.extname(name) ? name : undefined
+}
+
+function getInstalledTamaguiPackages(
+  root: string,
+  configuredEvaluationPackages: Set<string>
+) {
   const packageRequire = createRequire(path.join(root, 'package.json'))
   const packages = new Set<string>()
 
@@ -122,7 +153,10 @@ function getInstalledTamaguiPackages(root: string) {
     for (const entry of readdirSync(scopePath, { withFileTypes: true })) {
       if (!entry.isDirectory() && !entry.isSymbolicLink()) continue
       const packageName = `@tamagui/${entry.name}`
-      if (!inlineEvaluationTamaguiPackage.test(packageName)) {
+      if (
+        !inlineEvaluationTamaguiPackage.test(packageName) &&
+        !configuredEvaluationPackages.has(packageName)
+      ) {
         packages.add(packageName)
       }
     }
@@ -131,18 +165,11 @@ function getInstalledTamaguiPackages(root: string) {
   return packages
 }
 
-function getEvaluationExternalPackages(root: string) {
-  const packages = getInstalledTamaguiPackages(root)
-  if (isInstalled(root, 'tamagui')) {
-    packages.add('tamagui')
-  }
-  return packages
-}
-
 function getEvaluationResolve(
   resolve: ResolvedConfig['environments'][string]['resolve'],
   root: string,
-  disableTsconfigPaths: boolean
+  disableTsconfigPaths: boolean,
+  configuredEvaluationPackages: Set<string>
 ) {
   return {
     ...resolve,
@@ -151,8 +178,14 @@ function getEvaluationResolve(
         ? (true as const)
         : [
             ...new Set([
-              ...(resolve.external || []),
-              ...getEvaluationExternalPackages(root),
+              ...(resolve.external || []).filter(
+                (packageName) =>
+                  !isConfiguredEvaluationPackage(
+                    packageName,
+                    configuredEvaluationPackages
+                  )
+              ),
+              ...getInstalledTamaguiPackages(root, configuredEvaluationPackages),
             ]),
           ],
     ...(disableTsconfigPaths && { tsconfigPaths: false }),
@@ -171,7 +204,10 @@ function isConfiguredExternalPackage(
   )
 }
 
-function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
+function createServeEvaluationConfig(
+  config: ResolvedConfig,
+  configuredEvaluationPackages: Set<string>
+): ResolvedConfig {
   const environment = config.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
   let packageResolver: ReturnType<typeof createIdResolver> | undefined
   const resolveBarePackage: EvaluationBarePackageResolver = async (
@@ -184,12 +220,14 @@ function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
     const cleanResolved = resolved.split(/[?#]/, 1)[0]
     if (
       !inlineEvaluationTamaguiPackage.test(source) &&
+      !isConfiguredEvaluationPackage(source, configuredEvaluationPackages) &&
       isConfiguredExternalPackage(source, evaluationEnvironment.config.resolve.external)
     ) {
       return { id: source, external: true }
     }
     if (
       inlineEvaluationTamaguiPackage.test(source) ||
+      isConfiguredEvaluationPackage(source, configuredEvaluationPackages) ||
       !normalizePath(cleanResolved).includes('/node_modules/') ||
       !externalizablePackageExtensions.has(path.extname(cleanResolved))
     ) {
@@ -209,7 +247,8 @@ function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
   const resolve = getEvaluationResolve(
     environment.resolve,
     config.root,
-    plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
+    plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName),
+    configuredEvaluationPackages
   )
 
   const evaluationConfig: ResolvedConfig = {
@@ -227,7 +266,10 @@ function createServeEvaluationConfig(config: ResolvedConfig): ResolvedConfig {
   return evaluationConfig
 }
 
-async function createOwnedEvaluationConfig(config: ResolvedConfig) {
+async function createOwnedEvaluationConfig(
+  config: ResolvedConfig,
+  configuredEvaluationPackages: Set<string>
+) {
   const environment = config.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
   const plugins = environment.plugins
     .filter(isEvaluationUserPlugin)
@@ -235,7 +277,8 @@ async function createOwnedEvaluationConfig(config: ResolvedConfig) {
   const resolve = getEvaluationResolve(
     environment.resolve,
     config.root,
-    plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
+    plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName),
+    configuredEvaluationPackages
   )
   const { createEnvironment: _createEnvironment, ...dev } = environment.dev
 
@@ -435,6 +478,7 @@ export function tamaguiPlugin({
   const enableNativeEnv = !!globalThis.__vxrnEnableNativeEnv
   const tamaguiLoader = createViteTamaguiLoader(tamaguiOptionsIn)
   const pluginInstanceId = getNextPluginInstanceId()
+  const configuredEvaluationPackages = new Set<string>()
   let buildEnvironmentPromise: Promise<void> | null = null
   let buildCleanupPromise: Promise<void> | null = null
   const activeBuildEnvironments = new Set<Environment>()
@@ -489,12 +533,15 @@ export function tamaguiPlugin({
     resolve: {
       conditions: [...defaultClientConditions],
       mainFields: [...defaultClientMainFields],
-      noExternal: inlineEvaluationTamaguiPackage,
+      noExternal: [inlineEvaluationTamaguiPackage, ...configuredEvaluationPackages],
       extensions,
     },
     dev: {
       createEnvironment(name, resolved) {
-        const evaluationConfig = createServeEvaluationConfig(resolved)
+        const evaluationConfig = createServeEvaluationConfig(
+          resolved,
+          configuredEvaluationPackages
+        )
         return createRunnableDevEnvironment(name, evaluationConfig)
       },
       moduleRunnerTransform: true,
@@ -602,6 +649,13 @@ export function tamaguiPlugin({
 
       if (!options) {
         throw new Error(`No tamagui options loaded`)
+      }
+
+      for (const source of [options.config, ...(options.components || [])]) {
+        const packageName = getEvaluationPackageName(source)
+        if (packageName) {
+          configuredEvaluationPackages.add(packageName)
+        }
       }
 
       return {
@@ -768,7 +822,10 @@ export function tamaguiPlugin({
         if (!tamaguiLoader.getEnvironment()) {
           await tamaguiLoader.loadTamaguiBuildConfig()
           buildEnvironmentPromise ||= (async () => {
-            const evaluationConfig = await createOwnedEvaluationConfig(buildConfig)
+            const evaluationConfig = await createOwnedEvaluationConfig(
+              buildConfig,
+              configuredEvaluationPackages
+            )
             const evaluationEnvironment = createRunnableDevEnvironment(
               TAMAGUI_EVALUATION_ENVIRONMENT,
               evaluationConfig,

--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -1,18 +1,91 @@
-import type { TamaguiOptions, ExtractedResponse } from '@tamagui/static-worker'
-import * as Static from '@tamagui/static-worker'
-import { getPragmaOptions } from '@tamagui/static-worker'
+import Static from '@tamagui/static'
+import type { ExtractedResponse, TamaguiOptions } from '@tamagui/static'
 import { createHash } from 'node:crypto'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { Plugin, PluginOption, ResolvedConfig, ViteDevServer } from 'vite'
-import type { Environment } from 'vite'
 import {
-  loadTamaguiBuildConfig,
-  getLoadPromise,
-  getTamaguiOptions,
-  ensureFullConfigLoaded,
-} from './loadTamagui'
+  createRunnableDevEnvironment,
+  defaultClientConditions,
+  defaultClientMainFields,
+  isRunnableDevEnvironment,
+  resolveConfig,
+} from 'vite'
+import type {
+  EnvironmentOptions,
+  Plugin,
+  PluginOption,
+  ResolvedConfig,
+  ViteDevServer,
+} from 'vite'
+import type { Environment } from 'vite'
+import { createViteTamaguiLoader, TAMAGUI_EVALUATION_ENVIRONMENT } from './loadTamagui'
+
+function createEvaluationPluginFacade(plugin: Plugin): Plugin {
+  return {
+    name: plugin.name,
+    enforce: plugin.enforce,
+    resolveId: plugin.resolveId,
+    load: plugin.load,
+    transform: plugin.transform,
+  }
+}
+
+const tamaguiEvaluationPluginNames = new Set([
+  'tamagui',
+  'tamagui-extract',
+  'tamagui-rnw-lite',
+])
+
+function isEvaluationUserPlugin(plugin: Plugin) {
+  return (
+    !!(plugin.resolveId || plugin.load || plugin.transform) &&
+    plugin.name !== 'alias' &&
+    !plugin.name.startsWith('native:') &&
+    !plugin.name.startsWith('vite:') &&
+    !plugin.name.startsWith('builtin:vite-') &&
+    !tamaguiEvaluationPluginNames.has(plugin.name)
+  )
+}
+
+async function createOwnedEvaluationConfig(config: ResolvedConfig) {
+  const environment = config.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
+  const plugins = environment.plugins
+    .filter(isEvaluationUserPlugin)
+    .map(createEvaluationPluginFacade)
+  const { createEnvironment: _createEnvironment, ...dev } = environment.dev
+
+  // ModuleRunner needs Vite's serve-time core pipeline (especially import
+  // analysis), but user plugin selection must remain the already-resolved
+  // build pipeline. The facades retain only evaluation hooks, so resolving this
+  // owned config cannot replay user configuration or build lifecycles.
+  return resolveConfig(
+    {
+      configFile: false,
+      root: config.root,
+      mode: config.mode,
+      logLevel: config.logLevel,
+      plugins,
+      define: environment.define,
+      resolve: environment.resolve,
+      environments: {
+        [TAMAGUI_EVALUATION_ENVIRONMENT]: {
+          consumer: environment.consumer,
+          keepProcessEnv: environment.keepProcessEnv,
+          define: environment.define,
+          resolve: environment.resolve,
+          optimizeDeps: environment.optimizeDeps,
+          dev: {
+            ...dev,
+            moduleRunnerTransform: true,
+          },
+        },
+      },
+    },
+    'serve',
+    config.mode
+  )
+}
 
 // handle ESM/CJS duality for plugin dependencies - resolve from plugin's location, not user's project
 const _pluginRequire = createRequire(
@@ -26,11 +99,19 @@ type CacheEntry = {
   js: string
   map: any
   cssImport: string | null
+  css: { id: string; code: string } | null
 }
 
 const CACHE_KEY = '__tamagui_vite_cache__'
 const CACHE_SIZE_KEY = '__tamagui_vite_cache_size__'
 const PENDING_KEY = '__tamagui_vite_pending__'
+const PLUGIN_INSTANCE_KEY = '__tamagui_vite_plugin_instance__'
+
+function getNextPluginInstanceId() {
+  const next = ((globalThis as any)[PLUGIN_INSTANCE_KEY] || 0) + 1
+  ;(globalThis as any)[PLUGIN_INSTANCE_KEY] = next
+  return next
+}
 
 function getSharedCache(): Record<string, CacheEntry> {
   if (!(globalThis as any)[CACHE_KEY]) {
@@ -48,8 +129,12 @@ function setSharedCacheSize(size: number) {
 }
 
 function clearSharedCache() {
-  ;(globalThis as any)[CACHE_KEY] = {}
-  ;(globalThis as any)[CACHE_SIZE_KEY] = 0
+  const cache = getSharedCache()
+  for (const key in cache) {
+    delete cache[key]
+  }
+  setSharedCacheSize(0)
+  getPendingExtractions().clear()
 }
 
 // resolves package ids against the user's project root (not the plugin's
@@ -160,10 +245,12 @@ export function tamaguiPlugin({
 } = {}): PluginOption {
   // extraction ON by default, set disableExtraction: true to opt out
   let shouldExtract = !tamaguiOptionsIn.disableExtraction
-  let watcher: Promise<{ dispose: () => void } | void | undefined> | undefined
 
   // temporary vxrn native env bridge
   const enableNativeEnv = !!globalThis.__vxrnEnableNativeEnv
+  const tamaguiLoader = createViteTamaguiLoader(tamaguiOptionsIn)
+  const pluginInstanceId = getNextPluginInstanceId()
+  let buildEnvironmentPromise: Promise<void> | null = null
 
   const extensions = [
     `.web.mjs`,
@@ -180,14 +267,38 @@ export function tamaguiPlugin({
     '.json',
   ]
 
+  const getEvaluationEnvironmentOptions = (): EnvironmentOptions => ({
+    consumer: 'server',
+    keepProcessEnv: true,
+    define: {
+      'process.env.IS_STATIC': JSON.stringify('is_static'),
+      'process.env.TAMAGUI_IS_CLIENT': JSON.stringify(false),
+      'process.env.TAMAGUI_IS_SERVER': JSON.stringify(true),
+      'process.env.TAMAGUI_TARGET': JSON.stringify('web'),
+      'process.env.TAMAGUI_ENVIRONMENT': JSON.stringify(TAMAGUI_EVALUATION_ENVIRONMENT),
+    },
+    resolve: {
+      conditions: [...defaultClientConditions],
+      mainFields: [...defaultClientMainFields],
+      noExternal: /^@tamagui\/(?:config|core|web)(?:\/|$)/,
+      extensions,
+    },
+    dev: {
+      createEnvironment(name, resolved) {
+        return createRunnableDevEnvironment(name, resolved)
+      },
+      moduleRunnerTransform: true,
+    },
+  })
+
   // start loading immediately but don't block
-  loadTamaguiBuildConfig(tamaguiOptionsIn)
+  tamaguiLoader.loadTamaguiBuildConfig()
 
   // helper to await load when needed
   const ensureLoaded = async () => {
-    const promise = getLoadPromise()
+    const promise = tamaguiLoader.getLoadPromise()
     if (promise) await promise
-    const options = getTamaguiOptions()
+    const options = tamaguiLoader.getTamaguiOptions()
     // update shouldExtract from loaded config (tamagui.build.ts)
     if (options) {
       shouldExtract = !options.disableExtraction
@@ -202,6 +313,9 @@ export function tamaguiPlugin({
   const memoryCache = getSharedCache()
 
   const cssMap = new Map<string, string>()
+  const transformedModuleIds = new Set<string>()
+  const compilerHotUpdateSignatures = new Map<string, string>()
+  const compilerHotReloadSignatures = new Map<string, string>()
   let config: ResolvedConfig
   let server: ViteDevServer
   const virtualExt = `.tamagui.css`
@@ -237,18 +351,44 @@ export function tamaguiPlugin({
     }
   }
 
+  function invalidateCompilerModules() {
+    if (server) {
+      const ids = new Set([...transformedModuleIds, ...cssMap.keys()])
+      for (const environment of Object.values(server.environments)) {
+        if (environment.name === TAMAGUI_EVALUATION_ENVIRONMENT) continue
+        for (const id of ids) {
+          const modules = environment.moduleGraph.getModulesByFile(id)
+          if (!modules) continue
+          for (const module of modules) {
+            environment.moduleGraph.invalidateModule(module)
+          }
+        }
+      }
+    }
+    cssMap.clear()
+  }
+
   const basePlugin: Plugin = {
     name: 'tamagui',
     enforce: 'pre',
 
     configureServer(_server) {
       server = _server
+      const evaluationEnvironment = server.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
+      if (!isRunnableDevEnvironment(evaluationEnvironment)) {
+        throw new Error(
+          `The ${TAMAGUI_EVALUATION_ENVIRONMENT} Vite environment must support ModuleRunner evaluation`
+        )
+      }
+      tamaguiLoader.setEnvironment(evaluationEnvironment)
     },
 
     async buildEnd() {
-      await watcher?.then((res) => {
-        res?.dispose()
-      })
+      try {
+        await tamaguiLoader.cleanup()
+      } finally {
+        buildEnvironmentPromise = null
+      }
     },
 
     async config(_, env) {
@@ -256,17 +396,6 @@ export function tamaguiPlugin({
 
       if (!options) {
         throw new Error(`No tamagui options loaded`)
-      }
-
-      // start watching config if enabled
-      if (!options.disableWatchTamaguiConfig) {
-        watcher = Static.watchTamaguiConfig({
-          components: ['tamagui'],
-          config: './src/tamagui.config.ts',
-          ...options,
-        }).catch((err) => {
-          console.error(` [Tamagui] Error watching config: ${err}`)
-        })
       }
 
       return {
@@ -279,6 +408,7 @@ export function tamaguiPlugin({
               'process.env.TAMAGUI_ENVIRONMENT': '"client"',
             },
           },
+          [TAMAGUI_EVALUATION_ENVIRONMENT]: getEvaluationEnvironmentOptions(),
         },
 
         define: {
@@ -324,7 +454,7 @@ export function tamaguiPlugin({
         return {}
       }
 
-      const options = getTamaguiOptions()
+      const options = tamaguiLoader.getTamaguiOptions()
       if (!options?.useReactNativeWebLite) {
         return {}
       }
@@ -417,6 +547,82 @@ export function tamaguiPlugin({
       config = resolvedConfig
     },
 
+    async buildStart() {
+      const buildConfig = this.environment.getTopLevelConfig()
+      if (buildConfig.command === 'build' && !tamaguiLoader.getEnvironment()) {
+        await tamaguiLoader.loadTamaguiBuildConfig()
+        buildEnvironmentPromise ||= (async () => {
+          const evaluationConfig = await createOwnedEvaluationConfig(buildConfig)
+          const evaluationEnvironment = createRunnableDevEnvironment(
+            TAMAGUI_EVALUATION_ENVIRONMENT,
+            evaluationConfig,
+            { hot: false }
+          )
+          try {
+            await evaluationEnvironment.init()
+          } catch (error) {
+            await evaluationEnvironment.close().catch(() => undefined)
+            throw error
+          }
+          tamaguiLoader.setEnvironment(evaluationEnvironment, { owned: true })
+        })()
+        try {
+          await buildEnvironmentPromise
+        } catch (error) {
+          buildEnvironmentPromise = null
+          throw error
+        }
+      }
+    },
+
+    hotUpdate: {
+      order: 'post',
+      async handler(options) {
+        if (!tamaguiLoader.isEvaluationDependency(options.file)) {
+          return
+        }
+
+        const signature = await (async () => {
+          if (options.type === 'delete') {
+            return getHash(`${options.type}:${options.file}`)
+          }
+          try {
+            return getHash(`${options.type}:${options.file}:${await options.read()}`)
+          } catch {
+            return getHash(`${options.type}:${options.file}:${options.timestamp}`)
+          }
+        })()
+
+        if (compilerHotUpdateSignatures.get(options.file) !== signature) {
+          compilerHotUpdateSignatures.set(options.file, signature)
+          tamaguiLoader.invalidate(options.file)
+          clearSharedCache()
+          invalidateCompilerModules()
+        }
+        if (
+          this.environment.name === 'client' &&
+          compilerHotReloadSignatures.get(options.file) !== signature
+        ) {
+          compilerHotReloadSignatures.set(options.file, signature)
+          this.environment.hot.send({
+            type: 'full-reload',
+            path: '*',
+            triggeredBy: options.file,
+          })
+        }
+        return []
+      },
+    },
+
+    watchChange(id) {
+      if (config.command !== 'build' || !tamaguiLoader.isEvaluationDependency(id)) {
+        return
+      }
+      tamaguiLoader.invalidate(id)
+      clearSharedCache()
+      invalidateCompilerModules()
+    },
+
     async resolveId(source) {
       if (!shouldExtract) return
 
@@ -434,8 +640,8 @@ export function tamaguiPlugin({
         return
       }
 
-      const absoluteId = source.startsWith(config.root)
-        ? source
+      const absoluteId = validId.startsWith(config.root)
+        ? validId
         : getAbsoluteVirtualFileId(validId)
 
       if (cssMap.has(absoluteId)) {
@@ -446,7 +652,7 @@ export function tamaguiPlugin({
     async load(id) {
       if (!shouldExtract) return
 
-      const options = getTamaguiOptions()
+      const options = tamaguiLoader.getTamaguiOptions()
       if (options?.disable) {
         return
       }
@@ -466,11 +672,20 @@ export function tamaguiPlugin({
     transform: {
       order: 'pre',
       async handler(code, id) {
+        // Config/component evaluation must run through user plugins without
+        // recursively invoking Tamagui extraction inside its own ModuleRunner.
+        if (this.environment?.name === TAMAGUI_EVALUATION_ENVIRONMENT) {
+          return
+        }
+
         // ensure tamagui is loaded before transform
         const options = await ensureLoaded()
 
-        // ensure full config (heavy bundling) is loaded before extraction
-        await ensureFullConfigLoaded()
+        // evaluate config and components before extraction
+        const evaluationDependencies = await tamaguiLoader.ensureFullConfigLoaded()
+        for (const dependency of evaluationDependencies) {
+          this.addWatchFile(dependency)
+        }
 
         // fully disabled = no extraction AND no debug attrs
         if (options?.disable) {
@@ -485,8 +700,9 @@ export function tamaguiPlugin({
         if (!validId.endsWith('.tsx')) {
           return
         }
+        transformedModuleIds.add(validId)
 
-        const { shouldDisable, shouldPrintDebug } = await getPragmaOptions({
+        const { shouldDisable, shouldPrintDebug } = await Static.getPragmaOptions({
           source: code,
           path: validId,
         })
@@ -504,12 +720,18 @@ export function tamaguiPlugin({
 
         const isSSR = isNotClient(this.environment)
 
-        // cache key without environment - share compiled JS between SSR/client
-        const cacheKey = getHash(`${code}${id}`)
+        // share compiled JS between client/SSR, but never across plugin instances
+        const extractionGeneration = tamaguiLoader.getGeneration()
+        const cacheKey = getHash(
+          `${pluginInstanceId}:${extractionGeneration}:${code}${id}`
+        )
         const pending = getPendingExtractions()
 
         // helper to format result based on environment
         const formatResult = (entry: CacheEntry) => {
+          if (entry.css) {
+            cssMap.set(entry.css.id, entry.css.code)
+          }
           const finalCode =
             !isSSR && entry.cssImport ? `${entry.js}\n${entry.cssImport}` : entry.js
           return { code: finalCode, map: entry.map }
@@ -551,7 +773,7 @@ export function tamaguiPlugin({
         const extractionPromise = (async (): Promise<CacheEntry | null> => {
           let extracted: ExtractedResponse | null
           try {
-            extracted = await Static!.extractToClassNames({
+            extracted = await tamaguiLoader.extractToClassNames({
               source: code,
               sourcePath: validId,
               options: options!,
@@ -577,10 +799,15 @@ export function tamaguiPlugin({
             return null
           }
 
+          if (extractionGeneration !== tamaguiLoader.getGeneration()) {
+            return null
+          }
+
           const rootRelativeId = `${validId}${virtualExt}`
           const absoluteId = getAbsoluteVirtualFileId(rootRelativeId)
 
           let cssImport: string | null = null
+          let css: CacheEntry['css'] = null
 
           // store CSS and prepare import (but don't include in cached JS)
           if (extracted.styles) {
@@ -592,6 +819,7 @@ export function tamaguiPlugin({
 
             cssImport = `import "${rootRelativeId}";`
             cssMap.set(absoluteId, extracted.styles)
+            css = { id: absoluteId, code: extracted.styles }
           }
 
           // cache the JS separately from CSS import
@@ -600,10 +828,11 @@ export function tamaguiPlugin({
             js: jsCode,
             map: extracted.map,
             cssImport,
+            css,
           }
 
           // track cache size and clear if too large (64MB)
-          const newSize = getSharedCacheSize() + jsCode.length
+          const newSize = getSharedCacheSize() + jsCode.length + (css?.code.length || 0)
           if (newSize > 67108864) {
             clearSharedCache()
           } else {

--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -21,13 +21,20 @@ import type {
 import type { Environment } from 'vite'
 import { createViteTamaguiLoader, TAMAGUI_EVALUATION_ENVIRONMENT } from './loadTamagui'
 
+const environmentSpecificTransformPluginNames = new Set([
+  'one:compiler',
+  'one:compiler-css-to-js',
+])
+
 function createEvaluationPluginFacade(plugin: Plugin): Plugin {
   return {
     name: plugin.name,
     enforce: plugin.enforce,
     resolveId: plugin.resolveId,
     load: plugin.load,
-    transform: plugin.transform,
+    transform: environmentSpecificTransformPluginNames.has(plugin.name)
+      ? undefined
+      : plugin.transform,
   }
 }
 
@@ -251,6 +258,29 @@ export function tamaguiPlugin({
   const tamaguiLoader = createViteTamaguiLoader(tamaguiOptionsIn)
   const pluginInstanceId = getNextPluginInstanceId()
   let buildEnvironmentPromise: Promise<void> | null = null
+  let buildCleanupPromise: Promise<void> | null = null
+  const activeBuildEnvironments = new Set<Environment>()
+
+  const releaseBuildEnvironment = async (environment: Environment) => {
+    if (!activeBuildEnvironments.delete(environment) || activeBuildEnvironments.size) {
+      return
+    }
+    const currentCleanup = Promise.resolve().then(async () => {
+      try {
+        await tamaguiLoader.cleanup()
+      } finally {
+        buildEnvironmentPromise = null
+      }
+    })
+    buildCleanupPromise = currentCleanup
+    try {
+      await currentCleanup
+    } finally {
+      if (buildCleanupPromise === currentCleanup) {
+        buildCleanupPromise = null
+      }
+    }
+  }
 
   const extensions = [
     `.web.mjs`,
@@ -384,11 +414,7 @@ export function tamaguiPlugin({
     },
 
     async buildEnd() {
-      try {
-        await tamaguiLoader.cleanup()
-      } finally {
-        buildEnvironmentPromise = null
-      }
+      await releaseBuildEnvironment(this.environment)
     },
 
     async config(_, env) {
@@ -549,29 +575,38 @@ export function tamaguiPlugin({
 
     async buildStart() {
       const buildConfig = this.environment.getTopLevelConfig()
-      if (buildConfig.command === 'build' && !tamaguiLoader.getEnvironment()) {
-        await tamaguiLoader.loadTamaguiBuildConfig()
-        buildEnvironmentPromise ||= (async () => {
-          const evaluationConfig = await createOwnedEvaluationConfig(buildConfig)
-          const evaluationEnvironment = createRunnableDevEnvironment(
-            TAMAGUI_EVALUATION_ENVIRONMENT,
-            evaluationConfig,
-            { hot: false }
-          )
-          try {
-            await evaluationEnvironment.init()
-          } catch (error) {
-            await evaluationEnvironment.close().catch(() => undefined)
-            throw error
-          }
-          tamaguiLoader.setEnvironment(evaluationEnvironment, { owned: true })
-        })()
-        try {
+      if (buildConfig.command !== 'build') return
+
+      const pendingCleanup = buildCleanupPromise
+      if (pendingCleanup) {
+        await pendingCleanup
+      }
+
+      const buildEnvironment = this.environment
+      activeBuildEnvironments.add(buildEnvironment)
+      try {
+        if (!tamaguiLoader.getEnvironment()) {
+          await tamaguiLoader.loadTamaguiBuildConfig()
+          buildEnvironmentPromise ||= (async () => {
+            const evaluationConfig = await createOwnedEvaluationConfig(buildConfig)
+            const evaluationEnvironment = createRunnableDevEnvironment(
+              TAMAGUI_EVALUATION_ENVIRONMENT,
+              evaluationConfig,
+              { hot: false }
+            )
+            try {
+              await evaluationEnvironment.init()
+            } catch (error) {
+              await evaluationEnvironment.close().catch(() => undefined)
+              throw error
+            }
+            tamaguiLoader.setEnvironment(evaluationEnvironment, { owned: true })
+          })()
           await buildEnvironmentPromise
-        } catch (error) {
-          buildEnvironmentPromise = null
-          throw error
         }
+      } catch (error) {
+        await releaseBuildEnvironment(buildEnvironment)
+        throw error
       }
     },
 

--- a/code/compiler/vite-plugin/src/plugin.ts
+++ b/code/compiler/vite-plugin/src/plugin.ts
@@ -26,11 +26,38 @@ const environmentSpecificTransformPluginNames = new Set([
   'one:compiler-css-to-js',
 ])
 
+const oneTsconfigPathsPluginName = 'one:tsconfig-paths'
+const bareTamaguiPackage = /^@tamagui\/[^/?#]+(?:[/?#]|$)/
+type EvaluationResolveIdHandler = (this: any, source: string, ...args: any[]) => any
+
+function createEvaluationResolveId(plugin: Plugin): Plugin['resolveId'] {
+  const resolveId = plugin.resolveId
+  if (plugin.name !== oneTsconfigPathsPluginName || !resolveId) {
+    return resolveId
+  }
+
+  const handler = (
+    typeof resolveId === 'object' ? resolveId.handler : resolveId
+  ) as EvaluationResolveIdHandler
+  const evaluationHandler = function (this: any, source: string, ...args: any[]) {
+    // One's TS-path resolver can map workspace package imports to Metro's CJS
+    // directory fallbacks before Vite can apply the package exports map. Keep
+    // user TS aliases in this resolver, but let Tamagui packages use Vite's
+    // normal package resolution and externalization policy.
+    if (bareTamaguiPackage.test(source)) return
+    return Reflect.apply(handler, this, [source, ...args])
+  }
+
+  return typeof resolveId === 'object'
+    ? { ...resolveId, handler: evaluationHandler }
+    : evaluationHandler
+}
+
 function createEvaluationPluginFacade(plugin: Plugin): Plugin {
   return {
     name: plugin.name,
     enforce: plugin.enforce,
-    resolveId: plugin.resolveId,
+    resolveId: createEvaluationResolveId(plugin),
     load: plugin.load,
     transform: environmentSpecificTransformPluginNames.has(plugin.name)
       ? undefined
@@ -60,6 +87,9 @@ async function createOwnedEvaluationConfig(config: ResolvedConfig) {
   const plugins = environment.plugins
     .filter(isEvaluationUserPlugin)
     .map(createEvaluationPluginFacade)
+  const resolve = plugins.some((plugin) => plugin.name === oneTsconfigPathsPluginName)
+    ? { ...environment.resolve, tsconfigPaths: false }
+    : environment.resolve
   const { createEnvironment: _createEnvironment, ...dev } = environment.dev
 
   // ModuleRunner needs Vite's serve-time core pipeline (especially import
@@ -74,13 +104,13 @@ async function createOwnedEvaluationConfig(config: ResolvedConfig) {
       logLevel: config.logLevel,
       plugins,
       define: environment.define,
-      resolve: environment.resolve,
+      resolve,
       environments: {
         [TAMAGUI_EVALUATION_ENVIRONMENT]: {
           consumer: environment.consumer,
           keepProcessEnv: environment.keepProcessEnv,
           define: environment.define,
-          resolve: environment.resolve,
+          resolve,
           optimizeDeps: environment.optimizeDeps,
           dev: {
             ...dev,

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/package.json
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@fixture/module-runner-app",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@fixture/components": "workspace:*",
+    "@fixture/conditional": "workspace:*"
+  },
+  "workspaces": [
+    "packages/*"
+  ]
+}

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/package.json
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@fixture/components",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./static": "./src/static.ts"
+  },
+  "dependencies": {
+    "@fixture/conditional": "workspace:*"
+  }
+}

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/FixtureFrame.tsx
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/FixtureFrame.tsx
@@ -1,0 +1,5 @@
+import { styled, View } from '@tamagui/core'
+
+export const FixtureFrame = styled(View, {
+  name: 'FixtureFrame',
+})

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/index.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/index.ts
@@ -1,0 +1,3 @@
+export { FixtureFrame } from './FixtureFrame'
+
+export { compilerResolution } from './resolution'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/resolution.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/resolution.ts
@@ -1,0 +1,6 @@
+import { resolution as conditionalResolution } from '@fixture/conditional'
+import { resolution as commandResolution } from '#command-resolution'
+import { resolution as pluginResolution } from '#plugin-resolution'
+import { resolution as workspaceResolution } from '#workspace-resolution'
+
+export const compilerResolution = `${conditionalResolution}:${workspaceResolution}:${pluginResolution}:${commandResolution}`

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/static.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/components/src/static.ts
@@ -1,0 +1,7 @@
+import { FixtureFrame } from './FixtureFrame'
+import { compilerResolution } from './resolution'
+
+globalThis.__tamaguiFixtureEvaluationOrder ??= []
+globalThis.__tamaguiFixtureEvaluationOrder.push('component')
+
+export default { FixtureFrame, compilerResolution }

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional/browser.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional/browser.ts
@@ -1,0 +1,1 @@
+export const resolution = 'browser'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional/default.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional/default.ts
@@ -1,0 +1,1 @@
+export const resolution = 'default'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional/package.json
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/conditional/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@fixture/conditional",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "browser": "./browser.ts",
+      "default": "./default.ts"
+    }
+  }
+}

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/cjs/value.cjs
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/cjs/value.cjs
@@ -1,0 +1,1 @@
+exports.resolution = 'package-export-cjs'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/esm/value.mjs
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/esm/value.mjs
@@ -1,3 +1,4 @@
 globalThis.__tamaguiFixturePackageExportPath = import.meta.url
 
 export const resolution = 'package-export-esm'
+export const modulePath = import.meta.url

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/esm/value.mjs
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/esm/value.mjs
@@ -1,0 +1,3 @@
+globalThis.__tamaguiFixturePackageExportPath = import.meta.url
+
+export const resolution = 'package-export-esm'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/metro/value/index.js
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/metro/value/index.js
@@ -1,0 +1,5 @@
+globalThis.__tamaguiFixtureMetroFallbackUsed = true
+
+throw new Error('Tamagui package import used the TS-path Metro fallback')
+
+Object.assign(module.exports, require('../../../cjs/value.cjs'))

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/package.json.fixture
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/evaluation-fixture/package.json.fixture
@@ -1,0 +1,12 @@
+{
+  "name": "@tamagui/evaluation-fixture",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./value": {
+      "import": "./esm/value.mjs",
+      "require": "./cjs/value.cjs",
+      "default": "./esm/value.mjs"
+    }
+  }
+}

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/build-resolution.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/build-resolution.ts
@@ -1,0 +1,2 @@
+export const resolution = 'build-only'
+export const space = 7

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/config-space.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/config-space.ts
@@ -1,0 +1,1 @@
+export const space = 1

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/plugin-resolution.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/plugin-resolution.ts
@@ -1,0 +1,1 @@
+export const resolution = 'user-plugin'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/resolution.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/resolution.ts
@@ -1,0 +1,2 @@
+export const resolution = 'workspace-v1'
+export const fixtureSpace = 13

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/serve-resolution.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/serve-resolution.ts
@@ -1,0 +1,2 @@
+export const resolution = 'serve-only'
+export const space = 2

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/user-alias.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/packages/workspace/src/user-alias.ts
@@ -1,0 +1,1 @@
+export const resolution = 'user-alias'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/src/App.tsx
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/src/App.tsx
@@ -1,0 +1,10 @@
+import { FixtureFrame, compilerResolution } from '@fixture/components'
+import { LocalFrame } from './LocalFrame'
+
+export function App() {
+  return (
+    <FixtureFrame $sm={{ padding: 9 }} data-resolution={compilerResolution}>
+      <LocalFrame />
+    </FixtureFrame>
+  )
+}

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/src/LocalFrame.tsx
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/src/LocalFrame.tsx
@@ -1,0 +1,5 @@
+import { styled, View } from '@tamagui/core'
+
+export const LocalFrame = styled(View, {
+  name: 'LocalFrame',
+})

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.build.config.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.build.config.ts
@@ -1,0 +1,13 @@
+import { resolution as tamaguiPackageResolution } from '@tamagui/evaluation-fixture/value'
+import { resolution as userAliasResolution } from '~/user-alias'
+import config from './tamagui.config'
+import { oneTsconfigPathsOrder } from '#evaluation-pipeline'
+
+globalThis.__tamaguiFixtureOneTsconfigPathsOrder = oneTsconfigPathsOrder
+globalThis.__tamaguiFixturePackageExportResolution = tamaguiPackageResolution
+
+export * from './tamagui.config'
+export const tamaguiPackageExportLoaded =
+  tamaguiPackageResolution === 'package-export-esm'
+export { userAliasResolution }
+export default config

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.build.config.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.build.config.ts
@@ -1,9 +1,13 @@
-import { resolution as tamaguiPackageResolution } from '@tamagui/evaluation-fixture/value'
+import {
+  modulePath as tamaguiPackagePath,
+  resolution as tamaguiPackageResolution,
+} from '@tamagui/evaluation-fixture/value'
 import { resolution as userAliasResolution } from '~/user-alias'
 import config from './tamagui.config'
 import { oneTsconfigPathsOrder } from '#evaluation-pipeline'
 
 globalThis.__tamaguiFixtureOneTsconfigPathsOrder = oneTsconfigPathsOrder
+globalThis.__tamaguiFixturePackageExportPath = tamaguiPackagePath
 globalThis.__tamaguiFixturePackageExportResolution = tamaguiPackageResolution
 
 export * from './tamagui.config'

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
@@ -1,7 +1,8 @@
 import { defaultConfig } from '@tamagui/config/v4'
 import { createTamagui } from '@tamagui/core'
+import { resolution as packageExportResolution } from '@tamagui/evaluation-fixture/value'
 import { resolution as conditionalResolution } from '@fixture/conditional'
-import evaluationPluginNames from '#evaluation-pipeline'
+import evaluationPluginNames, { oneTsconfigPathsOrder } from '#evaluation-pipeline'
 import {
   resolution as commandResolution,
   space as commandSpace,
@@ -16,7 +17,7 @@ globalThis.__tamaguiFixtureOwnedEvaluation?.push('import:config')
 globalThis.__tamaguiFixtureOwnedPluginNames = evaluationPluginNames
 
 export const compilerResolution = `${conditionalResolution}:${workspaceResolution}:${pluginResolution}:${commandResolution}`
-export { evaluationPluginNames }
+export { evaluationPluginNames, oneTsconfigPathsOrder, packageExportResolution }
 
 export default createTamagui({
   ...defaultConfig,

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
@@ -1,0 +1,37 @@
+import { defaultConfig } from '@tamagui/config/v4'
+import { createTamagui } from '@tamagui/core'
+import { resolution as conditionalResolution } from '@fixture/conditional'
+import evaluationPluginNames from '#evaluation-pipeline'
+import {
+  resolution as commandResolution,
+  space as commandSpace,
+} from '#command-resolution'
+import { space as configSpace } from '#config-space'
+import { fixtureSpace, resolution as workspaceResolution } from '#workspace-resolution'
+import { resolution as pluginResolution } from '#plugin-resolution'
+
+globalThis.__tamaguiFixtureEvaluationOrder ??= []
+globalThis.__tamaguiFixtureEvaluationOrder.push('config')
+globalThis.__tamaguiFixtureOwnedEvaluation?.push('import:config')
+globalThis.__tamaguiFixtureOwnedPluginNames = evaluationPluginNames
+
+export const compilerResolution = `${conditionalResolution}:${workspaceResolution}:${pluginResolution}:${commandResolution}`
+export { evaluationPluginNames }
+
+export default createTamagui({
+  ...defaultConfig,
+  media: {
+    ...defaultConfig.media,
+    sm: {
+      ...defaultConfig.media.sm,
+      minWidth: fixtureSpace + commandSpace + configSpace,
+    },
+  },
+  tokens: {
+    ...defaultConfig.tokens,
+    space: {
+      ...defaultConfig.tokens.space,
+      fixture: fixtureSpace + commandSpace + configSpace,
+    },
+  },
+})

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
@@ -10,7 +10,6 @@ import { Slider as TamaguiBarrelSlider } from 'tamagui'
 import evaluationPluginNames, {
   oneTsconfigPathsOrder,
   sliderResolution,
-  tamaguiExternalConfigured,
   tamaguiResolution,
 } from '#evaluation-pipeline'
 import {
@@ -30,7 +29,6 @@ globalThis.__tamaguiFixtureSliderIntervalDisabled =
 globalThis.__tamaguiFixtureSliderModuleLoaded = Boolean(Slider)
 globalThis.__tamaguiFixtureSliderResolution = sliderResolution
 globalThis.__tamaguiFixtureTamaguiBarrelLoaded = Boolean(TamaguiBarrelSlider)
-globalThis.__tamaguiFixtureTamaguiExternalConfigured = tamaguiExternalConfigured
 globalThis.__tamaguiFixtureTamaguiResolution = tamaguiResolution
 
 export const compilerResolution = `${conditionalResolution}:${workspaceResolution}:${pluginResolution}:${commandResolution}`
@@ -43,7 +41,6 @@ export {
   packageExportPath,
   packageExportResolution,
   sliderResolution,
-  tamaguiExternalConfigured,
   tamaguiResolution,
 }
 

--- a/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
+++ b/code/compiler/vite-plugin/test/fixtures/module-runner/tamagui.config.ts
@@ -1,8 +1,18 @@
 import { defaultConfig } from '@tamagui/config/v4'
 import { createTamagui } from '@tamagui/core'
-import { resolution as packageExportResolution } from '@tamagui/evaluation-fixture/value'
+import {
+  modulePath as packageExportPath,
+  resolution as packageExportResolution,
+} from '@tamagui/evaluation-fixture/value'
+import { Slider } from '@tamagui/slider'
 import { resolution as conditionalResolution } from '@fixture/conditional'
-import evaluationPluginNames, { oneTsconfigPathsOrder } from '#evaluation-pipeline'
+import { Slider as TamaguiBarrelSlider } from 'tamagui'
+import evaluationPluginNames, {
+  oneTsconfigPathsOrder,
+  sliderResolution,
+  tamaguiExternalConfigured,
+  tamaguiResolution,
+} from '#evaluation-pipeline'
 import {
   resolution as commandResolution,
   space as commandSpace,
@@ -15,9 +25,27 @@ globalThis.__tamaguiFixtureEvaluationOrder ??= []
 globalThis.__tamaguiFixtureEvaluationOrder.push('config')
 globalThis.__tamaguiFixtureOwnedEvaluation?.push('import:config')
 globalThis.__tamaguiFixtureOwnedPluginNames = evaluationPluginNames
+globalThis.__tamaguiFixtureSliderIntervalDisabled =
+  process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+globalThis.__tamaguiFixtureSliderModuleLoaded = Boolean(Slider)
+globalThis.__tamaguiFixtureSliderResolution = sliderResolution
+globalThis.__tamaguiFixtureTamaguiBarrelLoaded = Boolean(TamaguiBarrelSlider)
+globalThis.__tamaguiFixtureTamaguiExternalConfigured = tamaguiExternalConfigured
+globalThis.__tamaguiFixtureTamaguiResolution = tamaguiResolution
 
 export const compilerResolution = `${conditionalResolution}:${workspaceResolution}:${pluginResolution}:${commandResolution}`
-export { evaluationPluginNames, oneTsconfigPathsOrder, packageExportResolution }
+export const sliderIntervalDisabled = process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+export const sliderModuleLoaded = Boolean(Slider)
+export const tamaguiBarrelLoaded = Boolean(TamaguiBarrelSlider)
+export {
+  evaluationPluginNames,
+  oneTsconfigPathsOrder,
+  packageExportPath,
+  packageExportResolution,
+  sliderResolution,
+  tamaguiExternalConfigured,
+  tamaguiResolution,
+}
 
 export default createTamagui({
   ...defaultConfig,

--- a/code/compiler/vite-plugin/test/loadTamagui.test.ts
+++ b/code/compiler/vite-plugin/test/loadTamagui.test.ts
@@ -1,0 +1,662 @@
+import { execFile } from 'node:child_process'
+import { access, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { promisify } from 'node:util'
+import ts from 'typescript'
+import { build, createServer, isRunnableDevEnvironment } from 'vite'
+import type { Plugin } from 'vite'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+
+import {
+  createViteTamaguiLoader,
+  TAMAGUI_EVALUATION_ENVIRONMENT,
+} from '../src/loadTamagui'
+import { tamaguiPlugin } from '../src/plugin'
+
+const execFileAsync = promisify(execFile)
+const fixtureRoot = path.resolve(__dirname, 'fixtures/module-runner')
+const appPath = path.join(fixtureRoot, 'src/App.tsx')
+const resolutionPath = path.join(fixtureRoot, 'packages/workspace/src/resolution.ts')
+const configSpacePath = path.join(fixtureRoot, 'packages/workspace/src/config-space.ts')
+const componentEntryPath = path.join(fixtureRoot, 'packages/components/src/index.ts')
+const watchOutputRoot = path.join(fixtureRoot, '.watch-dist')
+const fixtureComponents = ['@fixture/components', '@fixture/components/static']
+const evaluationPipelineId = '\0fixture-evaluation-pipeline'
+const fixtureAliases = {
+  '#workspace-resolution': resolutionPath,
+  '@fixture/conditional': path.join(fixtureRoot, 'packages/conditional'),
+}
+
+function fixtureResolverPlugin(): Plugin {
+  const resolveId = (source: string) => {
+    if (source === '#evaluation-pipeline') {
+      return evaluationPipelineId
+    }
+    if (source === '#plugin-resolution') {
+      return path.join(fixtureRoot, 'packages/workspace/src/plugin-resolution.ts')
+    }
+    if (source === '#config-space') {
+      return configSpacePath
+    }
+  }
+  const load = function (this: any, id: string) {
+    if (id === evaluationPipelineId) {
+      return `export default ${JSON.stringify(this.environment.plugins.map((plugin: Plugin) => plugin.name))}`
+    }
+  }
+  return {
+    name: 'fixture-user-resolver',
+    enforce: 'pre',
+    resolveId,
+    load,
+    applyToEnvironment() {
+      return {
+        name: 'fixture-user-resolver:environment',
+        enforce: 'pre',
+        resolveId,
+        load,
+      }
+    },
+  }
+}
+
+type LifecycleCounts = {
+  options: number
+  buildStart: number
+  buildEnd: number
+  closeBundle: number
+}
+
+function commandResolverPlugin(
+  command: 'serve' | 'build',
+  lifecycle?: LifecycleCounts
+): Plugin {
+  const resolveId = (source: string) => {
+    if (source === '#fixture-config') {
+      ;((globalThis as any).__tamaguiFixtureOwnedEvaluation ??= []).push(
+        `resolve:${command}`
+      )
+      return path.join(fixtureRoot, 'tamagui.config.ts')
+    }
+    if (source === '#command-resolution') {
+      return path.join(fixtureRoot, `packages/workspace/src/${command}-resolution.ts`)
+    }
+  }
+  const options = () => {
+    if (lifecycle) lifecycle.options++
+  }
+  const buildStart = () => {
+    if (lifecycle) lifecycle.buildStart++
+  }
+  const buildEnd = () => {
+    if (lifecycle) lifecycle.buildEnd++
+  }
+  const closeBundle = () => {
+    if (lifecycle) lifecycle.closeBundle++
+  }
+  return {
+    name: `fixture-${command}-resolver`,
+    apply: command,
+    enforce: 'pre',
+    options,
+    buildStart,
+    buildEnd,
+    closeBundle,
+    resolveId,
+    applyToEnvironment() {
+      return {
+        name: `fixture-${command}-resolver:environment`,
+        enforce: 'pre',
+        options,
+        buildStart,
+        buildEnd,
+        closeBundle,
+        resolveId,
+      }
+    },
+  }
+}
+
+function fixturePlugins(lifecycle?: LifecycleCounts) {
+  return [
+    fixtureResolverPlugin(),
+    commandResolverPlugin('serve'),
+    commandResolverPlugin('build', lifecycle),
+  ]
+}
+
+type TransformVisits = Record<'client' | 'ssr', number>
+
+function getTransformVisits(): TransformVisits {
+  return ((globalThis as any).__tamaguiFixtureTransformVisits ??= {
+    client: 0,
+    ssr: 0,
+  })
+}
+
+function fixtureTransformProbePlugin(): Plugin {
+  return {
+    name: 'fixture-transform-probe',
+    transform(this: any, _source, id) {
+      if (path.resolve(id.split('?')[0]) !== appPath) return
+      const environmentName = this.environment?.name
+      if (environmentName === 'client' || environmentName === 'ssr') {
+        getTransformVisits()[environmentName]++
+      }
+    },
+  }
+}
+
+function expectMediaPaddingCss(css: string | undefined, breakpoint: number) {
+  expect(css).toBeTruthy()
+  expect(css).toMatch(
+    new RegExp(`\\(\\s*(?:width\\s*>=|min-width\\s*:)\\s*${breakpoint}px\\s*\\)`)
+  )
+  for (const side of ['top', 'right', 'bottom', 'left']) {
+    expect(css).toMatch(new RegExp(`padding-${side}\\s*:\\s*9px`))
+  }
+}
+
+async function waitForFileChange(
+  server: Awaited<ReturnType<typeof createServer>>,
+  file: string,
+  stage: string
+) {
+  await new Promise<void>((resolve, reject) => {
+    const normalizedFile = path.resolve(file)
+    const cleanup = () => {
+      clearTimeout(timeout)
+      server.watcher.off('change', onChange)
+    }
+    const onChange = (changedFile: string) => {
+      if (path.resolve(changedFile) !== normalizedFile) return
+      cleanup()
+      setTimeout(resolve, 100)
+    }
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(
+        new Error(`Timed out waiting for ${stage} watcher change: ${normalizedFile}`)
+      )
+    }, 5_000)
+    server.watcher.on('change', onChange)
+  })
+}
+
+async function readBuiltCss(outDir: string) {
+  const cssFile = (await readdir(outDir)).find((file) => file.endsWith('.css'))
+  if (!cssFile) throw new Error(`Expected CSS output in ${outDir}`)
+  return readFile(path.join(outDir, cssFile), 'utf8')
+}
+
+function waitForWatchBuild(watcher: any) {
+  return new Promise<void>((resolve, reject) => {
+    const onEvent = (event: any) => {
+      if (event.code === 'ERROR') {
+        watcher.off?.('event', onEvent)
+        reject(event.error)
+      }
+      if (event.code === 'END') {
+        watcher.off?.('event', onEvent)
+        resolve()
+      }
+    }
+    watcher.on('event', onEvent)
+  })
+}
+
+const servers: Awaited<ReturnType<typeof createServer>>[] = []
+let previousCwd = ''
+
+beforeEach(() => {
+  previousCwd = process.cwd()
+  process.chdir(fixtureRoot)
+})
+
+afterEach(async () => {
+  try {
+    await Promise.all(servers.splice(0).map((server) => server.close()))
+  } finally {
+    process.chdir(previousCwd)
+    delete (globalThis as any).__tamaguiFixtureEvaluationOrder
+    delete (globalThis as any).__tamaguiFixtureOwnedEvaluation
+    delete (globalThis as any).__tamaguiFixtureOwnedPluginNames
+    delete (globalThis as any).__tamaguiFixtureTransformVisits
+    await rm(path.join(fixtureRoot, 'node_modules'), { force: true, recursive: true })
+    await rm(watchOutputRoot, { force: true, recursive: true })
+  }
+})
+
+test('evaluates config and components through the app resolver and invalidates HMR', async () => {
+  const server = await createServer({
+    configFile: false,
+    root: fixtureRoot,
+    logLevel: 'silent',
+    server: {
+      middlewareMode: true,
+    },
+    resolve: {
+      alias: fixtureAliases,
+    },
+    plugins: [
+      ...fixturePlugins(),
+      fixtureTransformProbePlugin(),
+      tamaguiPlugin({
+        components: fixtureComponents,
+        enableDynamicEvaluation: true,
+        disableWatchTamaguiConfig: false,
+      }),
+    ],
+  })
+  servers.push(server)
+
+  const clientEnvironment = server.environments.client
+  const evaluationEnvironment = server.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
+  expect(isRunnableDevEnvironment(evaluationEnvironment)).toBe(true)
+  if (!isRunnableDevEnvironment(evaluationEnvironment)) {
+    throw new Error('Expected a runnable Tamagui evaluation environment')
+  }
+
+  const loader = createViteTamaguiLoader()
+  loader.setEnvironment(evaluationEnvironment)
+  const componentResolution =
+    await evaluationEnvironment.pluginContainer.resolveId('@fixture/components')
+  const clientResolution =
+    await clientEnvironment.pluginContainer.resolveId('@fixture/conditional')
+  const compilerResolution =
+    await evaluationEnvironment.pluginContainer.resolveId('@fixture/conditional')
+
+  expect(componentResolution?.id).toBe(componentEntryPath)
+  expect(clientResolution?.id).toBe(compilerResolution?.id)
+  expect(clientResolution?.id).toMatch(/browser\.ts$/)
+
+  ;(globalThis as any).__tamaguiFixtureEvaluationOrder = []
+  const directConfigResolution = await evaluationEnvironment.pluginContainer.resolveId(
+    path.join(fixtureRoot, 'tamagui.config.ts')
+  )
+  expect(directConfigResolution?.id).toBe(path.join(fixtureRoot, 'tamagui.config.ts'))
+  const directConfigModule = await evaluationEnvironment.runner.import(
+    directConfigResolution!.id
+  )
+  expect(directConfigModule.compilerResolution).toBe(
+    'browser:workspace-v1:user-plugin:serve-only'
+  )
+  expect((directConfigModule.default as any).media.sm).toEqual({ minWidth: 16 })
+  expect(directConfigModule.evaluationPluginNames).toContain('vite:import-analysis')
+
+  const firstEvaluation = await loader.evaluateProjectModules({
+    config: 'tamagui.config.ts',
+    components: fixtureComponents,
+  })
+  expect(firstEvaluation.config.module.compilerResolution).toBe(
+    'browser:workspace-v1:user-plugin:serve-only'
+  )
+  expect((firstEvaluation.components[1].module.default as any).compilerResolution).toBe(
+    'browser:workspace-v1:user-plugin:serve-only'
+  )
+  expect((globalThis as any).__tamaguiFixtureEvaluationOrder).toEqual([
+    'config',
+    'component',
+  ])
+
+  const firstTransform = await clientEnvironment.transformRequest('/src/App.tsx')
+  expect(firstTransform?.code).toBeTruthy()
+  expect(firstTransform?.code).toContain('className')
+  const cssRequest = firstTransform?.code.match(/import "([^"]+\.tamagui\.css)"/)?.[1]
+  expect(cssRequest).toBeTruthy()
+  const firstCss = await clientEnvironment.transformRequest(cssRequest!)
+  expectMediaPaddingCss(firstCss?.code, 16)
+  const absoluteCssRequest = `${fixtureRoot}/src/App.tsx.tamagui.css`
+  const queryResolution = await clientEnvironment.pluginContainer.resolveId(
+    `${absoluteCssRequest}?direct`
+  )
+  expect(queryResolution?.id).toBe(`${absoluteCssRequest}?direct`)
+  const ssrEnvironment = server.environments.ssr
+  expect(ssrEnvironment).toBeTruthy()
+  if (!ssrEnvironment) {
+    throw new Error('Expected an SSR environment')
+  }
+  const firstSsrTransform = await ssrEnvironment.transformRequest('/src/App.tsx')
+  expect(firstSsrTransform?.code).toBeTruthy()
+  await Promise.all([
+    clientEnvironment.waitForRequestsIdle(),
+    ssrEnvironment.waitForRequestsIdle(),
+  ])
+  const initialTransformVisits = { ...getTransformVisits() }
+  expect(initialTransformVisits.client).toBeGreaterThan(0)
+  expect(initialTransformVisits.ssr).toBeGreaterThan(0)
+
+  const originalResolution = await readFile(resolutionPath, 'utf8')
+  const originalConfigSpace = await readFile(configSpacePath, 'utf8')
+  const sendSpy = vi.spyOn(server.ws, 'send')
+  const getHmrEvents = () =>
+    sendSpy.mock.calls
+      .map(([payload]) => payload)
+      .filter((payload) => payload.type === 'full-reload' || payload.type === 'update')
+  const getCompilerReloads = () =>
+    getHmrEvents().filter(
+      (payload) => payload.type === 'full-reload' && payload.triggeredBy
+    )
+  const expectValidNonCompilerEvents = () => {
+    const events = getHmrEvents().filter(
+      (payload) => !(payload.type === 'full-reload' && payload.triggeredBy)
+    )
+    expect(events.length).toBeLessThanOrEqual(1)
+    for (const payload of events) {
+      if (payload.type === 'full-reload') {
+        expect(payload).toEqual({ type: 'full-reload', path: '*' })
+      } else {
+        expect(payload.updates.length).toBeGreaterThan(0)
+        for (const update of payload.updates) {
+          expect(update).toEqual(
+            expect.objectContaining({
+              type: expect.stringMatching(/^(?:js|css)-update$/),
+              path: expect.any(String),
+              acceptedPath: expect.any(String),
+              timestamp: expect.any(Number),
+            })
+          )
+        }
+      }
+    }
+  }
+  try {
+    const configUpdateFinished = waitForFileChange(
+      server,
+      configSpacePath,
+      'config dependency update'
+    )
+    await writeFile(configSpacePath, originalConfigSpace.replace('1', '3'))
+    await configUpdateFinished
+
+    await vi.waitFor(() => {
+      expect(getCompilerReloads()).toHaveLength(1)
+    })
+
+    const configUpdatedTransform =
+      await clientEnvironment.transformRequest('/src/App.tsx')
+    const configUpdatedSsrTransform =
+      await ssrEnvironment.transformRequest('/src/App.tsx')
+    const configUpdatedCss = await clientEnvironment.transformRequest(cssRequest!)
+    expect(configUpdatedTransform?.code).toBeTruthy()
+    expect(configUpdatedSsrTransform?.code).toBeTruthy()
+    expect(configUpdatedCss?.code).not.toBe(firstCss?.code)
+    expectMediaPaddingCss(configUpdatedCss?.code, 18)
+    await Promise.all([
+      clientEnvironment.waitForRequestsIdle(),
+      ssrEnvironment.waitForRequestsIdle(),
+    ])
+    const configUpdatedTransformVisits = { ...getTransformVisits() }
+    expect(configUpdatedTransformVisits.client).toBeGreaterThan(
+      initialTransformVisits.client
+    )
+    expect(configUpdatedTransformVisits.ssr).toBeGreaterThan(initialTransformVisits.ssr)
+    expect(getCompilerReloads()).toEqual([
+      {
+        type: 'full-reload',
+        path: '*',
+        triggeredBy: configSpacePath,
+      },
+    ])
+    expectValidNonCompilerEvents()
+
+    sendSpy.mockClear()
+    const changed = originalResolution
+      .replace('workspace-v1', 'workspace-v2')
+      .replace('13', '17')
+    const updateFinished = waitForFileChange(
+      server,
+      resolutionPath,
+      'shared dependency update'
+    )
+    await writeFile(resolutionPath, changed)
+    await updateFinished
+
+    await vi.waitFor(() => {
+      expect(getCompilerReloads()).toHaveLength(1)
+    })
+
+    const updatedEvaluation = await loader.evaluateProjectModules({
+      config: 'tamagui.config.ts',
+      components: fixtureComponents,
+    })
+    expect(updatedEvaluation.config.module.compilerResolution).toBe(
+      'browser:workspace-v2:user-plugin:serve-only'
+    )
+    expect(
+      (updatedEvaluation.components[1].module.default as any).compilerResolution
+    ).toBe('browser:workspace-v2:user-plugin:serve-only')
+
+    const updatedTransform = await clientEnvironment.transformRequest('/src/App.tsx')
+    const updatedSsrTransform = await ssrEnvironment.transformRequest('/src/App.tsx')
+    expect(updatedTransform?.code).toBeTruthy()
+    expect(updatedSsrTransform?.code).toBeTruthy()
+    const updatedCss = await clientEnvironment.transformRequest(cssRequest!)
+    expect(updatedCss?.code).not.toBe(configUpdatedCss?.code)
+    expectMediaPaddingCss(updatedCss?.code, 22)
+    await Promise.all([
+      clientEnvironment.waitForRequestsIdle(),
+      ssrEnvironment.waitForRequestsIdle(),
+    ])
+    const updatedTransformVisits = getTransformVisits()
+    expect(updatedTransformVisits.client).toBeGreaterThan(
+      configUpdatedTransformVisits.client
+    )
+    expect(updatedTransformVisits.ssr).toBeGreaterThan(configUpdatedTransformVisits.ssr)
+    expect(getCompilerReloads()).toEqual([
+      {
+        type: 'full-reload',
+        path: '*',
+        triggeredBy: resolutionPath,
+      },
+    ])
+    expectValidNonCompilerEvents()
+  } finally {
+    const restoreFinished = waitForFileChange(
+      server,
+      resolutionPath,
+      'shared dependency restore'
+    )
+    await writeFile(resolutionPath, originalResolution)
+    await restoreFinished
+    const restoreConfigFinished = waitForFileChange(
+      server,
+      configSpacePath,
+      'config dependency restore'
+    )
+    await writeFile(configSpacePath, originalConfigSpace)
+    await restoreConfigFinished
+  }
+
+  await expect(access(path.join(fixtureRoot, '.tamagui'))).rejects.toThrow()
+}, 30_000)
+
+test('evaluates the same fixture during a production build without legacy bundles', async () => {
+  const lifecycle: LifecycleCounts = {
+    options: 0,
+    buildStart: 0,
+    buildEnd: 0,
+    closeBundle: 0,
+  }
+  ;(globalThis as any).__tamaguiFixtureOwnedEvaluation = []
+  const result = await build({
+    configFile: false,
+    root: fixtureRoot,
+    logLevel: 'silent',
+    resolve: {
+      alias: fixtureAliases,
+    },
+    plugins: [
+      ...fixturePlugins(lifecycle),
+      tamaguiPlugin({
+        config: '#fixture-config',
+        components: fixtureComponents,
+        enableDynamicEvaluation: true,
+      }),
+    ],
+    build: {
+      write: false,
+      lib: {
+        entry: path.join(fixtureRoot, 'src/App.tsx'),
+        formats: ['es'],
+      },
+    },
+  })
+
+  const outputs = Array.isArray(result) ? result : [result]
+  const buildOutput = outputs
+    .flatMap((output: any) => output.output || [])
+    .map((output: any) =>
+      output.type === 'asset'
+        ? typeof output.source === 'string'
+          ? output.source
+          : Buffer.from(output.source).toString('utf8')
+        : output.code
+    )
+    .join('\n')
+
+  expect(buildOutput).toContain('browser:workspace-v1:user-plugin:build-only')
+  expect(buildOutput).not.toContain('serve-only')
+  expectMediaPaddingCss(buildOutput, 21)
+  expect(buildOutput).not.toContain('$fixture')
+  const evaluationProbe = (globalThis as any).__tamaguiFixtureOwnedEvaluation
+  const evaluationPluginNames = (globalThis as any).__tamaguiFixtureOwnedPluginNames
+  expect(evaluationProbe).toContain('resolve:build')
+  expect(evaluationProbe).toContain('import:config')
+  expect(evaluationProbe).not.toContain('resolve:serve')
+  expect(evaluationProbe.indexOf('resolve:build')).toBeLessThan(
+    evaluationProbe.indexOf('import:config')
+  )
+  expect(
+    evaluationPluginNames.filter((name: string) => name.includes('import-analysis'))
+  ).toHaveLength(1)
+  for (const name of ['alias', 'vite:import-analysis']) {
+    expect(
+      evaluationPluginNames.filter((pluginName: string) => pluginName === name)
+    ).toHaveLength(1)
+  }
+  expect(
+    evaluationPluginNames.filter((name: string) =>
+      ['vite:resolve-dev', 'builtin:vite-resolve'].includes(name)
+    )
+  ).toHaveLength(1)
+  expect(evaluationPluginNames).not.toContain('vite:build-import-analysis')
+  expect(
+    evaluationPluginNames.some((name: string) => name.includes('load-fallback'))
+  ).toBe(false)
+  expect(
+    evaluationPluginNames.filter(
+      (name: string) => name === 'fixture-build-resolver:environment'
+    )
+  ).toHaveLength(1)
+  expect(evaluationPluginNames).not.toContain('fixture-serve-resolver:environment')
+  expect(lifecycle).toEqual({
+    options: 1,
+    buildStart: 1,
+    buildEnd: 1,
+    closeBundle: 1,
+  })
+  await expect(access(path.join(fixtureRoot, '.tamagui'))).rejects.toThrow()
+})
+
+test('isolates extraction caches and rebuilds CSS for a config-only dependency', async () => {
+  const originalConfigSpace = await readFile(configSpacePath, 'utf8')
+  const watcher = await build({
+    configFile: false,
+    root: fixtureRoot,
+    logLevel: 'silent',
+    resolve: {
+      alias: fixtureAliases,
+    },
+    plugins: [
+      ...fixturePlugins(),
+      tamaguiPlugin({
+        config: '#fixture-config',
+        components: fixtureComponents,
+        enableDynamicEvaluation: true,
+      }),
+    ],
+    build: {
+      outDir: watchOutputRoot,
+      emptyOutDir: true,
+      watch: {},
+      lib: {
+        entry: path.join(fixtureRoot, 'src/App.tsx'),
+        formats: ['es'],
+      },
+    },
+  })
+
+  if (Array.isArray(watcher) || !('on' in watcher)) {
+    throw new Error('Expected a Vite build watcher')
+  }
+
+  try {
+    await waitForWatchBuild(watcher)
+    const firstCss = await readBuiltCss(watchOutputRoot)
+    expectMediaPaddingCss(firstCss, 21)
+
+    const rebuildFinished = waitForWatchBuild(watcher)
+    await writeFile(configSpacePath, originalConfigSpace.replace('1', '4'))
+    await rebuildFinished
+
+    const updatedCss = await readBuiltCss(watchOutputRoot)
+    expectMediaPaddingCss(updatedCss, 24)
+    expect(updatedCss).not.toBe(firstCss)
+  } finally {
+    await watcher.close()
+    await writeFile(configSpacePath, originalConfigSpace)
+  }
+}, 20_000)
+
+test('published declarations typecheck for a package consumer', async () => {
+  const consumerPath = path.resolve(__dirname, 'types/consumer.ts')
+  const program = ts.createProgram([consumerPath], {
+    allowSyntheticDefaultImports: true,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+  })
+  const diagnostics = ts.getPreEmitDiagnostics(program)
+  expect(
+    ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (fileName) => fileName,
+      getCurrentDirectory: () => process.cwd(),
+      getNewLine: () => '\n',
+    })
+  ).toBe('')
+
+  const pluginTypes = await readFile(
+    path.resolve(__dirname, '../types/plugin.d.ts'),
+    'utf8'
+  )
+  const loaderTypes = await readFile(
+    path.resolve(__dirname, '../types/loadTamagui.d.ts'),
+    'utf8'
+  )
+  expect(pluginTypes).not.toContain('@tamagui/static-worker')
+  expect(loaderTypes).toContain('createViteTamaguiLoader')
+  expect(loaderTypes).not.toContain('export declare function getTamaguiOptions')
+})
+
+test('published ESM loader reads the CommonJS static runtime', async () => {
+  const loaderPath = path.resolve(__dirname, '../dist/esm/loadTamagui.mjs')
+  await access(loaderPath)
+
+  const { stdout } = await execFileAsync(process.execPath, [
+    '--input-type=module',
+    '--eval',
+    `
+      import { createViteTamaguiLoader } from ${JSON.stringify(pathToFileURL(loaderPath).href)}
+      const loader = createViteTamaguiLoader({ disable: true })
+      const options = await loader.loadTamaguiBuildConfig()
+      process.stdout.write(JSON.stringify({ disable: options.disable, platform: options.platform }))
+    `,
+  ])
+
+  expect(JSON.parse(stdout)).toEqual({ disable: true, platform: 'web' })
+})

--- a/code/compiler/vite-plugin/test/loadTamagui.test.ts
+++ b/code/compiler/vite-plugin/test/loadTamagui.test.ts
@@ -43,6 +43,11 @@ const metroFallbackPath = path.join(evaluationFixtureRuntimePath, 'metro/value/i
 const userAliasPath = path.join(fixtureRoot, 'packages/workspace/src/user-alias.ts')
 const watchOutputRoot = path.join(fixtureRoot, '.watch-dist')
 const fixtureComponents = ['@fixture/components', '@fixture/components/static']
+const directPackageFixtureComponents = [
+  ...fixtureComponents,
+  'tamagui',
+  '@tamagui/button',
+]
 const evaluationPipelineId = '\0fixture-evaluation-pipeline'
 const oneCompilerResolutionId = '\0fixture-one-compiler-resolution'
 const fixtureAliases = {
@@ -83,19 +88,7 @@ function fixtureResolverPlugin(): Plugin {
         'tamagui',
         path.join(fixtureRoot, 'tamagui.config.ts')
       )
-      const external = this.environment.config.resolve.external
-      const tamaguiExternalConfigured =
-        external === true || external?.includes('tamagui') === true
-      return `export default ${JSON.stringify(plugins.map((plugin) => plugin.name))}; export const oneTsconfigPathsOrder = ${JSON.stringify(oneTsconfigPathsOrder)}; export const sliderResolution = ${JSON.stringify({ id: sliderResolution?.id, external: sliderResolution?.external === true })}; export const tamaguiResolution = ${JSON.stringify({ id: tamaguiResolution?.id, external: tamaguiResolution?.external === true })}; export const tamaguiExternalConfigured = ${JSON.stringify(tamaguiExternalConfigured)}`
-    }
-  }
-  const transform = function (this: any, _source: string, id: string) {
-    if (
-      this.environment?.name === TAMAGUI_EVALUATION_ENVIRONMENT &&
-      /\/(?:node_modules\/tamagui|code\/ui\/tamagui)\//.test(id)
-    ) {
-      ;(globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms =
-        ((globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms || 0) + 1
+      return `export default ${JSON.stringify(plugins.map((plugin) => plugin.name))}; export const oneTsconfigPathsOrder = ${JSON.stringify(oneTsconfigPathsOrder)}; export const sliderResolution = ${JSON.stringify({ id: sliderResolution?.id, external: sliderResolution?.external === true })}; export const tamaguiResolution = ${JSON.stringify({ id: tamaguiResolution?.id, external: tamaguiResolution?.external === true })}`
     }
   }
   return {
@@ -103,14 +96,12 @@ function fixtureResolverPlugin(): Plugin {
     enforce: 'pre',
     resolveId,
     load,
-    transform,
     applyToEnvironment() {
       return {
         name: 'fixture-user-resolver:environment',
         enforce: 'pre',
         resolveId,
         load,
-        transform,
       }
     },
   }
@@ -419,8 +410,6 @@ afterEach(async () => {
     delete (globalThis as any).__tamaguiFixtureSliderModuleLoaded
     delete (globalThis as any).__tamaguiFixtureSliderResolution
     delete (globalThis as any).__tamaguiFixtureTamaguiBarrelLoaded
-    delete (globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms
-    delete (globalThis as any).__tamaguiFixtureTamaguiExternalConfigured
     delete (globalThis as any).__tamaguiFixtureTamaguiResolution
     delete (globalThis as any).__tamaguiFixtureTransformVisits
     delete (globalThis as any).__tamaguiFixtureTsconfigPathsContext
@@ -472,7 +461,7 @@ test('evaluates config and components through the app resolver and invalidates H
       ...fixturePlugins(undefined, true),
       fixtureTransformProbePlugin(),
       tamaguiPlugin({
-        components: fixtureComponents,
+        components: directPackageFixtureComponents,
         enableDynamicEvaluation: true,
         disableWatchTamaguiConfig: false,
       }),
@@ -531,21 +520,26 @@ test('evaluates config and components through the app resolver and invalidates H
     'tamagui',
     directConfigResolution!.id
   )
+  const buttonResolution = await evaluationEnvironment.pluginContainer.resolveId(
+    '@tamagui/button',
+    directConfigResolution!.id
+  )
   expect(inlinePackageResolution?.id).toMatch(
     /(?:node_modules\/@tamagui\/config|code\/core\/config)\/dist\/esm\/v5\.mjs$/
   )
   expect(inlinePackageResolution?.external).not.toBe(true)
   expect(sliderResolution?.id).toMatch(/\/slider\/dist\/esm\/index\.mjs$/)
   expect(sliderResolution?.external).not.toBe(true)
-  expect(tamaguiResolution).toEqual({
-    id: 'tamagui',
-    external: true,
-  })
+  expect(tamaguiResolution?.id).toMatch(/\/tamagui\/dist\/esm\/index\.mjs$/)
+  expect(tamaguiResolution?.external).not.toBe(true)
+  expect(buttonResolution?.id).toMatch(/\/button\/dist\/esm\/index\.mjs$/)
+  expect(buttonResolution?.external).not.toBe(true)
   const externalPackages = evaluationEnvironment.config.resolve.external
   expect(externalPackages).toContain('@tamagui/evaluation-fixture')
   expect(externalPackages).toContain('@tamagui/shorthands')
-  expect(externalPackages).toContain('tamagui')
+  expect(externalPackages).not.toContain('tamagui')
   expect(externalPackages).not.toContain('@tamagui/config')
+  expect(externalPackages).not.toContain('@tamagui/button')
   expect(externalPackages).not.toContain('@tamagui/core')
   expect(externalPackages).not.toContain('@tamagui/slider')
   expect(externalPackages).not.toContain('@tamagui/web')
@@ -572,11 +566,10 @@ test('evaluates config and components through the app resolver and invalidates H
   })
   expect(directConfigModule.tamaguiBarrelLoaded).toBe(true)
   expect(directConfigModule.tamaguiResolution).toEqual({
-    id: 'tamagui',
-    external: true,
+    id: tamaguiResolution?.id,
+    external: false,
   })
   expect(process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL).toBeUndefined()
-  expect((globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms).toBeUndefined()
   expect((globalThis as any).__tamaguiFixturePackageExportPath).toMatch(
     /\.evaluation-fixture-runtime\/esm\/value\.mjs$/
   )
@@ -586,7 +579,7 @@ test('evaluates config and components through the app resolver and invalidates H
 
   const firstEvaluation = await loader.evaluateProjectModules({
     config: 'tamagui.config.ts',
-    components: fixtureComponents,
+    components: directPackageFixtureComponents,
   })
   expect(firstEvaluation.config.module.compilerResolution).toBe(
     'browser:workspace-v1:user-plugin:serve-only'
@@ -594,6 +587,8 @@ test('evaluates config and components through the app resolver and invalidates H
   expect((firstEvaluation.components[1].module.default as any).compilerResolution).toBe(
     'browser:workspace-v1:user-plugin:serve-only'
   )
+  expect(firstEvaluation.components[2].module.Slider).toBeTruthy()
+  expect(firstEvaluation.components[3].module.Button).toBeTruthy()
   expect((globalThis as any).__tamaguiFixtureEvaluationOrder).toEqual([
     'config',
     'component',
@@ -840,7 +835,7 @@ test('evaluates the same fixture during a production build without legacy bundle
       ...fixturePlugins(lifecycle, true),
       tamaguiPlugin({
         config: '#fixture-config',
-        components: fixtureComponents,
+        components: directPackageFixtureComponents,
         enableDynamicEvaluation: true,
       }),
     ],
@@ -913,9 +908,7 @@ test('evaluates the same fixture during a production build without legacy bundle
     external: false,
   })
   expect((globalThis as any).__tamaguiFixtureTamaguiBarrelLoaded).toBe(true)
-  expect((globalThis as any).__tamaguiFixtureTamaguiExternalConfigured).toBe(true)
   expect(process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL).toBeUndefined()
-  expect((globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms).toBeUndefined()
   expect((globalThis as any).__tamaguiFixtureMetroFallbackUsed).toBeUndefined()
   expect(lifecycle).toEqual({
     options: 1,

--- a/code/compiler/vite-plugin/test/loadTamagui.test.ts
+++ b/code/compiler/vite-plugin/test/loadTamagui.test.ts
@@ -7,6 +7,7 @@ import {
   readdir,
   rename,
   rm,
+  symlink,
   writeFile,
 } from 'node:fs/promises'
 import path from 'node:path'
@@ -30,6 +31,10 @@ const resolutionPath = path.join(fixtureRoot, 'packages/workspace/src/resolution
 const configSpacePath = path.join(fixtureRoot, 'packages/workspace/src/config-space.ts')
 const componentEntryPath = path.join(fixtureRoot, 'packages/components/src/index.ts')
 const evaluationFixturePackagePath = path.join(fixtureRoot, 'packages/evaluation-fixture')
+const evaluationFixturePhysicalRuntimePath = path.join(
+  fixtureRoot,
+  '.evaluation-fixture-runtime'
+)
 const evaluationFixtureRuntimePath = path.join(
   fixtureRoot,
   'node_modules/@tamagui/evaluation-fixture'
@@ -42,7 +47,10 @@ const evaluationPipelineId = '\0fixture-evaluation-pipeline'
 const oneCompilerResolutionId = '\0fixture-one-compiler-resolution'
 const fixtureAliases = {
   '#workspace-resolution': resolutionPath,
-  '@fixture/conditional': path.join(fixtureRoot, 'packages/conditional'),
+}
+
+function isEvaluationCorePluginName(name: string) {
+  return name === 'alias' || name.startsWith('vite:') || name.startsWith('builtin:vite-')
 }
 
 function fixtureResolverPlugin(): Plugin {
@@ -113,12 +121,30 @@ function oneTsconfigPathsPlugin(): Plugin {
   }
 }
 
-function environmentSpecificCompilerPlugins(): Plugin[] {
+function environmentSpecificCompilerPlugins(
+  apply: 'serve' | 'build' = 'build'
+): Plugin[] {
+  const recordLifecycle = (pluginName: string, hook: string) => {
+    ;((globalThis as any).__tamaguiFixtureOneConfigLifecycles ??= []).push(
+      `${pluginName}:${hook}`
+    )
+  }
+  const recordTransform = (pluginName: string, environmentName: string | undefined) => {
+    ;((globalThis as any).__tamaguiFixtureOneTransformEnvironments ??= []).push(
+      `${pluginName}:${environmentName}`
+    )
+  }
   return [
     {
       name: 'one:compiler',
-      apply: 'build',
+      apply,
       enforce: 'pre',
+      config() {
+        recordLifecycle('one:compiler', 'config')
+      },
+      configResolved() {
+        recordLifecycle('one:compiler', 'configResolved')
+      },
       resolveId(source, importer) {
         if (source !== '#plugin-resolution') return
         const evaluationProbe = (globalThis as any).__tamaguiFixtureOwnedEvaluation
@@ -139,6 +165,7 @@ function environmentSpecificCompilerPlugins(): Plugin[] {
       },
       transform() {
         const environmentName = this.environment?.name
+        recordTransform('one:compiler', environmentName)
         if (environmentName !== 'client' && environmentName !== 'ssr') {
           throw new Error(`Invalid env: ${environmentName}`)
         }
@@ -146,9 +173,16 @@ function environmentSpecificCompilerPlugins(): Plugin[] {
     },
     {
       name: 'one:compiler-css-to-js',
-      apply: 'build',
+      apply,
+      config() {
+        recordLifecycle('one:compiler-css-to-js', 'config')
+      },
+      configResolved() {
+        recordLifecycle('one:compiler-css-to-js', 'configResolved')
+      },
       transform() {
         const environmentName = this.environment?.name
+        recordTransform('one:compiler-css-to-js', environmentName)
         if (environmentName !== 'client' && environmentName !== 'ssr') {
           throw new Error(`Invalid env: ${environmentName}`)
         }
@@ -330,13 +364,21 @@ beforeEach(async () => {
   previousCwd = process.cwd()
   process.chdir(fixtureRoot)
   const fixturePackageScope = path.join(fixtureRoot, 'node_modules/@tamagui')
+  const fixtureConditionalScope = path.join(fixtureRoot, 'node_modules/@fixture')
   await mkdir(fixturePackageScope, { recursive: true })
-  await cp(evaluationFixturePackagePath, evaluationFixtureRuntimePath, {
+  await mkdir(fixtureConditionalScope, { recursive: true })
+  await cp(evaluationFixturePackagePath, evaluationFixturePhysicalRuntimePath, {
     recursive: true,
   })
   await rename(
-    path.join(evaluationFixtureRuntimePath, 'package.json.fixture'),
-    path.join(evaluationFixtureRuntimePath, 'package.json')
+    path.join(evaluationFixturePhysicalRuntimePath, 'package.json.fixture'),
+    path.join(evaluationFixturePhysicalRuntimePath, 'package.json')
+  )
+  await symlink(evaluationFixturePhysicalRuntimePath, evaluationFixtureRuntimePath, 'dir')
+  await symlink(
+    path.join(fixtureRoot, 'packages/conditional'),
+    path.join(fixtureConditionalScope, 'conditional'),
+    'dir'
   )
 })
 
@@ -354,7 +396,10 @@ afterEach(async () => {
     delete (globalThis as any).__tamaguiFixturePackageExportResolution
     delete (globalThis as any).__tamaguiFixtureMetroFallbackUsed
     delete (globalThis as any).__tamaguiFixtureOneTsconfigPathsOrder
+    delete (globalThis as any).__tamaguiFixtureOneConfigLifecycles
+    delete (globalThis as any).__tamaguiFixtureOneTransformEnvironments
     await rm(path.join(fixtureRoot, 'node_modules'), { force: true, recursive: true })
+    await rm(evaluationFixturePhysicalRuntimePath, { force: true, recursive: true })
     await rm(watchOutputRoot, { force: true, recursive: true })
   }
 })
@@ -374,6 +419,7 @@ test('clears loader state when closing an owned environment fails', async () => 
 })
 
 test('evaluates config and components through the app resolver and invalidates HMR', async () => {
+  ;(globalThis as any).__tamaguiFixtureOwnedEvaluation = []
   const server = await createServer({
     configFile: false,
     root: fixtureRoot,
@@ -385,7 +431,8 @@ test('evaluates config and components through the app resolver and invalidates H
       alias: fixtureAliases,
     },
     plugins: [
-      ...fixturePlugins(),
+      ...environmentSpecificCompilerPlugins('serve'),
+      ...fixturePlugins(undefined, true),
       fixtureTransformProbePlugin(),
       tamaguiPlugin({
         components: fixtureComponents,
@@ -402,6 +449,17 @@ test('evaluates config and components through the app resolver and invalidates H
   if (!isRunnableDevEnvironment(evaluationEnvironment)) {
     throw new Error('Expected a runnable Tamagui evaluation environment')
   }
+  const resolvedCorePlugins = server.config.environments[
+    TAMAGUI_EVALUATION_ENVIRONMENT
+  ].plugins.filter((plugin) => isEvaluationCorePluginName(plugin.name))
+  const evaluationCorePlugins = evaluationEnvironment.plugins.filter((plugin) =>
+    isEvaluationCorePluginName(plugin.name)
+  )
+  expect(evaluationCorePlugins.length).toBeGreaterThan(0)
+  expect(evaluationCorePlugins).toHaveLength(resolvedCorePlugins.length)
+  expect(
+    evaluationCorePlugins.every((plugin) => resolvedCorePlugins.includes(plugin))
+  ).toBe(true)
 
   const loader = createViteTamaguiLoader()
   loader.setEnvironment(evaluationEnvironment)
@@ -421,6 +479,21 @@ test('evaluates config and components through the app resolver and invalidates H
     path.join(fixtureRoot, 'tamagui.config.ts')
   )
   expect(directConfigResolution?.id).toBe(path.join(fixtureRoot, 'tamagui.config.ts'))
+  const inlinePackageResolution = await evaluationEnvironment.pluginContainer.resolveId(
+    '@tamagui/config/v5',
+    directConfigResolution!.id
+  )
+  expect(inlinePackageResolution?.id).toMatch(
+    /(?:node_modules\/@tamagui\/config|code\/core\/config)\/dist\/esm\/v5\.mjs$/
+  )
+  expect(inlinePackageResolution?.external).not.toBe(true)
+  const externalPackages = evaluationEnvironment.config.resolve.external
+  expect(externalPackages).toContain('@tamagui/evaluation-fixture')
+  expect(externalPackages).toContain('@tamagui/shorthands')
+  expect(externalPackages).not.toContain('@tamagui/config')
+  expect(externalPackages).not.toContain('@tamagui/core')
+  expect(externalPackages).not.toContain('@tamagui/web')
+  expect(externalPackages).not.toContain('@fixture/conditional')
   const directConfigModule = await evaluationEnvironment.runner.import(
     directConfigResolution!.id
   )
@@ -428,8 +501,14 @@ test('evaluates config and components through the app resolver and invalidates H
     'browser:workspace-v1:user-plugin:serve-only'
   )
   expect(
-    evaluationEnvironment.plugins.some((plugin) => plugin.name === 'one:tsconfig-paths')
-  ).toBe(false)
+    evaluationEnvironment.plugins.filter((plugin) => plugin.name === 'one:tsconfig-paths')
+  ).toHaveLength(1)
+  expect(directConfigModule.oneTsconfigPathsOrder).toBe('pre')
+  expect(directConfigModule.packageExportResolution).toBe('package-export-esm')
+  expect((globalThis as any).__tamaguiFixturePackageExportPath).toMatch(
+    /\.evaluation-fixture-runtime\/esm\/value\.mjs$/
+  )
+  expect((globalThis as any).__tamaguiFixtureMetroFallbackUsed).toBeUndefined()
   expect((directConfigModule.default as any).media.sm).toEqual({ minWidth: 16 })
   expect(directConfigModule.evaluationPluginNames).toContain('vite:import-analysis')
 
@@ -447,6 +526,45 @@ test('evaluates config and components through the app resolver and invalidates H
     'config',
     'component',
   ])
+  const evaluationProbe = (globalThis as any).__tamaguiFixtureOwnedEvaluation
+  expect(
+    evaluationProbe.filter((entry: string) => entry === 'one:resolve:tamagui:config')
+  ).toHaveLength(1)
+  expect(
+    evaluationProbe.filter((entry: string) => entry === 'one:resolve:tamagui:component')
+  ).toHaveLength(1)
+  expect(
+    evaluationProbe.filter((entry: string) => entry === 'one:load:tamagui')
+  ).toHaveLength(1)
+  const evaluationPluginNames = directConfigModule.evaluationPluginNames as string[]
+  expect(evaluationPluginNames.filter((name) => name === 'one:compiler')).toHaveLength(1)
+  expect(
+    evaluationPluginNames.filter((name) => name === 'one:compiler-css-to-js')
+  ).toHaveLength(1)
+  expect(
+    evaluationPluginNames.filter((name) => name.includes('import-analysis'))
+  ).toHaveLength(1)
+  expect(evaluationPluginNames.filter((name) => name === 'alias')).toHaveLength(1)
+  expect(
+    evaluationPluginNames.filter((name) =>
+      ['vite:resolve-dev', 'builtin:vite-resolve'].includes(name)
+    )
+  ).toHaveLength(1)
+  expect(
+    evaluationPluginNames.filter((name) => name === 'fixture-serve-resolver:environment')
+  ).toHaveLength(1)
+  expect(evaluationPluginNames).not.toContain('fixture-build-resolver:environment')
+  expect(evaluationPluginNames).not.toContain('tamagui')
+  expect(evaluationPluginNames).not.toContain('tamagui-extract')
+  expect(evaluationPluginNames).not.toContain('tamagui-rnw-lite')
+  expect(evaluationPluginNames.some((name) => name.startsWith('native:'))).toBe(false)
+  expect((globalThis as any).__tamaguiFixtureOneConfigLifecycles).toEqual([
+    'one:compiler:config',
+    'one:compiler-css-to-js:config',
+    'one:compiler:configResolved',
+    'one:compiler-css-to-js:configResolved',
+  ])
+  expect((globalThis as any).__tamaguiFixtureOneTransformEnvironments).toBeUndefined()
 
   const firstTransform = await clientEnvironment.transformRequest('/src/App.tsx')
   expect(firstTransform?.code).toBeTruthy()
@@ -474,6 +592,13 @@ test('evaluates config and components through the app resolver and invalidates H
   const initialTransformVisits = { ...getTransformVisits() }
   expect(initialTransformVisits.client).toBeGreaterThan(0)
   expect(initialTransformVisits.ssr).toBeGreaterThan(0)
+  const oneTransformEnvironments = (globalThis as any)
+    .__tamaguiFixtureOneTransformEnvironments as string[]
+  expect(oneTransformEnvironments).toContain('one:compiler:client')
+  expect(oneTransformEnvironments).toContain('one:compiler-css-to-js:client')
+  expect(oneTransformEnvironments).toContain('one:compiler:ssr')
+  expect(oneTransformEnvironments).toContain('one:compiler-css-to-js:ssr')
+  expect(oneTransformEnvironments.some((entry) => entry.endsWith(':tamagui'))).toBe(false)
 
   const originalResolution = await readFile(resolutionPath, 'utf8')
   const originalConfigSpace = await readFile(configSpacePath, 'utf8')
@@ -490,7 +615,7 @@ test('evaluates config and components through the app resolver and invalidates H
     const events = getHmrEvents().filter(
       (payload) => !(payload.type === 'full-reload' && payload.triggeredBy)
     )
-    expect(events.length).toBeLessThanOrEqual(1)
+    expect(events.length, JSON.stringify(events, null, 2)).toBeLessThanOrEqual(1)
     for (const payload of events) {
       if (payload.type === 'full-reload') {
         expect(payload).toEqual({ type: 'full-reload', path: '*' })
@@ -701,7 +826,7 @@ test('evaluates the same fixture during a production build without legacy bundle
   expect((globalThis as any).__tamaguiFixtureTsconfigPathsContext).toBe('tamagui')
   expect((globalThis as any).__tamaguiFixtureOneTsconfigPathsOrder).toBe('pre')
   expect((globalThis as any).__tamaguiFixturePackageExportPath).toMatch(
-    /\/evaluation-fixture\/esm\/value\.mjs$/
+    /\.evaluation-fixture-runtime\/esm\/value\.mjs$/
   )
   expect((globalThis as any).__tamaguiFixturePackageExportResolution).toBe(
     'package-export-esm'

--- a/code/compiler/vite-plugin/test/loadTamagui.test.ts
+++ b/code/compiler/vite-plugin/test/loadTamagui.test.ts
@@ -65,7 +65,7 @@ function fixtureResolverPlugin(): Plugin {
       return configSpacePath
     }
   }
-  const load = function (this: any, id: string) {
+  const load = async function (this: any, id: string) {
     if (id === evaluationPipelineId) {
       const plugins = this.environment.plugins as Plugin[]
       const oneTsconfigPaths = plugins.find(
@@ -75,7 +75,27 @@ function fixtureResolverPlugin(): Plugin {
         typeof oneTsconfigPaths?.resolveId === 'object'
           ? oneTsconfigPaths.resolveId.order
           : undefined
-      return `export default ${JSON.stringify(plugins.map((plugin) => plugin.name))}; export const oneTsconfigPathsOrder = ${JSON.stringify(oneTsconfigPathsOrder)}`
+      const sliderResolution = await this.resolve(
+        '@tamagui/slider',
+        path.join(fixtureRoot, 'tamagui.config.ts')
+      )
+      const tamaguiResolution = await this.resolve(
+        'tamagui',
+        path.join(fixtureRoot, 'tamagui.config.ts')
+      )
+      const external = this.environment.config.resolve.external
+      const tamaguiExternalConfigured =
+        external === true || external?.includes('tamagui') === true
+      return `export default ${JSON.stringify(plugins.map((plugin) => plugin.name))}; export const oneTsconfigPathsOrder = ${JSON.stringify(oneTsconfigPathsOrder)}; export const sliderResolution = ${JSON.stringify({ id: sliderResolution?.id, external: sliderResolution?.external === true })}; export const tamaguiResolution = ${JSON.stringify({ id: tamaguiResolution?.id, external: tamaguiResolution?.external === true })}; export const tamaguiExternalConfigured = ${JSON.stringify(tamaguiExternalConfigured)}`
+    }
+  }
+  const transform = function (this: any, _source: string, id: string) {
+    if (
+      this.environment?.name === TAMAGUI_EVALUATION_ENVIRONMENT &&
+      /\/(?:node_modules\/tamagui|code\/ui\/tamagui)\//.test(id)
+    ) {
+      ;(globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms =
+        ((globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms || 0) + 1
     }
   }
   return {
@@ -83,12 +103,14 @@ function fixtureResolverPlugin(): Plugin {
     enforce: 'pre',
     resolveId,
     load,
+    transform,
     applyToEnvironment() {
       return {
         name: 'fixture-user-resolver:environment',
         enforce: 'pre',
         resolveId,
         load,
+        transform,
       }
     },
   }
@@ -359,9 +381,12 @@ function waitForWatchBuild(watcher: any) {
 
 const servers: Awaited<ReturnType<typeof createServer>>[] = []
 let previousCwd = ''
+let previousDisableSliderInterval: string | undefined
 
 beforeEach(async () => {
   previousCwd = process.cwd()
+  previousDisableSliderInterval = process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+  delete process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
   process.chdir(fixtureRoot)
   const fixturePackageScope = path.join(fixtureRoot, 'node_modules/@tamagui')
   const fixtureConditionalScope = path.join(fixtureRoot, 'node_modules/@fixture')
@@ -390,6 +415,13 @@ afterEach(async () => {
     delete (globalThis as any).__tamaguiFixtureEvaluationOrder
     delete (globalThis as any).__tamaguiFixtureOwnedEvaluation
     delete (globalThis as any).__tamaguiFixtureOwnedPluginNames
+    delete (globalThis as any).__tamaguiFixtureSliderIntervalDisabled
+    delete (globalThis as any).__tamaguiFixtureSliderModuleLoaded
+    delete (globalThis as any).__tamaguiFixtureSliderResolution
+    delete (globalThis as any).__tamaguiFixtureTamaguiBarrelLoaded
+    delete (globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms
+    delete (globalThis as any).__tamaguiFixtureTamaguiExternalConfigured
+    delete (globalThis as any).__tamaguiFixtureTamaguiResolution
     delete (globalThis as any).__tamaguiFixtureTransformVisits
     delete (globalThis as any).__tamaguiFixtureTsconfigPathsContext
     delete (globalThis as any).__tamaguiFixturePackageExportPath
@@ -401,6 +433,11 @@ afterEach(async () => {
     await rm(path.join(fixtureRoot, 'node_modules'), { force: true, recursive: true })
     await rm(evaluationFixturePhysicalRuntimePath, { force: true, recursive: true })
     await rm(watchOutputRoot, { force: true, recursive: true })
+    if (previousDisableSliderInterval === undefined) {
+      delete process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+    } else {
+      process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL = previousDisableSliderInterval
+    }
   }
 })
 
@@ -445,6 +482,9 @@ test('evaluates config and components through the app resolver and invalidates H
 
   const clientEnvironment = server.environments.client
   const evaluationEnvironment = server.environments[TAMAGUI_EVALUATION_ENVIRONMENT]
+  expect(
+    clientEnvironment.config.define?.['process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL']
+  ).toBeUndefined()
   expect(isRunnableDevEnvironment(evaluationEnvironment)).toBe(true)
   if (!isRunnableDevEnvironment(evaluationEnvironment)) {
     throw new Error('Expected a runnable Tamagui evaluation environment')
@@ -483,15 +523,31 @@ test('evaluates config and components through the app resolver and invalidates H
     '@tamagui/config/v5',
     directConfigResolution!.id
   )
+  const sliderResolution = await evaluationEnvironment.pluginContainer.resolveId(
+    '@tamagui/slider',
+    directConfigResolution!.id
+  )
+  const tamaguiResolution = await evaluationEnvironment.pluginContainer.resolveId(
+    'tamagui',
+    directConfigResolution!.id
+  )
   expect(inlinePackageResolution?.id).toMatch(
     /(?:node_modules\/@tamagui\/config|code\/core\/config)\/dist\/esm\/v5\.mjs$/
   )
   expect(inlinePackageResolution?.external).not.toBe(true)
+  expect(sliderResolution?.id).toMatch(/\/slider\/dist\/esm\/index\.mjs$/)
+  expect(sliderResolution?.external).not.toBe(true)
+  expect(tamaguiResolution).toEqual({
+    id: 'tamagui',
+    external: true,
+  })
   const externalPackages = evaluationEnvironment.config.resolve.external
   expect(externalPackages).toContain('@tamagui/evaluation-fixture')
   expect(externalPackages).toContain('@tamagui/shorthands')
+  expect(externalPackages).toContain('tamagui')
   expect(externalPackages).not.toContain('@tamagui/config')
   expect(externalPackages).not.toContain('@tamagui/core')
+  expect(externalPackages).not.toContain('@tamagui/slider')
   expect(externalPackages).not.toContain('@tamagui/web')
   expect(externalPackages).not.toContain('@fixture/conditional')
   const directConfigModule = await evaluationEnvironment.runner.import(
@@ -505,6 +561,22 @@ test('evaluates config and components through the app resolver and invalidates H
   ).toHaveLength(1)
   expect(directConfigModule.oneTsconfigPathsOrder).toBe('pre')
   expect(directConfigModule.packageExportResolution).toBe('package-export-esm')
+  expect(directConfigModule.packageExportPath).toMatch(
+    /\.evaluation-fixture-runtime\/esm\/value\.mjs$/
+  )
+  expect(directConfigModule.sliderIntervalDisabled).toBe('1')
+  expect(directConfigModule.sliderModuleLoaded).toBe(true)
+  expect(directConfigModule.sliderResolution).toEqual({
+    id: sliderResolution?.id,
+    external: false,
+  })
+  expect(directConfigModule.tamaguiBarrelLoaded).toBe(true)
+  expect(directConfigModule.tamaguiResolution).toEqual({
+    id: 'tamagui',
+    external: true,
+  })
+  expect(process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL).toBeUndefined()
+  expect((globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms).toBeUndefined()
   expect((globalThis as any).__tamaguiFixturePackageExportPath).toMatch(
     /\.evaluation-fixture-runtime\/esm\/value\.mjs$/
   )
@@ -583,6 +655,9 @@ test('evaluates config and components through the app resolver and invalidates H
   if (!ssrEnvironment) {
     throw new Error('Expected an SSR environment')
   }
+  expect(
+    ssrEnvironment.config.define?.['process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL']
+  ).toBeUndefined()
   const firstSsrTransform = await ssrEnvironment.transformRequest('/src/App.tsx')
   expect(firstSsrTransform?.code).toBeTruthy()
   await Promise.all([
@@ -831,6 +906,16 @@ test('evaluates the same fixture during a production build without legacy bundle
   expect((globalThis as any).__tamaguiFixturePackageExportResolution).toBe(
     'package-export-esm'
   )
+  expect((globalThis as any).__tamaguiFixtureSliderIntervalDisabled).toBe('1')
+  expect((globalThis as any).__tamaguiFixtureSliderModuleLoaded).toBe(true)
+  expect((globalThis as any).__tamaguiFixtureSliderResolution).toEqual({
+    id: expect.stringMatching(/\/slider\/dist\/esm\/index\.mjs$/),
+    external: false,
+  })
+  expect((globalThis as any).__tamaguiFixtureTamaguiBarrelLoaded).toBe(true)
+  expect((globalThis as any).__tamaguiFixtureTamaguiExternalConfigured).toBe(true)
+  expect(process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL).toBeUndefined()
+  expect((globalThis as any).__tamaguiFixtureTamaguiBarrelTransforms).toBeUndefined()
   expect((globalThis as any).__tamaguiFixtureMetroFallbackUsed).toBeUndefined()
   expect(lifecycle).toEqual({
     options: 1,

--- a/code/compiler/vite-plugin/test/loadTamagui.test.ts
+++ b/code/compiler/vite-plugin/test/loadTamagui.test.ts
@@ -23,6 +23,7 @@ const componentEntryPath = path.join(fixtureRoot, 'packages/components/src/index
 const watchOutputRoot = path.join(fixtureRoot, '.watch-dist')
 const fixtureComponents = ['@fixture/components', '@fixture/components/static']
 const evaluationPipelineId = '\0fixture-evaluation-pipeline'
+const oneCompilerResolutionId = '\0fixture-one-compiler-resolution'
 const fixtureAliases = {
   '#workspace-resolution': resolutionPath,
   '@fixture/conditional': path.join(fixtureRoot, 'packages/conditional'),
@@ -59,6 +60,50 @@ function fixtureResolverPlugin(): Plugin {
       }
     },
   }
+}
+
+function environmentSpecificCompilerPlugins(): Plugin[] {
+  return [
+    {
+      name: 'one:compiler',
+      apply: 'build',
+      enforce: 'pre',
+      resolveId(source, importer) {
+        if (source !== '#plugin-resolution') return
+        const evaluationProbe = (globalThis as any).__tamaguiFixtureOwnedEvaluation
+        const environmentName = this.environment?.name
+        if (importer?.endsWith('tamagui.config.ts')) {
+          evaluationProbe?.push(`one:resolve:${environmentName}:config`)
+        } else if (importer?.endsWith('/packages/components/src/resolution.ts')) {
+          evaluationProbe?.push(`one:resolve:${environmentName}:component`)
+        }
+        return oneCompilerResolutionId
+      },
+      load(id) {
+        if (id !== oneCompilerResolutionId) return
+        ;(globalThis as any).__tamaguiFixtureOwnedEvaluation?.push(
+          `one:load:${this.environment?.name}`
+        )
+        return `export const resolution = 'user-plugin'`
+      },
+      transform() {
+        const environmentName = this.environment?.name
+        if (environmentName !== 'client' && environmentName !== 'ssr') {
+          throw new Error(`Invalid env: ${environmentName}`)
+        }
+      },
+    },
+    {
+      name: 'one:compiler-css-to-js',
+      apply: 'build',
+      transform() {
+        const environmentName = this.environment?.name
+        if (environmentName !== 'client' && environmentName !== 'ssr') {
+          throw new Error(`Invalid env: ${environmentName}`)
+        }
+      },
+    },
+  ]
 }
 
 type LifecycleCounts = {
@@ -190,6 +235,20 @@ async function readBuiltCss(outDir: string) {
   return readFile(path.join(outDir, cssFile), 'utf8')
 }
 
+function getBuildOutput(result: Awaited<ReturnType<typeof build>>) {
+  const outputs = Array.isArray(result) ? result : [result]
+  return outputs
+    .flatMap((output: any) => output.output || [])
+    .map((output: any) =>
+      output.type === 'asset'
+        ? typeof output.source === 'string'
+          ? output.source
+          : Buffer.from(output.source).toString('utf8')
+        : output.code
+    )
+    .join('\n')
+}
+
 function waitForWatchBuild(watcher: any) {
   return new Promise<void>((resolve, reject) => {
     const onEvent = (event: any) => {
@@ -226,6 +285,20 @@ afterEach(async () => {
     await rm(path.join(fixtureRoot, 'node_modules'), { force: true, recursive: true })
     await rm(watchOutputRoot, { force: true, recursive: true })
   }
+})
+
+test('clears loader state when closing an owned environment fails', async () => {
+  const loader = createViteTamaguiLoader({ disable: true })
+  await loader.loadTamaguiBuildConfig()
+  const closeError = new Error('fixture close failed')
+  const close = vi.fn().mockRejectedValue(closeError)
+  loader.setEnvironment({ close } as any, { owned: true })
+
+  await expect(loader.cleanup()).rejects.toBe(closeError)
+  expect(close).toHaveBeenCalledOnce()
+  expect(loader.getEnvironment()).toBeNull()
+  expect(loader.getLoadPromise()).toBeNull()
+  expect(loader.getTamaguiOptions()).toBeNull()
 })
 
 test('evaluates config and components through the app resolver and invalidates HMR', async () => {
@@ -488,6 +561,7 @@ test('evaluates the same fixture during a production build without legacy bundle
       alias: fixtureAliases,
     },
     plugins: [
+      ...environmentSpecificCompilerPlugins(),
       ...fixturePlugins(lifecycle),
       tamaguiPlugin({
         config: '#fixture-config',
@@ -504,17 +578,7 @@ test('evaluates the same fixture during a production build without legacy bundle
     },
   })
 
-  const outputs = Array.isArray(result) ? result : [result]
-  const buildOutput = outputs
-    .flatMap((output: any) => output.output || [])
-    .map((output: any) =>
-      output.type === 'asset'
-        ? typeof output.source === 'string'
-          ? output.source
-          : Buffer.from(output.source).toString('utf8')
-        : output.code
-    )
-    .join('\n')
+  const buildOutput = getBuildOutput(result)
 
   expect(buildOutput).toContain('browser:workspace-v1:user-plugin:build-only')
   expect(buildOutput).not.toContain('serve-only')
@@ -524,6 +588,9 @@ test('evaluates the same fixture during a production build without legacy bundle
   const evaluationPluginNames = (globalThis as any).__tamaguiFixtureOwnedPluginNames
   expect(evaluationProbe).toContain('resolve:build')
   expect(evaluationProbe).toContain('import:config')
+  expect(evaluationProbe).toContain('one:resolve:tamagui:config')
+  expect(evaluationProbe).toContain('one:resolve:tamagui:component')
+  expect(evaluationProbe).toContain('one:load:tamagui')
   expect(evaluationProbe).not.toContain('resolve:serve')
   expect(evaluationProbe.indexOf('resolve:build')).toBeLessThan(
     evaluationProbe.indexOf('import:config')
@@ -551,6 +618,8 @@ test('evaluates the same fixture during a production build without legacy bundle
     )
   ).toHaveLength(1)
   expect(evaluationPluginNames).not.toContain('fixture-serve-resolver:environment')
+  expect(evaluationPluginNames).toContain('one:compiler')
+  expect(evaluationPluginNames).toContain('one:compiler-css-to-js')
   expect(lifecycle).toEqual({
     options: 1,
     buildStart: 1,
@@ -559,6 +628,166 @@ test('evaluates the same fixture during a production build without legacy bundle
   })
   await expect(access(path.join(fixtureRoot, '.tamagui'))).rejects.toThrow()
 })
+
+test('keeps the owned runner alive across concurrent builds sharing one plugin', async () => {
+  const originalConfigSpace = await readFile(configSpacePath, 'utf8')
+  const slowOutDir = path.join(fixtureRoot, '.concurrent-slow')
+  const fastOutDir = path.join(fixtureRoot, '.concurrent-fast')
+  const afterCleanupOutDir = path.join(fixtureRoot, '.concurrent-after')
+  let holdSlowTransform = true
+  let thirdBuildPassedCleanup = false
+  let markSlowTransformStarted!: () => void
+  let releaseSlowTransform!: () => void
+  let markCleanupStarted!: () => void
+  let releaseCleanup!: () => void
+  let markThirdBuildStarted!: () => void
+  let markThirdBuildPassedCleanup!: () => void
+  const slowTransformStarted = new Promise<void>((resolve) => {
+    markSlowTransformStarted = resolve
+  })
+  const slowTransformRelease = new Promise<void>((resolve) => {
+    releaseSlowTransform = resolve
+  })
+  const cleanupStarted = new Promise<void>((resolve) => {
+    markCleanupStarted = resolve
+  })
+  const cleanupRelease = new Promise<void>((resolve) => {
+    releaseCleanup = resolve
+  })
+  const thirdBuildStarted = new Promise<void>((resolve) => {
+    markThirdBuildStarted = resolve
+  })
+  const thirdBuildPassedCleanupPromise = new Promise<void>((resolve) => {
+    markThirdBuildPassedCleanup = resolve
+  })
+
+  const slowTransformGate: Plugin = {
+    name: 'fixture-concurrent-build-gate',
+    enforce: 'pre',
+    buildStart: {
+      order: 'pre',
+      sequential: true,
+      handler() {
+        if (this.environment.config.build.outDir === afterCleanupOutDir) {
+          markThirdBuildStarted()
+        }
+      },
+    },
+    resolveId() {
+      const environment = this.environment as any
+      if (
+        environment.name === TAMAGUI_EVALUATION_ENVIRONMENT &&
+        !environment.__tamaguiFixtureClosePatched
+      ) {
+        environment.__tamaguiFixtureClosePatched = true
+        const close = environment.close.bind(environment)
+        environment.close = async () => {
+          markCleanupStarted()
+          await cleanupRelease
+          await close()
+        }
+      }
+    },
+    transform: {
+      order: 'pre',
+      async handler(_source, id) {
+        if (
+          holdSlowTransform &&
+          this.environment.config.build.outDir === slowOutDir &&
+          path.resolve(id.split('?')[0]) === appPath
+        ) {
+          holdSlowTransform = false
+          markSlowTransformStarted()
+          await slowTransformRelease
+        }
+      },
+    },
+  }
+  const releaseAfterTamaguiBuildEnd: Plugin = {
+    name: 'fixture-release-concurrent-build',
+    buildStart: {
+      order: 'post',
+      sequential: true,
+      handler() {
+        if (this.environment.config.build.outDir === afterCleanupOutDir) {
+          thirdBuildPassedCleanup = true
+          markThirdBuildPassedCleanup()
+        }
+      },
+    },
+    buildEnd: {
+      order: 'post',
+      sequential: true,
+      handler() {
+        if (this.environment.config.build.outDir === fastOutDir) {
+          releaseSlowTransform()
+        }
+      },
+    },
+  }
+  const sharedPlugins = [
+    slowTransformGate,
+    ...fixturePlugins(),
+    tamaguiPlugin({
+      config: '#fixture-config',
+      components: fixtureComponents,
+      enableDynamicEvaluation: true,
+    }),
+    releaseAfterTamaguiBuildEnd,
+  ]
+  const runBuild = (outDir: string) =>
+    build({
+      configFile: false,
+      root: fixtureRoot,
+      logLevel: 'silent',
+      resolve: {
+        alias: fixtureAliases,
+      },
+      plugins: sharedPlugins,
+      build: {
+        outDir,
+        write: false,
+        lib: {
+          entry: appPath,
+          formats: ['es'],
+        },
+      },
+    })
+
+  try {
+    const slowBuild = runBuild(slowOutDir)
+    await slowTransformStarted
+    const fastBuild = runBuild(fastOutDir)
+    const fastResult = await fastBuild
+    await cleanupStarted
+
+    await writeFile(configSpacePath, originalConfigSpace.replace('1', '4'))
+    const afterCleanupBuild = runBuild(afterCleanupOutDir)
+    await thirdBuildStarted
+    expect(thirdBuildPassedCleanup).toBe(false)
+    releaseCleanup()
+    await thirdBuildPassedCleanupPromise
+
+    const [slowResult, afterCleanupResult] = await Promise.all([
+      slowBuild,
+      afterCleanupBuild,
+    ])
+
+    for (const result of [slowResult, fastResult]) {
+      const output = getBuildOutput(result)
+      expect(output).toContain('className')
+      expect(output).not.toContain('$fixture')
+      expectMediaPaddingCss(output, 21)
+    }
+
+    const rebuiltOutput = getBuildOutput(afterCleanupResult)
+    expectMediaPaddingCss(rebuiltOutput, 24)
+  } finally {
+    releaseSlowTransform()
+    releaseCleanup()
+    await writeFile(configSpacePath, originalConfigSpace)
+  }
+}, 30_000)
 
 test('isolates extraction caches and rebuilds CSS for a config-only dependency', async () => {
   const originalConfigSpace = await readFile(configSpacePath, 'utf8')

--- a/code/compiler/vite-plugin/test/loadTamagui.test.ts
+++ b/code/compiler/vite-plugin/test/loadTamagui.test.ts
@@ -1,5 +1,14 @@
 import { execFile } from 'node:child_process'
-import { access, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import {
+  access,
+  cp,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { promisify } from 'node:util'
@@ -20,6 +29,13 @@ const appPath = path.join(fixtureRoot, 'src/App.tsx')
 const resolutionPath = path.join(fixtureRoot, 'packages/workspace/src/resolution.ts')
 const configSpacePath = path.join(fixtureRoot, 'packages/workspace/src/config-space.ts')
 const componentEntryPath = path.join(fixtureRoot, 'packages/components/src/index.ts')
+const evaluationFixturePackagePath = path.join(fixtureRoot, 'packages/evaluation-fixture')
+const evaluationFixtureRuntimePath = path.join(
+  fixtureRoot,
+  'node_modules/@tamagui/evaluation-fixture'
+)
+const metroFallbackPath = path.join(evaluationFixtureRuntimePath, 'metro/value/index.js')
+const userAliasPath = path.join(fixtureRoot, 'packages/workspace/src/user-alias.ts')
 const watchOutputRoot = path.join(fixtureRoot, '.watch-dist')
 const fixtureComponents = ['@fixture/components', '@fixture/components/static']
 const evaluationPipelineId = '\0fixture-evaluation-pipeline'
@@ -43,7 +59,15 @@ function fixtureResolverPlugin(): Plugin {
   }
   const load = function (this: any, id: string) {
     if (id === evaluationPipelineId) {
-      return `export default ${JSON.stringify(this.environment.plugins.map((plugin: Plugin) => plugin.name))}`
+      const plugins = this.environment.plugins as Plugin[]
+      const oneTsconfigPaths = plugins.find(
+        (plugin) => plugin.name === 'one:tsconfig-paths'
+      )
+      const oneTsconfigPathsOrder =
+        typeof oneTsconfigPaths?.resolveId === 'object'
+          ? oneTsconfigPaths.resolveId.order
+          : undefined
+      return `export default ${JSON.stringify(plugins.map((plugin) => plugin.name))}; export const oneTsconfigPathsOrder = ${JSON.stringify(oneTsconfigPathsOrder)}`
     }
   }
   return {
@@ -58,6 +82,33 @@ function fixtureResolverPlugin(): Plugin {
         resolveId,
         load,
       }
+    },
+  }
+}
+
+function oneTsconfigPathsPlugin(): Plugin {
+  return {
+    name: 'one:tsconfig-paths',
+    enforce: 'pre',
+    config() {
+      return {
+        resolve: {
+          tsconfigPaths: true,
+        },
+      }
+    },
+    resolveId: {
+      order: 'pre',
+      handler(source) {
+        if (source === '@tamagui/evaluation-fixture/value') {
+          return metroFallbackPath
+        }
+        if (source === '~/user-alias') {
+          ;(globalThis as any).__tamaguiFixtureTsconfigPathsContext =
+            this.environment?.name
+          return userAliasPath
+        }
+      },
     },
   }
 }
@@ -115,14 +166,20 @@ type LifecycleCounts = {
 
 function commandResolverPlugin(
   command: 'serve' | 'build',
-  lifecycle?: LifecycleCounts
+  lifecycle?: LifecycleCounts,
+  useBuildProofConfig = false
 ): Plugin {
   const resolveId = (source: string) => {
     if (source === '#fixture-config') {
       ;((globalThis as any).__tamaguiFixtureOwnedEvaluation ??= []).push(
         `resolve:${command}`
       )
-      return path.join(fixtureRoot, 'tamagui.config.ts')
+      return path.join(
+        fixtureRoot,
+        command === 'build' && useBuildProofConfig
+          ? 'tamagui.build.config.ts'
+          : 'tamagui.config.ts'
+      )
     }
     if (source === '#command-resolution') {
       return path.join(fixtureRoot, `packages/workspace/src/${command}-resolution.ts`)
@@ -163,11 +220,12 @@ function commandResolverPlugin(
   }
 }
 
-function fixturePlugins(lifecycle?: LifecycleCounts) {
+function fixturePlugins(lifecycle?: LifecycleCounts, includeOneTsconfigPaths = false) {
   return [
+    ...(includeOneTsconfigPaths ? [oneTsconfigPathsPlugin()] : []),
     fixtureResolverPlugin(),
     commandResolverPlugin('serve'),
-    commandResolverPlugin('build', lifecycle),
+    commandResolverPlugin('build', lifecycle, includeOneTsconfigPaths),
   ]
 }
 
@@ -268,9 +326,18 @@ function waitForWatchBuild(watcher: any) {
 const servers: Awaited<ReturnType<typeof createServer>>[] = []
 let previousCwd = ''
 
-beforeEach(() => {
+beforeEach(async () => {
   previousCwd = process.cwd()
   process.chdir(fixtureRoot)
+  const fixturePackageScope = path.join(fixtureRoot, 'node_modules/@tamagui')
+  await mkdir(fixturePackageScope, { recursive: true })
+  await cp(evaluationFixturePackagePath, evaluationFixtureRuntimePath, {
+    recursive: true,
+  })
+  await rename(
+    path.join(evaluationFixtureRuntimePath, 'package.json.fixture'),
+    path.join(evaluationFixtureRuntimePath, 'package.json')
+  )
 })
 
 afterEach(async () => {
@@ -282,6 +349,11 @@ afterEach(async () => {
     delete (globalThis as any).__tamaguiFixtureOwnedEvaluation
     delete (globalThis as any).__tamaguiFixtureOwnedPluginNames
     delete (globalThis as any).__tamaguiFixtureTransformVisits
+    delete (globalThis as any).__tamaguiFixtureTsconfigPathsContext
+    delete (globalThis as any).__tamaguiFixturePackageExportPath
+    delete (globalThis as any).__tamaguiFixturePackageExportResolution
+    delete (globalThis as any).__tamaguiFixtureMetroFallbackUsed
+    delete (globalThis as any).__tamaguiFixtureOneTsconfigPathsOrder
     await rm(path.join(fixtureRoot, 'node_modules'), { force: true, recursive: true })
     await rm(watchOutputRoot, { force: true, recursive: true })
   }
@@ -355,6 +427,9 @@ test('evaluates config and components through the app resolver and invalidates H
   expect(directConfigModule.compilerResolution).toBe(
     'browser:workspace-v1:user-plugin:serve-only'
   )
+  expect(
+    evaluationEnvironment.plugins.some((plugin) => plugin.name === 'one:tsconfig-paths')
+  ).toBe(false)
   expect((directConfigModule.default as any).media.sm).toEqual({ minWidth: 16 })
   expect(directConfigModule.evaluationPluginNames).toContain('vite:import-analysis')
 
@@ -562,7 +637,7 @@ test('evaluates the same fixture during a production build without legacy bundle
     },
     plugins: [
       ...environmentSpecificCompilerPlugins(),
-      ...fixturePlugins(lifecycle),
+      ...fixturePlugins(lifecycle, true),
       tamaguiPlugin({
         config: '#fixture-config',
         components: fixtureComponents,
@@ -618,8 +693,20 @@ test('evaluates the same fixture during a production build without legacy bundle
     )
   ).toHaveLength(1)
   expect(evaluationPluginNames).not.toContain('fixture-serve-resolver:environment')
+  expect(
+    evaluationPluginNames.filter((name: string) => name === 'one:tsconfig-paths')
+  ).toHaveLength(1)
   expect(evaluationPluginNames).toContain('one:compiler')
   expect(evaluationPluginNames).toContain('one:compiler-css-to-js')
+  expect((globalThis as any).__tamaguiFixtureTsconfigPathsContext).toBe('tamagui')
+  expect((globalThis as any).__tamaguiFixtureOneTsconfigPathsOrder).toBe('pre')
+  expect((globalThis as any).__tamaguiFixturePackageExportPath).toMatch(
+    /\/evaluation-fixture\/esm\/value\.mjs$/
+  )
+  expect((globalThis as any).__tamaguiFixturePackageExportResolution).toBe(
+    'package-export-esm'
+  )
+  expect((globalThis as any).__tamaguiFixtureMetroFallbackUsed).toBeUndefined()
   expect(lifecycle).toEqual({
     options: 1,
     buildStart: 1,

--- a/code/compiler/vite-plugin/test/types/consumer.ts
+++ b/code/compiler/vite-plugin/test/types/consumer.ts
@@ -1,0 +1,9 @@
+import { tamaguiPlugin } from '@tamagui/vite-plugin'
+import type { PluginOption } from 'vite'
+
+const plugin: PluginOption = tamaguiPlugin({
+  components: ['@fixture/components/static'],
+  disableExtraction: true,
+})
+
+void plugin

--- a/code/compiler/vite-plugin/tsconfig.json
+++ b/code/compiler/vite-plugin/tsconfig.json
@@ -13,9 +13,6 @@
       "path": "../static"
     }
   ],
-  "exclude": [
-    "types",
-    "dist",
-    "**/__tests__"
-  ]
+  "include": ["src"],
+  "exclude": ["types", "dist", "**/__tests__", "src/**/*.test.ts"]
 }

--- a/code/compiler/vite-plugin/types/loadTamagui.d.ts
+++ b/code/compiler/vite-plugin/types/loadTamagui.d.ts
@@ -1,15 +1,38 @@
+import type { ExtractedResponse } from '@tamagui/static';
 import type { TamaguiOptions } from '@tamagui/types';
-export declare function getTamaguiOptions(): TamaguiOptions | null;
-export declare function getLoadPromise(): Promise<TamaguiOptions> | null;
-/**
- * Load just the tamagui.build.ts config (lightweight)
- * This doesn't bundle the full tamagui config - call ensureFullConfigLoaded() for that
- */
-export declare function loadTamaguiBuildConfig(optionsIn?: Partial<TamaguiOptions>): Promise<TamaguiOptions>;
-/**
- * Ensure the full tamagui config is loaded (heavy - bundles config + components)
- * Call this lazily when transform/extraction is actually needed
- */
-export declare function ensureFullConfigLoaded(): Promise<void>;
-export declare function cleanup(): Promise<void>;
+import type { RunnableDevEnvironment } from 'vite';
+export declare const TAMAGUI_EVALUATION_ENVIRONMENT = "tamagui";
+type ResolvedEvaluationModule = {
+    moduleName: string;
+    id: string;
+    module: Record<string, unknown>;
+};
+type EvaluatedProjectModules = {
+    config: ResolvedEvaluationModule;
+    components: ResolvedEvaluationModule[];
+};
+export type ViteTamaguiLoader = {
+    getEnvironment(): RunnableDevEnvironment | null;
+    getGeneration(): number;
+    getLoadPromise(): Promise<TamaguiOptions> | null;
+    getTamaguiOptions(): TamaguiOptions | null;
+    getEvaluationDependencies(): string[];
+    isEvaluationDependency(id: string): boolean;
+    evaluateProjectModules(options: TamaguiOptions): Promise<EvaluatedProjectModules>;
+    loadTamaguiBuildConfig(): Promise<TamaguiOptions>;
+    setEnvironment(next: RunnableDevEnvironment, options?: {
+        owned?: boolean;
+    }): void;
+    invalidate(file?: string): void;
+    ensureFullConfigLoaded(): Promise<string[]>;
+    extractToClassNames(params: {
+        source: string;
+        sourcePath: string;
+        options: TamaguiOptions;
+        shouldPrintDebug: boolean | 'verbose';
+    }): Promise<ExtractedResponse | null>;
+    cleanup(): Promise<void>;
+};
+export declare function createViteTamaguiLoader(optionsIn?: Partial<TamaguiOptions>): ViteTamaguiLoader;
+export {};
 //# sourceMappingURL=loadTamagui.d.ts.map

--- a/code/compiler/vite-plugin/types/plugin.d.ts
+++ b/code/compiler/vite-plugin/types/plugin.d.ts
@@ -1,4 +1,4 @@
-import type { TamaguiOptions } from '@tamagui/static-worker';
+import type { TamaguiOptions } from '@tamagui/static';
 import type { PluginOption } from 'vite';
 type AliasOptions = {
     /** use @tamagui/react-native-web-lite, 'without-animated' for smaller bundle */

--- a/code/compiler/vite-plugin/vite.test.config.ts
+++ b/code/compiler/vite-plugin/vite.test.config.ts
@@ -1,0 +1,14 @@
+import path from 'node:path'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@tamagui/static': path.resolve(__dirname, '../static/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['code/compiler/vite-plugin/test/**/*.test.ts'],
+  },
+})

--- a/code/core/web/src/createTamagui.ts
+++ b/code/core/web/src/createTamagui.ts
@@ -53,6 +53,42 @@ function initializeTamaguiConfig(config: TamaguiInternalConfig) {
   configureMedia(config)
 }
 
+export function installTamaguiConfig(config: TamaguiInternalConfig) {
+  const tokens = config.tokens as Record<string, Record<string, Variable>>
+  const tokensParsed = config.tokensParsed as Record<string, Record<string, Variable>>
+  const tokensMerged: TokensMerged = {} as any
+  const categories = new Set([
+    ...Object.keys(tokens || {}),
+    ...Object.keys(tokensParsed || {}),
+  ])
+
+  for (const category of categories) {
+    const categoryTokens = tokens?.[category] || {}
+    const categoryTokensParsed = tokensParsed?.[category] || {}
+    const categoryTokensMerged = (tokensMerged[category] = {})
+
+    for (const name in categoryTokens) {
+      const unprefixedName = name[0] === '$' ? name.slice(1) : name
+      const prefixedName = `$${unprefixedName}`
+      categoryTokensMerged[unprefixedName] = categoryTokens[name]
+      categoryTokensMerged[prefixedName] =
+        categoryTokensParsed[prefixedName] ?? categoryTokens[name]
+    }
+
+    for (const name in categoryTokensParsed) {
+      const unprefixedName = name[0] === '$' ? name.slice(1) : name
+      const prefixedName = `$${unprefixedName}`
+      categoryTokensMerged[unprefixedName] ??=
+        categoryTokens[unprefixedName] ?? categoryTokensParsed[name]
+      categoryTokensMerged[prefixedName] = categoryTokensParsed[name]
+    }
+  }
+
+  setTokens(tokensMerged)
+  initializeTamaguiConfig(config)
+  return config
+}
+
 function normalizeDefaultSize(defaultSize: string | undefined) {
   if (!defaultSize) return DEFAULT_SIZE_TOKEN
   return defaultSize[0] === '$' ? defaultSize : `$${defaultSize}`

--- a/code/core/web/src/helpers/insertStyleRule.tsx
+++ b/code/core/web/src/helpers/insertStyleRule.tsx
@@ -44,6 +44,7 @@ export function scanAllSheets(
   if (!process.env.TAMAGUI_DID_OUTPUT_CSS) {
     if (process.env.NODE_ENV === 'test') return
     if (process.env.TAMAGUI_TARGET !== 'web') return
+    if (typeof document === 'undefined') return
 
     let themes: DedupedThemes | undefined
 

--- a/code/core/web/types/createTamagui.d.ts
+++ b/code/core/web/types/createTamagui.d.ts
@@ -1,3 +1,4 @@
-import type { CreateTamaguiProps, InferTamaguiConfig } from './types';
+import type { CreateTamaguiProps, InferTamaguiConfig, TamaguiInternalConfig } from './types';
+export declare function installTamaguiConfig(config: TamaguiInternalConfig): TamaguiInternalConfig;
 export declare function createTamagui<Conf extends CreateTamaguiProps>(configIn: Conf): InferTamaguiConfig<Conf>;
 //# sourceMappingURL=createTamagui.d.ts.map

--- a/code/tamagui.dev/package.json
+++ b/code/tamagui.dev/package.json
@@ -14,7 +14,7 @@
     "build": "tamagui generate-css || true",
     "build:prod": "one build",
     "prod": "bun run build:prod && bun run serve",
-    "serve:railway": "one serve --host 0.0.0.0",
+    "serve:railway": "one serve --host 0.0.0.0 --port ${PORT:-3000}",
     "dev-build-prod": "VXRN_DISABLE_PROD_OPTIMIZATION=1 bun run build:prod && bun run serve",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/code/tests/integration/tests/simple.integration.test.js
+++ b/code/tests/integration/tests/simple.integration.test.js
@@ -11,6 +11,7 @@ function spawnServer(command, args) {
     stdio: 'pipe',
     detached: true,
   })
+  proc.stdout.on('data', (d) => process.stdout.write(d))
   proc.stderr.on('data', (d) => console.log(d.toString()))
   return proc
 }

--- a/code/ui/components-test/Slider.web.test.tsx
+++ b/code/ui/components-test/Slider.web.test.tsx
@@ -1,0 +1,121 @@
+import '@testing-library/jest-dom'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+type IntersectionCallback = (
+  entries: Pick<IntersectionObserverEntry, 'isIntersecting'>[]
+) => void
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = []
+  callback: IntersectionCallback
+  options?: IntersectionObserverInit
+
+  constructor(callback: IntersectionCallback, options?: IntersectionObserverInit) {
+    this.callback = callback
+    this.options = options
+    MockIntersectionObserver.instances.push(this)
+  }
+
+  observe() {}
+  disconnect() {}
+
+  setIntersecting(isIntersecting: boolean) {
+    this.callback([{ isIntersecting }])
+  }
+}
+
+describe('Slider measurement interval', () => {
+  let previousDisableInterval: string | undefined
+
+  beforeEach(() => {
+    previousDisableInterval = process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+    delete process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+    vi.useFakeTimers()
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+    MockIntersectionObserver.instances = []
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllTimers()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    if (previousDisableInterval === undefined) {
+      delete process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+    } else {
+      process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL = previousDisableInterval
+    }
+  })
+
+  it('is lazy, shared, and scoped to intersecting sliders', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const { Slider } = await import('@tamagui/slider')
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    const first = render(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <Slider defaultValue={[50]} />
+      </TamaguiProvider>
+    )
+    const second = render(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <Slider defaultValue={[50]} />
+      </TamaguiProvider>
+    )
+
+    const measurementObservers = MockIntersectionObserver.instances.filter((instance) =>
+      Array.isArray(instance.options?.threshold)
+    )
+    expect(measurementObservers).toHaveLength(2)
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    act(() => measurementObservers[0].setIntersecting(true))
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+    act(() => measurementObservers[1].setIntersecting(true))
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1)
+
+    act(() => measurementObservers[0].setIntersecting(false))
+    expect(clearIntervalSpy).not.toHaveBeenCalled()
+
+    act(() => measurementObservers[1].setIntersecting(false))
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+
+    act(() => measurementObservers[0].setIntersecting(true))
+    act(() => measurementObservers[1].setIntersecting(true))
+    expect(setIntervalSpy).toHaveBeenCalledTimes(2)
+
+    first.unmount()
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1)
+    second.unmount()
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('respects the interval disable guard when a slider becomes active', async () => {
+    process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL = '1'
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+    const { Slider } = await import('@tamagui/slider')
+
+    render(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <Slider defaultValue={[50]} />
+      </TamaguiProvider>
+    )
+    const measurementObserver = MockIntersectionObserver.instances.find((instance) =>
+      Array.isArray(instance.options?.threshold)
+    )
+    expect(measurementObserver).toBeDefined()
+    act(() => measurementObserver!.setIntersecting(true))
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+  })
+})

--- a/code/ui/slider/src/Slider.tsx
+++ b/code/ui/slider/src/Slider.tsx
@@ -58,19 +58,34 @@ import type {
 } from './types'
 
 const activeSliderMeasureListeners = new Set<Function>()
+let activeSliderMeasureInterval: ReturnType<typeof setInterval> | undefined
 
 // run an interval on web as using translate can move things at any moment
 // without triggering layout or intersection observers
+function startSliderMeasureInterval() {
+  if (
+    process.env.TAMAGUI_TARGET !== 'web' ||
+    activeSliderMeasureInterval !== undefined ||
+    process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL
+  ) {
+    return
+  }
 
-if (process.env.TAMAGUI_TARGET === 'web') {
-  if (!process.env.TAMAGUI_DISABLE_SLIDER_INTERVAL) {
-    setInterval?.(
-      () => {
-        activeSliderMeasureListeners.forEach((cb) => cb())
-      },
-      // really doesn't need to be super often
-      1000
-    )
+  activeSliderMeasureInterval = setInterval(() => {
+    activeSliderMeasureListeners.forEach((cb) => cb())
+  }, 1000)
+}
+
+function addActiveSliderMeasureListener(listener: Function) {
+  activeSliderMeasureListeners.add(listener)
+  startSliderMeasureInterval()
+}
+
+function removeActiveSliderMeasureListener(listener: Function) {
+  activeSliderMeasureListeners.delete(listener)
+  if (!activeSliderMeasureListeners.size && activeSliderMeasureInterval !== undefined) {
+    clearInterval(activeSliderMeasureInterval)
+    activeSliderMeasureInterval = undefined
   }
 }
 
@@ -193,9 +208,9 @@ function useSliderMeasure(sliderRef: React.RefObject<View | null>, measure: () =
       (entries) => {
         debouncedMeasure()
         if (entries?.[0].isIntersecting) {
-          activeSliderMeasureListeners.add(debouncedMeasure)
+          addActiveSliderMeasureListener(debouncedMeasure)
         } else {
-          activeSliderMeasureListeners.delete(debouncedMeasure)
+          removeActiveSliderMeasureListener(debouncedMeasure)
         }
       },
       {
@@ -208,7 +223,7 @@ function useSliderMeasure(sliderRef: React.RefObject<View | null>, measure: () =
     io.observe(node)
 
     return () => {
-      activeSliderMeasureListeners.delete(debouncedMeasure)
+      removeActiveSliderMeasureListener(debouncedMeasure)
       io.disconnect()
     }
   }, [])


### PR DESCRIPTION
Implements E0 from `plans/v3-evolution.md`.

- evaluates Tamagui config and configured component modules through Vite ModuleRunner using the app's resolver/plugin pipeline
- preserves aliases, conditional exports, configured package roots, HMR invalidation, extraction caches, and client/SSR CSS hydration
- isolates One environment-specific transforms while retaining user `resolveId`/`load` behavior
- coordinates one shared evaluation runner across concurrent client/SSR builds and closing/restart epochs
- installs parsed and raw Tamagui configs without requiring browser globals and synchronizes duplicate-instance token/media state
- bounds evaluation work to extractable `.tsx` candidates, preserves direct package boundaries, and removes Slider's import-time polling side effect
- binds the Railway preview server to the injected `PORT`

Validation:

- `code/compiler/static`: package build and focused browserless config tests
- `code/compiler/vite-plugin`: package build
- focused ModuleRunner suite: 7/7
- Node 24 dev SSR/hydration: 18/18
- Node 24 production SSR/hydration: 18/18
- Node 24 integration Playwright: 2/2 in 8.0s (Turbo task 9.635s)
- local production site build plus exact `serve:railway` artifact: `/api/health` and `/` return 200 and the server remains alive on the injected port
