### PR TITLE
feat(compiler): E1 analyzer evidence run — verdict: yuku

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,19 @@
         "ultra-runner": "^3.10.5",
       },
     },
+    "code/compiler/analyzer-spike": {
+      "name": "@tamagui/analyzer-spike",
+      "version": "0.0.0",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "magic-string": "0.30.21",
+        "yuku-analyzer": "0.6.1",
+      },
+      "devDependencies": {
+        "@types/node": "^22.1.0",
+        "typescript": "~5.9.2",
+      },
+    },
     "code/compiler/babel-plugin": {
       "name": "@tamagui/babel-plugin",
       "version": "2.4.3",
@@ -5153,6 +5166,8 @@
 
     "@tamagui/alert-dialog": ["@tamagui/alert-dialog@workspace:code/ui/alert-dialog"],
 
+    "@tamagui/analyzer-spike": ["@tamagui/analyzer-spike@workspace:code/compiler/analyzer-spike"],
+
     "@tamagui/animate": ["@tamagui/animate@workspace:code/ui/animate"],
 
     "@tamagui/animate-presence": ["@tamagui/animate-presence@workspace:code/ui/animate-presence"],
@@ -5840,6 +5855,30 @@
     "@xtuc/ieee754": ["@xtuc/ieee754@1.2.0", "", {}, "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="],
 
     "@xtuc/long": ["@xtuc/long@4.2.2", "", {}, "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="],
+
+    "@yuku-analyzer/binding-darwin-arm64": ["@yuku-analyzer/binding-darwin-arm64@0.6.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UIR1mV13mSuKKPlStlhY/1G7hlyO4iuZLAH3VYjEm0SaiDEW43vBghEBsqvL/WU/Os+6gIbyMkJqvqe1vbl1cg=="],
+
+    "@yuku-analyzer/binding-darwin-x64": ["@yuku-analyzer/binding-darwin-x64@0.6.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zl+Tf6QCBAYCXqyhw6rNd8hQUfcyxUoKc08swYCNZau4DKwlPKAnl/Zp5CBYGSfp4a3qM9Rs4qpR1e0oP5Erew=="],
+
+    "@yuku-analyzer/binding-freebsd-x64": ["@yuku-analyzer/binding-freebsd-x64@0.6.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-8PUqz5mGTr1bM7OX9omnUzgH5xDjTYZW7MdJecevjT7c96xkM1vdF4qTeL2rGzaKHVXfgUFDU3K8rFZanJq+6g=="],
+
+    "@yuku-analyzer/binding-linux-arm-gnu": ["@yuku-analyzer/binding-linux-arm-gnu@0.6.1", "", { "os": "linux", "cpu": "arm" }, "sha512-s9Pm7qORjYGbpFpvTe8P9Pg6Fd4C0TPVIKwVEPueqYVyDAhvQ45o/ebrl6tK5qEUvORfLQkKIvvMW0hT08LYvA=="],
+
+    "@yuku-analyzer/binding-linux-arm-musl": ["@yuku-analyzer/binding-linux-arm-musl@0.6.1", "", { "os": "linux", "cpu": "arm" }, "sha512-RrEZf2V6MBl29PVhkSjHeo5i6jeF3cVK1KxBoBsKjfCythdio4B+lsP7J7mB+7IJwNoZ+ZRM35q1D/3EHbFXug=="],
+
+    "@yuku-analyzer/binding-linux-arm64-gnu": ["@yuku-analyzer/binding-linux-arm64-gnu@0.6.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-h3ZhSz+yvCqHHDxZyO3fp2NzVto1tPoxRqJBpQN0niY9k8YfLk3avIEXjubazuWPDKsq47HK8+/kWLbnhzDBtw=="],
+
+    "@yuku-analyzer/binding-linux-arm64-musl": ["@yuku-analyzer/binding-linux-arm64-musl@0.6.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LlGM5mazQmEwdSP3FcRUrMfxRyPSr/1Bb49XNwch0vd5ScBOIfpqvynNDirq5odpX9JAOSxlgZYx1qng0TR6VA=="],
+
+    "@yuku-analyzer/binding-linux-x64-gnu": ["@yuku-analyzer/binding-linux-x64-gnu@0.6.1", "", { "os": "linux", "cpu": "x64" }, "sha512-zJcTLS2afBf0LdBc8F0bS5qCILJ8HDr8SLsyYDXNG4+IbkwnpUw1qgXHaPVBnFbTEY6AUGV+JgHJLBX031gLfQ=="],
+
+    "@yuku-analyzer/binding-linux-x64-musl": ["@yuku-analyzer/binding-linux-x64-musl@0.6.1", "", { "os": "linux", "cpu": "x64" }, "sha512-XrABg2pUq7con6fnN3EYNBi0xddr+TBjeE8QMG3PhQc3qAUm80ZoDsfwuXpv8jCgeNO/18QdFsfq/z6xNlG/Aw=="],
+
+    "@yuku-analyzer/binding-win32-arm64": ["@yuku-analyzer/binding-win32-arm64@0.6.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-SPFNyb08ueZZLZsxJ3397lzzzNY4BPei7aCwimF/ugZlSIlgn5q3az3QmcB7O1OBoXKp9iXCWh+doy3enJxdKA=="],
+
+    "@yuku-analyzer/binding-win32-x64": ["@yuku-analyzer/binding-win32-x64@0.6.1", "", { "os": "win32", "cpu": "x64" }, "sha512-AS6PGnurmJ05ZN5GZdEcVBLuEJIcJu4Wqv7nVTSSktJ3iWfU1se+VlHvrA9Ik94FgX28todZ9TEK1Zdha8UAIQ=="],
+
+    "@yuku-toolchain/types": ["@yuku-toolchain/types@0.5.43", "", {}, "sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ=="],
 
     "@zeit/schemas": ["@zeit/schemas@2.36.0", "", {}, "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg=="],
 
@@ -8950,6 +8989,8 @@
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "yuku-analyzer": ["yuku-analyzer@0.6.1", "", { "dependencies": { "@yuku-toolchain/types": "0.5.43" }, "optionalDependencies": { "@yuku-analyzer/binding-darwin-arm64": "0.6.1", "@yuku-analyzer/binding-darwin-x64": "0.6.1", "@yuku-analyzer/binding-freebsd-x64": "0.6.1", "@yuku-analyzer/binding-linux-arm-gnu": "0.6.1", "@yuku-analyzer/binding-linux-arm-musl": "0.6.1", "@yuku-analyzer/binding-linux-arm64-gnu": "0.6.1", "@yuku-analyzer/binding-linux-arm64-musl": "0.6.1", "@yuku-analyzer/binding-linux-x64-gnu": "0.6.1", "@yuku-analyzer/binding-linux-x64-musl": "0.6.1", "@yuku-analyzer/binding-win32-arm64": "0.6.1", "@yuku-analyzer/binding-win32-x64": "0.6.1" } }, "sha512-MDfksqhepu1Fneo9i3EL2tsqWBBUNVcdtLtyEwaGTeFdcMfQ+pya9UatnjeRRTZTmlkJpyIy9mOfWYbxtYwINg=="],
 
     "zeego": ["zeego@3.0.6", "", { "dependencies": { "@radix-ui/react-context-menu": "^2.0.1", "@radix-ui/react-dropdown-menu": "^2.0.1", "sf-symbols-typescript": "^2.0.0" }, "peerDependencies": { "@react-native-menu/menu": "1.2.2", "react": "*", "react-native": "*", "react-native-ios-context-menu": "3.1.0", "react-native-ios-utilities": "5.1.2" } }, "sha512-vg0GCMPYg6or/J91bwRnUpIYwz7QnhkyeKOdd3FjvICg+Gzq2D5QhD8k5RUSv1B+048LpNmNYdLm8qJVIbBONw=="],
 

--- a/code/compiler/analyzer-spike/README.md
+++ b/code/compiler/analyzer-spike/README.md
@@ -1,0 +1,14 @@
+# V3 analyzer decision spike
+
+This private workspace measures the two candidates named by E1 in
+`plans/v3-evolution.md`. It is deliberately outside the published static compiler. The
+host fixture supplies every resolved module id; neither candidate performs filesystem or
+package resolution.
+
+The checked-in source is a reviewable experiment, not a second compiler implementation.
+After evidence is collected, the losing candidate is deleted and the retained graph becomes
+the starting point for E2.
+
+**Decided 2026-07-13: yuku.** `evidence/results.json` holds the recorded two-candidate run;
+the `oxc-owned` adapter is deleted. The verdict and its reasoning live in
+`plans/v3-evolution.md` under E1.

--- a/code/compiler/analyzer-spike/evidence/README.md
+++ b/code/compiler/analyzer-spike/evidence/README.md
@@ -1,0 +1,21 @@
+# Evidence protocol
+
+The E1 decision uses one command from this directory after dependencies are locked:
+
+```sh
+bun --expose-gc src/harness/run.ts
+```
+
+The command checks binding, re-export, spread, workspace, source JSX, compiled JSX, and
+source-map correctness before measuring either candidate. Timing workers run in fresh
+processes over the same generated 1,000-module, two-branch graph and record ten cold samples,
+one hundred warm root edits affecting exactly one 500-module branch, changed/unchanged static
+values, and unaffected parse counts. Separate fresh memory workers take a post-GC baseline
+after importing one candidate and creating the fixture, then construct, link, and query exactly
+one graph before the final GC and heap/RSS measurement. The runtime/CPU environment is recorded
+in `results.json`.
+
+Correctness and source maps are absolute gates. Warm invalidation must have a p95 no greater
+than 50ms and no greater than 25% of the cold median. Yuku is eligible only through its public
+API without a patch, fork, or internal import. Memory is a recorded decision input; more than
+2x the competing candidate or 256MiB for this graph requires explicit justification.

--- a/code/compiler/analyzer-spike/evidence/results.json
+++ b/code/compiler/analyzer-spike/evidence/results.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": 1,
+  "environment": {
+    "platform": "darwin",
+    "arch": "arm64",
+    "runtime": "node",
+    "runtimeVersion": "v24.3.0",
+    "bunVersion": "1.3.14",
+    "cpu": "Apple M3 Max",
+    "cpuCount": 16,
+    "command": "bun --expose-gc src/harness/run.ts"
+  },
+  "packageVersions": {
+    "oxcParser": "0.112.0",
+    "yukuAnalyzer": "0.6.1",
+    "magicString": "0.30.21",
+    "traceMapping": "0.3.31"
+  },
+  "thresholds": {
+    "correctnessAndMaps": "absolute",
+    "warmP95Ms": 50,
+    "warmToColdMedianRatio": 0.25,
+    "yukuApi": "public API only; no patch, fork, or internal imports"
+  },
+  "correctness": [
+    {
+      "candidate": "yuku",
+      "fixtureCount": 8,
+      "definitionReferenceChecks": 4,
+      "sourceMapChecks": 1
+    },
+    {
+      "candidate": "oxc-owned",
+      "fixtureCount": 8,
+      "definitionReferenceChecks": 4,
+      "sourceMapChecks": 1
+    }
+  ],
+  "measurements": [
+    {
+      "candidate": "yuku",
+      "moduleCount": 1000,
+      "cold": {
+        "medianMs": 64.707875,
+        "p95Ms": 153.272042,
+        "samples": 10
+      },
+      "warm": {
+        "medianMs": 9.382041999999956,
+        "p95Ms": 20.570249999999987,
+        "samples": 100
+      },
+      "warmToColdRatio": 0.31789407394385905,
+      "unaffectedReparseCount": 0,
+      "affectedModuleCount": 500,
+      "gates": {
+        "warmUnder50Ms": true,
+        "warmUnder25PercentCold": false,
+        "exactInvalidation": true,
+        "noUnaffectedReparse": true
+      },
+      "memory": {
+        "heapDeltaBytes": 0,
+        "rssDeltaBytes": 20037632
+      }
+    },
+    {
+      "candidate": "oxc-owned",
+      "moduleCount": 1000,
+      "cold": {
+        "medianMs": 136.092084,
+        "p95Ms": 288.8000420000001,
+        "samples": 10
+      },
+      "warm": {
+        "medianMs": 1.7433750000000146,
+        "p95Ms": 25.375332999999955,
+        "samples": 100
+      },
+      "warmToColdRatio": 0.18645708298507616,
+      "unaffectedReparseCount": 0,
+      "affectedModuleCount": 500,
+      "gates": {
+        "warmUnder50Ms": true,
+        "warmUnder25PercentCold": true,
+        "exactInvalidation": true,
+        "noUnaffectedReparse": true
+      },
+      "memory": {
+        "heapDeltaBytes": 0,
+        "rssDeltaBytes": 50069504
+      }
+    }
+  ]
+}

--- a/code/compiler/analyzer-spike/fixtures/project/packages/theme/src/index.ts
+++ b/code/compiler/analyzer-spike/fixtures/project/packages/theme/src/index.ts
@@ -1,0 +1,3 @@
+export const workspaceScale = {
+  multiplier: 2,
+} as const

--- a/code/compiler/analyzer-spike/fixtures/project/packages/ui/src/index.ts
+++ b/code/compiler/analyzer-spike/fixtures/project/packages/ui/src/index.ts
@@ -1,0 +1,1 @@
+export const View = 'fixture-view'

--- a/code/compiler/analyzer-spike/fixtures/project/src/App.compiled.ts
+++ b/code/compiler/analyzer-spike/fixtures/project/src/App.compiled.ts
@@ -1,0 +1,12 @@
+import { View as Frame } from '@fixture/ui'
+import { jsx as _jsx, jsxs as _jsxs } from 'react/jsx-runtime'
+
+import { config } from './config'
+
+export const Compiled = () =>
+  _jsxs(Frame, {
+    children: [
+      _jsx(Frame, { padding: config.padding }),
+      _jsx(Frame, { gap: config.gap }),
+    ],
+  })

--- a/code/compiler/analyzer-spike/fixtures/project/src/App.create-element.ts
+++ b/code/compiler/analyzer-spike/fixtures/project/src/App.create-element.ts
@@ -1,0 +1,6 @@
+import { View as Frame } from '@fixture/ui'
+import React from 'react'
+
+import { config } from './config'
+
+export const Created = () => React.createElement(Frame, { padding: config.padding })

--- a/code/compiler/analyzer-spike/fixtures/project/src/App.tsx
+++ b/code/compiler/analyzer-spike/fixtures/project/src/App.tsx
@@ -1,0 +1,7 @@
+import { View as Frame } from '@fixture/ui'
+
+import { config } from './config'
+
+export const App = () => <Frame padding={config.padding} gap={config.gap} />
+
+export const shadowProof = (config = { padding: 99 }) => config.padding

--- a/code/compiler/analyzer-spike/fixtures/project/src/config.ts
+++ b/code/compiler/analyzer-spike/fixtures/project/src/config.ts
@@ -1,0 +1,13 @@
+import { workspaceScale } from '@fixture/theme'
+import { aliasedToken as baseSpace } from '#tokens'
+
+const baseConfig = {
+  padding: baseSpace,
+}
+
+export const config = {
+  ...baseConfig,
+  gap: baseSpace * workspaceScale.multiplier,
+}
+
+export const configUse = config.gap

--- a/code/compiler/analyzer-spike/fixtures/project/src/token-barrel.ts
+++ b/code/compiler/analyzer-spike/fixtures/project/src/token-barrel.ts
@@ -1,0 +1,1 @@
+export { importedToken as aliasedToken } from './tokens'

--- a/code/compiler/analyzer-spike/fixtures/project/src/tokens.ts
+++ b/code/compiler/analyzer-spike/fixtures/project/src/tokens.ts
@@ -1,0 +1,6 @@
+export const spacing = {
+  sm: 8,
+  md: 12,
+} as const
+
+export const importedToken = spacing.md

--- a/code/compiler/analyzer-spike/package.json
+++ b/code/compiler/analyzer-spike/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tamagui/analyzer-spike",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit",
+    "evidence": "bun --expose-gc src/harness/run.ts"
+  },
+  "dependencies": {
+    "@jridgewell/trace-mapping": "0.3.31",
+    "magic-string": "0.30.21",
+    "yuku-analyzer": "0.6.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.1.0",
+    "typescript": "~5.9.2"
+  }
+}

--- a/code/compiler/analyzer-spike/src/ast.ts
+++ b/code/compiler/analyzer-spike/src/ast.ts
@@ -1,0 +1,86 @@
+import type { AstNode } from './contracts'
+
+const ignoredKeys = new Set(['loc', 'range', 'parent', 'comments', 'tokens'])
+
+export function isAstNode(value: unknown): value is AstNode {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as AstNode).type === 'string' &&
+    typeof (value as AstNode).start === 'number' &&
+    typeof (value as AstNode).end === 'number'
+  )
+}
+
+export function walkAst(
+  node: AstNode,
+  visitor: (node: AstNode, parent: AstNode | null, key: string | null) => void,
+  parent: AstNode | null = null,
+  key: string | null = null
+): void {
+  visitor(node, parent, key)
+
+  for (const [childKey, value] of Object.entries(node)) {
+    if (ignoredKeys.has(childKey)) continue
+    if (isAstNode(value)) {
+      walkAst(value, visitor, node, childKey)
+    } else if (Array.isArray(value)) {
+      for (const child of value) {
+        if (isAstNode(child)) {
+          walkAst(child, visitor, node, childKey)
+        }
+      }
+    }
+  }
+}
+
+export function findAstNode(
+  root: AstNode,
+  predicate: (node: AstNode, parent: AstNode | null, key: string | null) => boolean
+): AstNode | null {
+  let found: AstNode | null = null
+  walkAst(root, (node, parent, key) => {
+    if (!found && predicate(node, parent, key)) {
+      found = node
+    }
+  })
+  return found
+}
+
+export function childNode(node: AstNode, key: string): AstNode | null {
+  const value = node[key]
+  return isAstNode(value) ? value : null
+}
+
+export function childNodes(node: AstNode, key: string): AstNode[] {
+  const value = node[key]
+  return Array.isArray(value) ? value.filter(isAstNode) : []
+}
+
+export function identifierName(node: AstNode | null): string | null {
+  if (!node || (node.type !== 'Identifier' && node.type !== 'JSXIdentifier')) return null
+  return typeof node.name === 'string' ? node.name : null
+}
+
+export function literalValue(node: AstNode | null): unknown {
+  if (!node) return undefined
+  if (node.type === 'Literal' || node.type.endsWith('Literal')) {
+    return node.value
+  }
+  return undefined
+}
+
+export function unwrapExpression(node: AstNode): AstNode {
+  let current = node
+  while (
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSSatisfiesExpression' ||
+    current.type === 'TSNonNullExpression' ||
+    current.type === 'ParenthesizedExpression'
+  ) {
+    const expression = childNode(current, 'expression')
+    if (!expression) break
+    current = expression
+  }
+  return current
+}

--- a/code/compiler/analyzer-spike/src/candidates/yuku.ts
+++ b/code/compiler/analyzer-spike/src/candidates/yuku.ts
@@ -1,0 +1,138 @@
+import { Analyzer, type Module, type Symbol as YukuSymbol } from 'yuku-analyzer'
+
+import type {
+  AnalyzerCandidate,
+  CandidateFactory,
+  DefinitionSite,
+  ParseDiagnostic,
+  ProjectInput,
+  ReferenceSite,
+} from '../contracts'
+import { resolveFromHost } from '../contracts'
+import { asAstNode, declarationForName, definitionFromDeclaration } from '../normalize'
+
+class YukuCandidate implements AnalyzerCandidate {
+  readonly name = 'yuku' as const
+  readonly #analyzer: Analyzer
+  readonly #parseCounts = new Map<string, number>()
+
+  constructor(private readonly project: ProjectInput) {
+    this.#analyzer = new Analyzer({
+      resolve: (specifier, importer) =>
+        resolveFromHost(this.project.resolutions, specifier, importer),
+    })
+    for (const [id, source] of project.files) this.addFile(id, source)
+  }
+
+  addFile(id: string, source: string): void {
+    this.#analyzer.addFile(id, source, { preserveParens: true, sourceType: 'module' })
+    this.#parseCounts.set(id, (this.#parseCounts.get(id) ?? 0) + 1)
+  }
+
+  removeFile(id: string): boolean {
+    return this.#analyzer.removeFile(id)
+  }
+
+  link(): void {
+    this.#analyzer.link()
+  }
+
+  #module(id: string): Module {
+    const module = this.#analyzer.module(id)
+    if (!module) throw new Error(`yuku: unknown module ${id}`)
+    return module
+  }
+
+  #canonicalSymbol(id: string, localName: string): YukuSymbol | null {
+    const symbol = this.#module(id).resolve(localName)
+    return symbol ? (this.#analyzer.definitionOf(symbol)?.symbol ?? null) : null
+  }
+
+  definitionOf(id: string, localName: string): DefinitionSite | null {
+    const symbol = this.#canonicalSymbol(id, localName)
+    if (!symbol) return null
+    const declaration = symbol.declarations[0]
+    if (!declaration) return null
+    const program = asAstNode(symbol.module.ast, `${symbol.module.path} program`)
+    const normalizedDeclaration =
+      declarationForName(program, symbol.name) ??
+      asAstNode(declaration, `${symbol.name} declaration`)
+    return definitionFromDeclaration(
+      symbol.module.path,
+      symbol.name,
+      program,
+      normalizedDeclaration
+    )
+  }
+
+  referencesOf(definition: DefinitionSite): ReferenceSite[] {
+    const symbol = this.#canonicalSymbol(definition.id, definition.name)
+    if (!symbol) return []
+    return this.#analyzer.referencesOf(symbol).map(({ module, reference }) => ({
+      id: module.path,
+      name: reference.name,
+      start: reference.node.start,
+      end: reference.node.end,
+    }))
+  }
+
+  dependenciesOf(id: string): string[] {
+    return this.#module(id)
+      .dependencies.map((module) => module.path)
+      .sort()
+  }
+
+  dependentsOf(id: string): string[] {
+    return this.#module(id)
+      .dependents.map((module) => module.path)
+      .sort()
+  }
+
+  affectedBy(id: string): string[] {
+    const affected = new Set([id])
+    const queue = [id]
+    while (queue.length) {
+      const current = queue.shift()!
+      for (const dependent of this.dependentsOf(current)) {
+        if (!affected.has(dependent)) {
+          affected.add(dependent)
+          queue.push(dependent)
+        }
+      }
+    }
+    return [...affected].sort()
+  }
+
+  programOf(id: string) {
+    return asAstNode(this.#module(id).ast, `${id} program`)
+  }
+
+  sourceOf(id: string): string {
+    return this.#module(id).source
+  }
+
+  parseCount(id: string): number {
+    return this.#parseCounts.get(id) ?? 0
+  }
+
+  diagnostics(): ParseDiagnostic[] {
+    const parseDiagnostics = [...this.#analyzer.modules.values()].flatMap((module) =>
+      module.diagnostics.map((diagnostic) => ({
+        id: module.path,
+        message: diagnostic.message,
+      }))
+    )
+    return [
+      ...parseDiagnostics,
+      ...this.#analyzer.diagnostics.map((diagnostic) => ({
+        id: diagnostic.module,
+        message: diagnostic.message,
+      })),
+    ]
+  }
+}
+
+export const yukuFactory: CandidateFactory = {
+  name: 'yuku',
+  create: (project) => new YukuCandidate(project),
+}

--- a/code/compiler/analyzer-spike/src/contracts.ts
+++ b/code/compiler/analyzer-spike/src/contracts.ts
@@ -1,0 +1,64 @@
+export interface AstNode {
+  type: string
+  start: number
+  end: number
+  [key: string]: unknown
+}
+
+export interface ProjectInput {
+  files: ReadonlyMap<string, string>
+  resolutions: ReadonlyMap<string, string>
+}
+
+export interface DefinitionSite {
+  id: string
+  name: string
+  start: number
+  end: number
+  initializer: AstNode | null
+}
+
+export interface ReferenceSite {
+  id: string
+  name: string
+  start: number
+  end: number
+}
+
+export interface ParseDiagnostic {
+  id: string
+  message: string
+}
+
+export interface AnalyzerCandidate {
+  readonly name: 'yuku'
+  addFile(id: string, source: string): void
+  removeFile(id: string): boolean
+  link(): void
+  definitionOf(id: string, localName: string): DefinitionSite | null
+  referencesOf(definition: DefinitionSite): ReferenceSite[]
+  dependenciesOf(id: string): string[]
+  dependentsOf(id: string): string[]
+  affectedBy(id: string): string[]
+  programOf(id: string): AstNode
+  sourceOf(id: string): string
+  parseCount(id: string): number
+  diagnostics(): ParseDiagnostic[]
+}
+
+export interface CandidateFactory {
+  name: AnalyzerCandidate['name']
+  create(project: ProjectInput): AnalyzerCandidate
+}
+
+export function resolutionKey(importer: string, specifier: string): string {
+  return `${importer}\0${specifier}`
+}
+
+export function resolveFromHost(
+  resolutions: ReadonlyMap<string, string>,
+  specifier: string,
+  importer: string
+): string | null {
+  return resolutions.get(resolutionKey(importer, specifier)) ?? null
+}

--- a/code/compiler/analyzer-spike/src/evaluate.ts
+++ b/code/compiler/analyzer-spike/src/evaluate.ts
@@ -1,0 +1,108 @@
+import {
+  childNode,
+  childNodes,
+  identifierName,
+  literalValue,
+  unwrapExpression,
+} from './ast'
+import type { AnalyzerCandidate, AstNode } from './contracts'
+
+const evaluating = new Set<string>()
+
+export function evaluateBinding(
+  candidate: AnalyzerCandidate,
+  id: string,
+  localName: string
+): unknown {
+  const definition = candidate.definitionOf(id, localName)
+  if (!definition?.initializer) {
+    throw new Error(`${candidate.name}: ${id}:${localName} has no static initializer`)
+  }
+
+  const key = `${definition.id}:${definition.start}`
+  if (evaluating.has(key)) throw new Error(`Static evaluation cycle at ${key}`)
+  evaluating.add(key)
+  try {
+    return evaluateNode(candidate, definition.id, definition.initializer)
+  } finally {
+    evaluating.delete(key)
+  }
+}
+
+export function evaluateNode(
+  candidate: AnalyzerCandidate,
+  id: string,
+  input: AstNode
+): unknown {
+  const node = unwrapExpression(input)
+  const literal = literalValue(node)
+  if (literal !== undefined) return literal
+
+  switch (node.type) {
+    case 'Identifier': {
+      const name = identifierName(node)
+      if (!name) throw new Error(`Unnamed identifier at ${id}:${node.start}`)
+      return evaluateBinding(candidate, id, name)
+    }
+    case 'ObjectExpression': {
+      const output: Record<string, unknown> = {}
+      for (const property of childNodes(node, 'properties')) {
+        if (property.type === 'SpreadElement') {
+          const spread = childNode(property, 'argument')
+          const value = spread ? evaluateNode(candidate, id, spread) : null
+          if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            throw new Error(`Non-object spread at ${id}:${property.start}`)
+          }
+          Object.assign(output, value)
+          continue
+        }
+        if (property.type !== 'Property' && property.type !== 'ObjectProperty') continue
+        const keyNode = childNode(property, 'key')
+        const key = identifierName(keyNode) ?? literalValue(keyNode)
+        if (typeof key !== 'string' && typeof key !== 'number') {
+          throw new Error(`Unsupported object key at ${id}:${property.start}`)
+        }
+        const valueNode = childNode(property, 'value')
+        if (!valueNode) throw new Error(`Missing object value at ${id}:${property.start}`)
+        output[String(key)] = evaluateNode(candidate, id, valueNode)
+      }
+      return output
+    }
+    case 'MemberExpression': {
+      const objectNode = childNode(node, 'object')
+      const propertyNode = childNode(node, 'property')
+      if (!objectNode || !propertyNode)
+        throw new Error(`Invalid member expression at ${id}`)
+      const object = evaluateNode(candidate, id, objectNode)
+      const computed = node.computed === true
+      const property = computed
+        ? evaluateNode(candidate, id, propertyNode)
+        : identifierName(propertyNode)
+      if ((typeof object !== 'object' || object === null) && typeof object !== 'string') {
+        throw new Error(
+          `Cannot read ${String(property)} from non-object at ${id}:${node.start}`
+        )
+      }
+      return (object as Record<string, unknown>)[String(property)]
+    }
+    case 'BinaryExpression': {
+      const leftNode = childNode(node, 'left')
+      const rightNode = childNode(node, 'right')
+      if (!leftNode || !rightNode) throw new Error(`Invalid binary expression at ${id}`)
+      const left = evaluateNode(candidate, id, leftNode)
+      const right = evaluateNode(candidate, id, rightNode)
+      switch (node.operator) {
+        case '+':
+          return (left as number) + (right as number)
+        case '*':
+          return (left as number) * (right as number)
+        default:
+          throw new Error(
+            `Unsupported operator ${String(node.operator)} at ${id}:${node.start}`
+          )
+      }
+    }
+    default:
+      throw new Error(`Unsupported static node ${node.type} at ${id}:${node.start}`)
+  }
+}

--- a/code/compiler/analyzer-spike/src/fixture.ts
+++ b/code/compiler/analyzer-spike/src/fixture.ts
@@ -1,0 +1,81 @@
+import { readdir, readFile } from 'node:fs/promises'
+import { dirname, extname, join, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import type { ProjectInput } from './contracts'
+import { resolutionKey } from './contracts'
+
+const fixtureRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../fixtures/project'
+)
+
+async function collectFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name)
+      return entry.isDirectory() ? collectFiles(path) : [path]
+    })
+  )
+  return files.flat()
+}
+
+function fixtureId(path: string): string {
+  return `/${relative(fixtureRoot, path).replaceAll('\\', '/')}`
+}
+
+export async function loadFixtureProject(): Promise<ProjectInput> {
+  const paths = (await collectFiles(fixtureRoot))
+    .filter((path) => ['.ts', '.tsx'].includes(extname(path)))
+    .sort()
+  const files = new Map<string, string>()
+  for (const path of paths) {
+    files.set(fixtureId(path), await readFile(path, 'utf8'))
+  }
+
+  const resolutions = new Map<string, string>([
+    [resolutionKey('/src/token-barrel.ts', './tokens'), '/src/tokens.ts'],
+    [resolutionKey('/src/config.ts', '#tokens'), '/src/token-barrel.ts'],
+    [resolutionKey('/src/config.ts', '@fixture/theme'), '/packages/theme/src/index.ts'],
+    [resolutionKey('/src/App.tsx', './config'), '/src/config.ts'],
+    [resolutionKey('/src/App.tsx', '@fixture/ui'), '/packages/ui/src/index.ts'],
+    [resolutionKey('/src/App.compiled.ts', './config'), '/src/config.ts'],
+    [resolutionKey('/src/App.compiled.ts', '@fixture/ui'), '/packages/ui/src/index.ts'],
+    [resolutionKey('/src/App.create-element.ts', './config'), '/src/config.ts'],
+    [
+      resolutionKey('/src/App.create-element.ts', '@fixture/ui'),
+      '/packages/ui/src/index.ts',
+    ],
+  ])
+
+  return { files, resolutions }
+}
+
+export function createGeneratedProject(size = 1_000): ProjectInput {
+  if (size < 4 || size % 2 !== 0) {
+    throw new Error(
+      'Generated analyzer graph must contain an even number of at least four modules'
+    )
+  }
+
+  const files = new Map<string, string>()
+  const resolutions = new Map<string, string>()
+  const secondRoot = size / 2
+  files.set('/generated/module-0.ts', 'export const value0 = 1\n')
+  files.set(`/generated/module-${secondRoot}.ts`, `export const value${secondRoot} = 1\n`)
+
+  for (let index = 1; index < size; index++) {
+    if (index === secondRoot) continue
+    const id = `/generated/module-${index}.ts`
+    const rootIndex = index < secondRoot ? 0 : secondRoot
+    const root = `/generated/module-${rootIndex}.ts`
+    files.set(
+      id,
+      `import { value${rootIndex} } from '#root'\nexport const value${index} = value${rootIndex} + ${index - rootIndex}\n`
+    )
+    resolutions.set(resolutionKey(id, '#root'), root)
+  }
+
+  return { files, resolutions }
+}

--- a/code/compiler/analyzer-spike/src/harness/correctness.ts
+++ b/code/compiler/analyzer-spike/src/harness/correctness.ts
@@ -1,0 +1,162 @@
+import assert from 'node:assert/strict'
+
+import type {
+  AnalyzerCandidate,
+  CandidateFactory,
+  ProjectInput,
+  ReferenceSite,
+} from '../contracts'
+import { evaluateBinding } from '../evaluate'
+import { inspectElementForms } from '../normalize'
+import { assertSpanEditSourceMap } from '../sourceMap'
+
+function compactReferences(references: ReferenceSite[]): string[] {
+  return references.map(({ id, name }) => `${id}:${name}`).sort()
+}
+
+function assertReferenceSpans(
+  candidate: AnalyzerCandidate,
+  references: ReferenceSite[]
+): void {
+  for (const reference of references) {
+    assert.equal(
+      candidate.sourceOf(reference.id).slice(reference.start, reference.end),
+      reference.name,
+      `${candidate.name}: invalid reference span for ${reference.id}:${reference.name}`
+    )
+  }
+}
+
+function assertDefinition(
+  candidate: AnalyzerCandidate,
+  id: string,
+  localName: string,
+  expectedId: string,
+  expectedName: string
+) {
+  const definition = candidate.definitionOf(id, localName)
+  assert.ok(definition, `${candidate.name}: missing definition for ${id}:${localName}`)
+  assert.deepEqual(
+    { id: definition.id, name: definition.name },
+    { id: expectedId, name: expectedName }
+  )
+  assert.equal(
+    candidate.sourceOf(definition.id).slice(definition.start, definition.end),
+    definition.name,
+    `${candidate.name}: invalid definition span for ${definition.id}:${definition.name}`
+  )
+  return definition
+}
+
+export interface CorrectnessSummary {
+  candidate: AnalyzerCandidate['name']
+  fixtureCount: number
+  definitionReferenceChecks: number
+  sourceMapChecks: number
+}
+
+export function assertCandidateCorrectness(
+  factory: CandidateFactory,
+  project: ProjectInput
+): CorrectnessSummary {
+  const candidate = factory.create(project)
+  candidate.link()
+  assert.deepEqual(candidate.diagnostics(), [], `${candidate.name}: analyzer diagnostics`)
+
+  const tokenDefinition = assertDefinition(
+    candidate,
+    '/src/config.ts',
+    'baseSpace',
+    '/src/tokens.ts',
+    'importedToken'
+  )
+  const tokenReferences = candidate.referencesOf(tokenDefinition)
+  assertReferenceSpans(candidate, tokenReferences)
+  assert.deepEqual(compactReferences(tokenReferences), [
+    '/src/config.ts:baseSpace',
+    '/src/config.ts:baseSpace',
+  ])
+
+  const workspaceDefinition = assertDefinition(
+    candidate,
+    '/src/config.ts',
+    'workspaceScale',
+    '/packages/theme/src/index.ts',
+    'workspaceScale'
+  )
+  const workspaceReferences = candidate.referencesOf(workspaceDefinition)
+  assertReferenceSpans(candidate, workspaceReferences)
+  assert.deepEqual(compactReferences(workspaceReferences), [
+    '/src/config.ts:workspaceScale',
+  ])
+
+  const configDefinition = assertDefinition(
+    candidate,
+    '/src/App.tsx',
+    'config',
+    '/src/config.ts',
+    'config'
+  )
+  const configReferences = candidate.referencesOf(configDefinition)
+  assertReferenceSpans(candidate, configReferences)
+  assert.deepEqual(compactReferences(configReferences), [
+    '/src/App.compiled.ts:config',
+    '/src/App.compiled.ts:config',
+    '/src/App.create-element.ts:config',
+    '/src/App.tsx:config',
+    '/src/App.tsx:config',
+    '/src/config.ts:config',
+  ])
+
+  assert.deepEqual(evaluateBinding(candidate, '/src/config.ts', 'config'), {
+    padding: 12,
+    gap: 24,
+  })
+
+  const sourceElements = inspectElementForms(candidate, '/src/App.tsx')
+  assert.equal(sourceElements.length, 1)
+  assert.deepEqual(sourceElements[0]?.propNames, ['padding', 'gap'])
+
+  const compiledElements = inspectElementForms(candidate, '/src/App.compiled.ts')
+  assert.equal(compiledElements.length, 3)
+  assert.deepEqual(
+    compiledElements.map((element) => element.propNames),
+    [['children'], ['padding'], ['gap']]
+  )
+
+  const createElement = inspectElementForms(candidate, '/src/App.create-element.ts')
+  assert.equal(createElement.length, 1)
+  assert.deepEqual(createElement[0]?.propNames, ['padding'])
+
+  for (const element of [...sourceElements, ...compiledElements, ...createElement]) {
+    assert.deepEqual(
+      element.componentDefinition && {
+        id: element.componentDefinition.id,
+        name: element.componentDefinition.name,
+      },
+      { id: '/packages/ui/src/index.ts', name: 'View' }
+    )
+  }
+
+  assert.deepEqual(candidate.dependenciesOf('/src/config.ts'), [
+    '/packages/theme/src/index.ts',
+    '/src/token-barrel.ts',
+  ])
+  assert.deepEqual(candidate.affectedBy('/src/tokens.ts'), [
+    '/src/App.compiled.ts',
+    '/src/App.create-element.ts',
+    '/src/App.tsx',
+    '/src/config.ts',
+    '/src/token-barrel.ts',
+    '/src/tokens.ts',
+  ])
+
+  assertSpanEditSourceMap(candidate, '/src/App.tsx')
+
+  return {
+    candidate: candidate.name,
+    fixtureCount: project.files.size,
+    definitionReferenceChecks: 4,
+    sourceMapChecks: 1,
+  }
+}

--- a/code/compiler/analyzer-spike/src/harness/measure.ts
+++ b/code/compiler/analyzer-spike/src/harness/measure.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict'
+import { performance } from 'node:perf_hooks'
+
+import type { CandidateFactory } from '../contracts'
+import { evaluateBinding } from '../evaluate'
+import { createGeneratedProject } from '../fixture'
+
+export interface Distribution {
+  medianMs: number
+  p95Ms: number
+  samples: number
+}
+
+export interface MemoryMeasurement {
+  heapDeltaBytes: number
+  rssDeltaBytes: number
+}
+
+export interface CandidateMeasurement {
+  candidate: CandidateFactory['name']
+  moduleCount: number
+  cold: Distribution
+  warm: Distribution
+  warmToColdRatio: number
+  memory: MemoryMeasurement
+  unaffectedReparseCount: number
+  affectedModuleCount: number
+  gates: {
+    warmUnder50Ms: boolean
+    warmUnder25PercentCold: boolean
+    exactInvalidation: boolean
+    noUnaffectedReparse: boolean
+  }
+}
+
+function distribution(samples: number[]): Distribution {
+  const sorted = [...samples].sort((a, b) => a - b)
+  const percentile = (value: number) => sorted[Math.ceil(sorted.length * value) - 1] ?? 0
+  return {
+    medianMs: percentile(0.5),
+    p95Ms: percentile(0.95),
+    samples: sorted.length,
+  }
+}
+
+function collectGarbage(): void {
+  const gc = (globalThis as typeof globalThis & { gc?: () => void }).gc
+  gc?.()
+}
+
+export function measureCandidateTiming(
+  factory: CandidateFactory,
+  moduleCount = 1_000
+): Omit<CandidateMeasurement, 'memory'> {
+  const project = createGeneratedProject(moduleCount)
+  const affectedFinalIndex = moduleCount / 2 - 1
+  const unaffectedRootIndex = moduleCount / 2
+  const unaffectedFinalIndex = moduleCount - 1
+  const affectedFinalId = `/generated/module-${affectedFinalIndex}.ts`
+  const affectedFinalName = `value${affectedFinalIndex}`
+  const unaffectedFinalId = `/generated/module-${unaffectedFinalIndex}.ts`
+  const unaffectedFinalName = `value${unaffectedFinalIndex}`
+  const coldSamples: number[] = []
+
+  for (let sample = 0; sample < 10; sample++) {
+    collectGarbage()
+    const start = performance.now()
+    const candidate = factory.create(project)
+    candidate.link()
+    assert.ok(candidate.definitionOf(affectedFinalId, affectedFinalName))
+    assert.ok(candidate.definitionOf(unaffectedFinalId, unaffectedFinalName))
+    coldSamples.push(performance.now() - start)
+  }
+
+  const candidate = factory.create(project)
+  candidate.link()
+  assert.ok(candidate.definitionOf(affectedFinalId, affectedFinalName))
+  assert.ok(candidate.definitionOf(unaffectedFinalId, unaffectedFinalName))
+  const expectedAffected = [...project.files.keys()]
+    .filter((id) => Number(id.match(/module-(\d+)\.ts$/)?.[1]) < moduleCount / 2)
+    .sort()
+  const actualAffected = candidate.affectedBy('/generated/module-0.ts')
+  const initialParseCounts = new Map(
+    [...project.files.keys()].map((id) => [id, candidate.parseCount(id)])
+  )
+  const warmSamples: number[] = []
+
+  for (let sample = 0; sample < 100; sample++) {
+    const nextValue = sample % 2 === 0 ? 2 : 1
+    const start = performance.now()
+    candidate.addFile('/generated/module-0.ts', `export const value0 = ${nextValue}\n`)
+    candidate.link()
+    assert.equal(
+      evaluateBinding(candidate, affectedFinalId, affectedFinalName),
+      nextValue + affectedFinalIndex
+    )
+    assert.equal(
+      evaluateBinding(candidate, unaffectedFinalId, unaffectedFinalName),
+      1 + unaffectedFinalIndex - unaffectedRootIndex
+    )
+    warmSamples.push(performance.now() - start)
+  }
+
+  const unaffectedReparseCount = [...project.files.keys()]
+    .filter((id) => id !== '/generated/module-0.ts')
+    .reduce(
+      (total, id) => total + candidate.parseCount(id) - (initialParseCounts.get(id) ?? 0),
+      0
+    )
+  const cold = distribution(coldSamples)
+  const warm = distribution(warmSamples)
+  const warmToColdRatio = warm.p95Ms / cold.medianMs
+
+  return {
+    candidate: factory.name,
+    moduleCount,
+    cold,
+    warm,
+    warmToColdRatio,
+    unaffectedReparseCount,
+    affectedModuleCount: actualAffected.length,
+    gates: {
+      warmUnder50Ms: warm.p95Ms <= 50,
+      warmUnder25PercentCold: warmToColdRatio <= 0.25,
+      exactInvalidation:
+        JSON.stringify(actualAffected) === JSON.stringify(expectedAffected),
+      noUnaffectedReparse: unaffectedReparseCount === 0,
+    },
+  }
+}
+
+export function measureCandidateMemory(
+  factory: CandidateFactory,
+  moduleCount = 1_000
+): MemoryMeasurement {
+  const project = createGeneratedProject(moduleCount)
+  const finalIndex = moduleCount / 2 - 1
+  const finalId = `/generated/module-${finalIndex}.ts`
+  const finalName = `value${finalIndex}`
+
+  collectGarbage()
+  const before = process.memoryUsage()
+  const candidate = factory.create(project)
+  candidate.link()
+  assert.ok(candidate.definitionOf(finalId, finalName))
+  collectGarbage()
+  const after = process.memoryUsage()
+
+  return {
+    heapDeltaBytes: Math.max(0, after.heapUsed - before.heapUsed),
+    rssDeltaBytes: Math.max(0, after.rss - before.rss),
+  }
+}

--- a/code/compiler/analyzer-spike/src/harness/run.ts
+++ b/code/compiler/analyzer-spike/src/harness/run.ts
@@ -1,0 +1,111 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import { cpus } from 'node:os'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+import type { CandidateFactory } from '../contracts'
+import { loadFixtureProject } from '../fixture'
+import { assertCandidateCorrectness } from './correctness'
+import {
+  measureCandidateMemory,
+  measureCandidateTiming,
+  type CandidateMeasurement,
+  type MemoryMeasurement,
+} from './measure'
+
+const candidateNames = ['yuku'] as const
+const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+const evidencePath = resolve(workspaceRoot, 'evidence/results.json')
+
+async function loadFactory(name: string): Promise<CandidateFactory> {
+  if (name === 'yuku') {
+    return (await import('../candidates/yuku')).yukuFactory
+  }
+  throw new Error(`Unknown analyzer candidate: ${name}`)
+}
+
+function runWorker<T>(factory: CandidateFactory, mode: 'timing' | 'memory'): T {
+  const result = spawnSync(
+    process.execPath,
+    ['--expose-gc', fileURLToPath(import.meta.url), '--worker', mode, factory.name],
+    { encoding: 'utf8', env: { ...process.env, TAMAGUI_E1_EVIDENCE_WORKER: '1' } }
+  )
+  if (result.status !== 0) {
+    throw new Error(
+      `${factory.name} measurement failed (${result.status})\n${result.stdout}\n${result.stderr}`
+    )
+  }
+  const resultLine = result.stdout
+    .split('\n')
+    .find((line) => line.startsWith('TAMAGUI_E1_RESULT='))
+  if (!resultLine) throw new Error(`${factory.name} measurement returned no result`)
+  return JSON.parse(resultLine.slice('TAMAGUI_E1_RESULT='.length)) as T
+}
+
+async function main(): Promise<void> {
+  const workerIndex = process.argv.indexOf('--worker')
+  if (workerIndex !== -1) {
+    const mode = process.argv[workerIndex + 1]
+    const factory = await loadFactory(process.argv[workerIndex + 2] ?? '')
+    const result =
+      mode === 'timing'
+        ? measureCandidateTiming(factory)
+        : mode === 'memory'
+          ? measureCandidateMemory(factory)
+          : (() => {
+              throw new Error(`Unknown measurement mode: ${mode}`)
+            })()
+    process.stdout.write(`TAMAGUI_E1_RESULT=${JSON.stringify(result)}\n`)
+    return
+  }
+
+  const project = await loadFixtureProject()
+  const factories = await Promise.all(candidateNames.map(loadFactory))
+  const correctness = factories.map((factory) =>
+    assertCandidateCorrectness(factory, project)
+  )
+  const timings = factories.map((factory) =>
+    runWorker<Omit<CandidateMeasurement, 'memory'>>(factory, 'timing')
+  )
+  const memories = factories.map((factory) =>
+    runWorker<MemoryMeasurement>(factory, 'memory')
+  )
+  const measurements: CandidateMeasurement[] = timings.map((timing, index) => ({
+    ...timing,
+    memory: memories[index]!,
+  }))
+
+  const report = {
+    schemaVersion: 1,
+    environment: {
+      platform: process.platform,
+      arch: process.arch,
+      runtime: process.release.name,
+      runtimeVersion: process.version,
+      bunVersion: (process.versions as Record<string, string | undefined>).bun ?? null,
+      cpu: cpus()[0]?.model ?? 'unknown',
+      cpuCount: cpus().length,
+      command: 'bun --expose-gc src/harness/run.ts',
+    },
+    packageVersions: {
+      yukuAnalyzer: '0.6.1',
+      magicString: '0.30.21',
+      traceMapping: '0.3.31',
+    },
+    thresholds: {
+      correctnessAndMaps: 'absolute',
+      warmP95Ms: 50,
+      warmToColdMedianRatio: 0.25,
+      yukuApi: 'public API only; no patch, fork, or internal imports',
+    },
+    correctness,
+    measurements,
+  }
+
+  await mkdir(dirname(evidencePath), { recursive: true })
+  await writeFile(evidencePath, `${JSON.stringify(report, null, 2)}\n`)
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+}
+
+await main()

--- a/code/compiler/analyzer-spike/src/normalize.ts
+++ b/code/compiler/analyzer-spike/src/normalize.ts
@@ -1,0 +1,158 @@
+import {
+  childNode,
+  childNodes,
+  findAstNode,
+  identifierName,
+  isAstNode,
+  walkAst,
+} from './ast'
+import type { AnalyzerCandidate, AstNode, DefinitionSite } from './contracts'
+
+export function definitionFromDeclaration(
+  id: string,
+  name: string,
+  program: AstNode,
+  declaration: AstNode
+): DefinitionSite {
+  let identifier = declaration
+  let initializer: AstNode | null = null
+
+  if (declaration.type === 'VariableDeclarator') {
+    identifier = childNode(declaration, 'id') ?? declaration
+    initializer = childNode(declaration, 'init')
+  } else if (declaration.type === 'Identifier') {
+    const declarator = findAstNode(
+      program,
+      (node) =>
+        node.type === 'VariableDeclarator' &&
+        childNode(node, 'id')?.start === declaration.start
+    )
+    if (declarator) {
+      initializer = childNode(declarator, 'init')
+    }
+  }
+
+  return {
+    id,
+    name,
+    start: identifier.start,
+    end: identifier.end,
+    initializer,
+  }
+}
+
+export interface ElementInspection {
+  form: 'jsx' | 'jsx-runtime' | 'create-element'
+  componentLocal: string
+  componentDefinition: DefinitionSite | null
+  propNames: string[]
+}
+
+function importProvenance(program: AstNode, localName: string): string | null {
+  for (const statement of childNodes(program, 'body')) {
+    if (statement.type !== 'ImportDeclaration') continue
+    const source = childNode(statement, 'source')
+    const sourceValue = source && typeof source.value === 'string' ? source.value : null
+    for (const specifier of childNodes(statement, 'specifiers')) {
+      if (identifierName(childNode(specifier, 'local')) === localName) {
+        return sourceValue
+      }
+    }
+  }
+  return null
+}
+
+function objectPropertyNames(node: AstNode | null): string[] {
+  if (!node || node.type !== 'ObjectExpression') return []
+  return childNodes(node, 'properties')
+    .map((property) => {
+      if (property.type !== 'Property' && property.type !== 'ObjectProperty') return null
+      const key = childNode(property, 'key')
+      return identifierName(key) ?? (typeof key?.value === 'string' ? key.value : null)
+    })
+    .filter((name): name is string => name !== null)
+}
+
+export function inspectElementForms(
+  candidate: AnalyzerCandidate,
+  id: string
+): ElementInspection[] {
+  const program = candidate.programOf(id)
+  const inspections: ElementInspection[] = []
+
+  walkAst(program, (node) => {
+    if (node.type === 'JSXOpeningElement') {
+      const componentLocal = identifierName(childNode(node, 'name'))
+      if (!componentLocal || !/^[A-Z]/.test(componentLocal)) return
+      const propNames = childNodes(node, 'attributes')
+        .map((attribute) => identifierName(childNode(attribute, 'name')))
+        .filter((name): name is string => name !== null)
+      inspections.push({
+        form: 'jsx',
+        componentLocal,
+        componentDefinition: candidate.definitionOf(id, componentLocal),
+        propNames,
+      })
+      return
+    }
+
+    if (node.type !== 'CallExpression') return
+    const callee = childNode(node, 'callee')
+    const args = childNodes(node, 'arguments')
+    if (!callee || args.length === 0) return
+
+    const calleeName = identifierName(callee)
+    if (
+      calleeName &&
+      (calleeName === '_jsx' || calleeName === '_jsxs') &&
+      importProvenance(program, calleeName) === 'react/jsx-runtime'
+    ) {
+      const componentLocal = identifierName(args[0])
+      if (!componentLocal) return
+      inspections.push({
+        form: 'jsx-runtime',
+        componentLocal,
+        componentDefinition: candidate.definitionOf(id, componentLocal),
+        propNames: objectPropertyNames(args[1]),
+      })
+      return
+    }
+
+    if (callee.type === 'MemberExpression') {
+      const objectName = identifierName(childNode(callee, 'object'))
+      const propertyName = identifierName(childNode(callee, 'property'))
+      if (
+        objectName === 'React' &&
+        propertyName === 'createElement' &&
+        importProvenance(program, objectName) === 'react'
+      ) {
+        const componentLocal = identifierName(args[0])
+        if (!componentLocal) return
+        inspections.push({
+          form: 'create-element',
+          componentLocal,
+          componentDefinition: candidate.definitionOf(id, componentLocal),
+          propNames: objectPropertyNames(args[1]),
+        })
+      }
+    }
+  })
+
+  return inspections
+}
+
+export function declarationForName(program: AstNode, name: string): AstNode | null {
+  return findAstNode(program, (node) => {
+    if (node.type !== 'VariableDeclarator') return false
+    return identifierName(childNode(node, 'id')) === name
+  })
+}
+
+export function nodeAtSpan(program: AstNode, start: number, end: number): AstNode | null {
+  return findAstNode(program, (node) => node.start === start && node.end === end)
+}
+
+export function asAstNode(value: unknown, label: string): AstNode {
+  if (!isAstNode(value)) throw new Error(`${label} is not an AST node`)
+  return value
+}

--- a/code/compiler/analyzer-spike/src/sourceMap.ts
+++ b/code/compiler/analyzer-spike/src/sourceMap.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+
+import { TraceMap, originalPositionFor } from '@jridgewell/trace-mapping'
+import MagicString from 'magic-string'
+
+import { childNode, findAstNode, identifierName } from './ast'
+import type { AnalyzerCandidate } from './contracts'
+
+function lineAndColumn(source: string, offset: number): { line: number; column: number } {
+  const prefix = source.slice(0, offset)
+  const lines = prefix.split('\n')
+  return { line: lines.length, column: lines.at(-1)?.length ?? 0 }
+}
+
+export function assertSpanEditSourceMap(candidate: AnalyzerCandidate, id: string): void {
+  const source = candidate.sourceOf(id)
+  const attribute = findAstNode(candidate.programOf(id), (node) => {
+    if (node.type !== 'JSXAttribute') return false
+    return identifierName(childNode(node, 'name')) === 'padding'
+  })
+  const attributeName = attribute && childNode(attribute, 'name')
+  const unchangedStart = source.indexOf('config.padding')
+  assert.ok(
+    attributeName,
+    `${candidate.name}: source-map fixture must contain a padding attribute`
+  )
+  assert.equal(source.slice(attributeName.start, attributeName.end), 'padding')
+  assert.notEqual(
+    unchangedStart,
+    -1,
+    'source-map fixture must contain an unchanged sentinel'
+  )
+
+  const edited = new MagicString(source)
+  edited.overwrite(attributeName.start, attributeName.end, 'paddingBlock')
+  const code = edited.toString()
+  const map = edited.generateMap({ source: id, includeContent: true, hires: true })
+  const traced = new TraceMap(map.toString())
+
+  assert.match(code, /paddingBlock=\{config\.padding\}/)
+  const generatedEdit = lineAndColumn(code, code.indexOf('paddingBlock'))
+  const originalEdit = originalPositionFor(traced, generatedEdit)
+  const expectedEdit = lineAndColumn(source, attributeName.start)
+  assert.deepEqual(
+    {
+      source: originalEdit.source,
+      line: originalEdit.line,
+      column: originalEdit.column,
+    },
+    { source: id, ...expectedEdit }
+  )
+
+  const generatedSentinel = code.indexOf('config.padding')
+  const generatedPosition = lineAndColumn(code, generatedSentinel)
+  const originalPosition = originalPositionFor(traced, generatedPosition)
+  const expectedOriginal = lineAndColumn(source, unchangedStart)
+  assert.deepEqual(
+    {
+      source: originalPosition.source,
+      line: originalPosition.line,
+      column: originalPosition.column,
+    },
+    { source: id, ...expectedOriginal }
+  )
+}

--- a/code/compiler/analyzer-spike/tsconfig.json
+++ b/code/compiler/analyzer-spike/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "importHelpers": false,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/plans/v3-evolution.md
+++ b/plans/v3-evolution.md
@@ -602,6 +602,20 @@ fails, choose `oxc-parser` plus a Tamagui-owned symbol graph. Parser adapters
 target the same ESTree/TS-ESTree interface either way. Record the result in this
 plan and delete the losing spike code.
 
+**Decision (recorded 2026-07-13): yuku.** Evidence in
+`code/compiler/analyzer-spike/evidence/results.json` (Apple M3 Max, Node 24.3,
+`yuku-analyzer@0.6.1` vs `oxc-parser@0.112.0` + owned graph, 1,000-module
+two-branch fixture). All eight binding/re-export/spread/workspace/JSX fixtures
+and the source-map check passed for both candidates, with exact invalidation
+and zero unaffected reparses. yuku through its public API only, no fork. yuku
+won cold link 2.1x (64.7ms vs 136.1ms median), warm p95 (20.6ms vs 25.4ms),
+and memory 2.5x (20.0MiB vs 50.1MiB RSS; the owned graph exceeded the 2x
+memory rule). The owned graph won warm median (1.7ms vs 9.4ms); both sit far
+inside the 50ms warm budget. yuku's one failed gate, warm p95 ≤ 25% of cold
+median (0.318), is an artifact of its faster cold denominator, and it beats
+the alternative on both absolute terms of that ratio. The `oxc-owned` spike
+adapter is deleted; the yuku graph is the E2 starting point.
+
 **Resource class:** light/medium; no full repo build.
 
 ### E2 — shared element IR and project graph


### PR DESCRIPTION
## E1 — analyzer decision spike: evidence run and verdict

Runs the checked-in E1 spike's evidence protocol and records the decision per the rule in `plans/v3-evolution.md`.

**Verdict: yuku** (`yuku-analyzer@0.6.1`, public API only, no fork).

### Evidence (`code/compiler/analyzer-spike/evidence/results.json`)
Apple M3 Max, Node v24.3.0 under Bun 1.3.14, 1,000-module two-branch fixture, fresh-process timing and memory workers.

| metric | yuku | oxc-owned |
| --- | --- | --- |
| cold link median | **64.7ms** | 136.1ms |
| cold link p95 | **153.3ms** | 288.8ms |
| warm edit median | 9.4ms | **1.7ms** |
| warm edit p95 | **20.6ms** | 25.4ms |
| RSS delta | **20.0MiB** | 50.1MiB |
| correctness (8 fixtures + maps) | pass | pass |
| exact invalidation / no unaffected reparse | pass | pass |

- Both candidates pass every absolute gate: all binding/re-export/spread/workspace/JSX fixtures, source maps, exact 500-module invalidation, zero unaffected reparses, warm p95 well under the 50ms budget.
- yuku's single failed gate (warm p95 <= 25% of cold median: 0.318) is a denominator artifact of its 2.1x faster cold link; it beats oxc-owned on both absolute terms of that ratio.
- oxc-owned exceeds the protocol's 2x memory rule at 2.5x yuku's RSS.
- Plan-level decision rule (choose yuku if fixtures correct, warm invalidation usable, no fork needed): all three hold.

### Changes
- Adds the spike source + evidence record (previously untracked on the fleet machine).
- Deletes the losing `oxc-owned` adapter and its `oxc-parser` dependency per protocol; the yuku graph is the E2 starting point.
- Records the verdict in `plans/v3-evolution.md` under E1.
- Fixes two latent type errors surfaced by the first real install (magic-string map fed to `TraceMap` as string; `importHelpers: false` for the noEmit spike so the workspace's tslib@2.1 doesn't fail private-field lowering checks).
- Post-deletion `bun run check` and a yuku-only harness rerun are green; the committed `results.json` is the two-candidate record.