### PR TITLE
T4: un-dormant A1 state vocabulary (registry generator + tests)

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -25,9 +25,8 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # the generator reads its A1 state vocabulary from @tamagui/style-grammar, so
-  # that one leaf package (no runtime deps) must be built first; everything else
-  # is a pure source read.
+  # fast, no workspace build needed — pure source reads (the generator reads the
+  # A1 state vocabulary from style-grammar's committed src/states.ts).
   generate:
     runs-on: ubuntu-latest
     steps:
@@ -38,9 +37,6 @@ jobs:
 
       - name: Install
         uses: ./.github/actions/install
-
-      - name: Build style-grammar (registry generator reads its state vocabulary)
-        run: bun --filter='@tamagui/style-grammar' run build
 
       - name: Unit tests (derivation, drift transform, item build)
         run: bun run registry:test

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -25,7 +25,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  # fast, no workspace build needed — pure source reads.
+  # the generator reads its A1 state vocabulary from @tamagui/style-grammar, so
+  # that one leaf package (no runtime deps) must be built first; everything else
+  # is a pure source read.
   generate:
     runs-on: ubuntu-latest
     steps:
@@ -36,6 +38,9 @@ jobs:
 
       - name: Install
         uses: ./.github/actions/install
+
+      - name: Build style-grammar (registry generator reads its state vocabulary)
+        run: bun --filter='@tamagui/style-grammar' run build
 
       - name: Unit tests (derivation, drift transform, item build)
         run: bun run registry:test

--- a/code/core/style-grammar/src/__tests__/states.test.ts
+++ b/code/core/style-grammar/src/__tests__/states.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest'
+import {
+  stateVocabulary,
+  stateNames,
+  stateToModifier,
+  modifierToState,
+  stateToSelector,
+  stateToPseudoProp,
+  componentStateNames,
+} from '..'
+
+// A1 state vocabulary — the join tables the registry generator and the Tailwind
+// bridge read as the single source of truth. these tests pin the joins (state ->
+// modifier / selector / pseudo-prop, and the reverse modifier -> state including
+// aliases) so a future edit to states.ts can't silently drift the contract.
+
+describe('A1 state vocabulary joins', () => {
+  test('the nine canonical states are exactly these', () => {
+    expect(stateNames).toEqual([
+      'pressed',
+      'disabled',
+      'starting',
+      'ending',
+      'open',
+      'checked',
+      'highlighted',
+      'selected',
+      'invalid',
+    ])
+  })
+
+  test('every state resolves to a Tailwind modifier', () => {
+    for (const state of stateNames) {
+      expect(stateToModifier[state], `modifier for ${state}`).toBeTruthy()
+    }
+    expect(stateToModifier.open).toBe('data-[state=open]')
+    expect(stateToModifier.selected).toBe('data-[state=active]')
+    expect(stateToModifier.invalid).toBe('aria-invalid')
+    expect(stateToModifier.pressed).toBe('press')
+  })
+
+  test('the canonical modifier round-trips back to its state', () => {
+    for (const state of stateNames) {
+      expect(modifierToState[stateToModifier[state]]).toBe(state)
+    }
+  })
+
+  test('aliases resolve to the canonical state, and bare `active` is pressed not selected', () => {
+    // reconciliation words
+    expect(modifierToState['active']).toBe('pressed')
+    expect(modifierToState['starting']).toBe('starting')
+    expect(modifierToState['ending']).toBe('ending')
+    // component-tier aliases grounded against the emitted attributes
+    expect(modifierToState['data-[state=on]']).toBe('checked')
+    expect(modifierToState['aria-checked']).toBe('checked')
+    expect(modifierToState['data-[invalid]']).toBe('invalid')
+    // the `selected` collision guard: item selection is data-[state=active],
+    // but the bare word `active` must stay an alias of pressed (`:active`).
+    expect(modifierToState['active']).not.toBe('selected')
+  })
+
+  test('component-tier states carry a web selector; pseudo-tier states carry a pseudo-prop', () => {
+    const componentEntries = stateVocabulary.filter((e) => e.tier === 'component')
+    const pseudoEntries = stateVocabulary.filter((e) => e.tier === 'pseudo')
+
+    expect(componentStateNames).toEqual(componentEntries.map((e) => e.state))
+
+    for (const e of componentEntries) {
+      expect(stateToSelector[e.state], `selector for ${e.state}`).toBeTruthy()
+      expect(stateToPseudoProp[e.state]).toBeUndefined()
+    }
+    for (const e of pseudoEntries) {
+      expect(stateToPseudoProp[e.state], `pseudo-prop for ${e.state}`).toBeTruthy()
+      expect(stateToSelector[e.state]).toBeUndefined()
+    }
+  })
+
+  test('component selectors match the attributes the behavior packages emit', () => {
+    // grounded against the runtime emitters (dialog/popover/... -> data-state=open,
+    // tabs/select item -> data-state=active, checkbox/switch -> data-state=checked,
+    // menu -> data-highlighted, field -> aria-invalid).
+    expect(stateToSelector.open).toBe('[data-state="open"]')
+    expect(stateToSelector.checked).toBe('[data-state="checked"]')
+    expect(stateToSelector.highlighted).toBe('[data-highlighted]')
+    expect(stateToSelector.selected).toBe('[data-state="active"]')
+    expect(stateToSelector.invalid).toBe('[aria-invalid="true"]')
+  })
+
+  test('pseudo-tier props are the core pseudo-style props', () => {
+    expect(stateToPseudoProp.pressed).toBe('pressStyle')
+    expect(stateToPseudoProp.disabled).toBe('disabledStyle')
+    expect(stateToPseudoProp.starting).toBe('enterStyle')
+    expect(stateToPseudoProp.ending).toBe('exitStyle')
+  })
+})

--- a/code/kitchen-sink/tests/ButtonSkin.test.tsx
+++ b/code/kitchen-sink/tests/ButtonSkin.test.tsx
@@ -25,6 +25,11 @@ test('disables press and focus behavior', async ({ page }) => {
   await expect(button).toBeDisabled()
   await expect(button).toHaveAttribute('aria-disabled', 'true')
   await expect(button).toHaveAttribute('tabindex', '-1')
+  // A1 canonical `disabled` state (registry meta.states=['disabled','pressed']
+  // for button) styles the copied skin: the `variants: { disabled: { true } }`
+  // block dims the frame. proves the state modifier resolves to real styling,
+  // not just the behavior's aria/tabindex.
+  await expect(button).toHaveCSS('opacity', '0.35')
 
   await button.evaluate((element) => {
     ;(element as HTMLElement).click()

--- a/code/kitchen-sink/tests/SheetSkin.test.tsx
+++ b/code/kitchen-sink/tests/SheetSkin.test.tsx
@@ -58,7 +58,9 @@ test('preserves close behavior through the copied parts', async ({ page }) => {
 // attribute selector — the exact form a shadcn/Tailwind consumer's
 // `data-[state=open]:` class uses — proves the state resolves through one
 // data-state vocabulary, not a per-component spelling.
-test('the copied skin resolves the canonical open-state web selector', async ({ page }) => {
+test('the copied skin resolves the canonical open-state web selector', async ({
+  page,
+}) => {
   const openContainer = `[data-testid="sheet-skin-container"][data-state="open"]`
 
   await page.getByTestId('sheet-skin-open').click()

--- a/code/kitchen-sink/tests/SheetSkin.test.tsx
+++ b/code/kitchen-sink/tests/SheetSkin.test.tsx
@@ -50,3 +50,20 @@ test('preserves close behavior through the copied parts', async ({ page }) => {
   await expect(container).toHaveAttribute('data-state', 'closed')
   await expect(page.getByTestId('sheet-skin-overlay')).toHaveCount(0)
 })
+
+// A1 component-state, end to end on web: the copied Sheet skin, driven only by
+// the public behavior, emits the canonical `open` web attribute the vocabulary
+// maps that state to (stateToSelector.open === '[data-state="open"]', and the
+// registry's meta.states=['open'] for sheet). resolving the container BY that
+// attribute selector — the exact form a shadcn/Tailwind consumer's
+// `data-[state=open]:` class uses — proves the state resolves through one
+// data-state vocabulary, not a per-component spelling.
+test('the copied skin resolves the canonical open-state web selector', async ({ page }) => {
+  const openContainer = `[data-testid="sheet-skin-container"][data-state="open"]`
+
+  await page.getByTestId('sheet-skin-open').click()
+  await expect(page.locator(openContainer)).toBeVisible()
+
+  await page.getByTestId('sheet-skin-close').click()
+  await expect(page.locator(openContainer)).toHaveCount(0)
+})

--- a/scripts/lib/registry/emit.ts
+++ b/scripts/lib/registry/emit.ts
@@ -12,7 +12,15 @@ import { discoverSkins, loadSkin, buildItem, renderConsumerCopy, type Skin } fro
 import { validateRegistry } from './validate'
 import type { StateTables } from './states-derive'
 import type { Registry, RegistryItem } from './types'
-import { stateToPseudoProp, stateNames, stateToSelector } from '@tamagui/style-grammar'
+// import the A1 vocabulary from style-grammar's committed source, not the built
+// package: the registry `generate` CI job does pure source reads (no workspace
+// build), and the generator already reads skin SOURCE across packages. states.ts
+// is pure data with no imports.
+import {
+  stateToPseudoProp,
+  stateNames,
+  stateToSelector,
+} from '../../../code/core/style-grammar/src/states'
 
 const JSON_INDENT = 2
 

--- a/scripts/lib/registry/registry.test.ts
+++ b/scripts/lib/registry/registry.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from 'bun:test'
+// the real A1 vocabulary from style-grammar's committed source (see emit.ts) —
+// pure source read so the registry CI job needs no workspace build.
 import {
   stateToPseudoProp,
   stateNames,
   stateToSelector,
   stateToModifier,
-} from '@tamagui/style-grammar'
+} from '../../../code/core/style-grammar/src/states'
 import { extractImportSpecifiers, classifyDependencies, packageNameOf } from './deps'
 import { reprefixNames, buildItem, loadSkin, type Skin } from './core'
 import { buildRegistry } from './emit'

--- a/scripts/lib/registry/registry.test.ts
+++ b/scripts/lib/registry/registry.test.ts
@@ -265,9 +265,7 @@ describe('A1 reassembly join (real style-grammar tables + real skins)', () => {
 
   test('buildRegistry emits uniform canonical meta.states across the real skins', async () => {
     const { registry } = await buildRegistry()
-    const states = Object.fromEntries(
-      registry.items.map((i) => [i.name, i.meta?.states])
-    )
+    const states = Object.fromEntries(registry.items.map((i) => [i.name, i.meta?.states]))
     // source-scanned + extraStates-merged, all canonical A1 names
     expect(states.button).toEqual(['disabled', 'pressed'])
     expect(states.sheet).toEqual(['open'])

--- a/scripts/lib/registry/registry.test.ts
+++ b/scripts/lib/registry/registry.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test'
+import {
+  stateToPseudoProp,
+  stateNames,
+  stateToSelector,
+  stateToModifier,
+} from '@tamagui/style-grammar'
 import { extractImportSpecifiers, classifyDependencies, packageNameOf } from './deps'
-import { reprefixNames, buildItem, type Skin } from './core'
+import { reprefixNames, buildItem, loadSkin, type Skin } from './core'
+import { buildRegistry } from './emit'
 import { deriveStates, type StateTables } from './states-derive'
 
 describe('extractImportSpecifiers', () => {
@@ -220,5 +227,58 @@ describe('deriveStates', () => {
   test('does not match a state word inside a comment or string', () => {
     const src = `// open the sheet\nconst label = 'checked out'\nstyled(F, {})`
     expect(deriveStates(src, TABLES)).toEqual([])
+  })
+})
+
+// the reassembly join: the generator now feeds the REAL @tamagui/style-grammar
+// vocabulary (not the fixture above) into deriveStates + buildItem, so these
+// tests run against the real tables and the real skin sources. they prove the
+// A1 wiring is live end to end — table shapes match what deriveStates expects,
+// derivation matches the three authoring tiers on the real skins, and every
+// emitted state joins back to a Tailwind modifier.
+const REAL_TABLES: StateTables = {
+  pseudoProps: stateToPseudoProp,
+  allStates: stateNames,
+  selectors: stateToSelector,
+}
+
+describe('A1 reassembly join (real style-grammar tables + real skins)', () => {
+  test('the injected table shapes match what deriveStates consumes', () => {
+    // guards the exact failure the reassembly could reintroduce: a states.ts
+    // export renamed/reshaped so the generator silently derives nothing.
+    expect(Object.values(stateToPseudoProp)).toContain('pressStyle')
+    expect(stateNames).toContain('open')
+    expect(stateToSelector.selected).toBe('[data-state="active"]')
+  })
+
+  test('source-scanned tiers derive from the real Button + Sheet skin source', async () => {
+    const button = await loadSkin('Button')
+    // tier 1 pseudo-prop (pressStyle) + tier 2 canonical variant (disabled)
+    expect(deriveStates(button.source, REAL_TABLES)).toEqual(['disabled', 'pressed'])
+
+    const sheet = await loadSkin('Sheet')
+    // tier 2 canonical `open` variant — the blessed component-tier form
+    expect(deriveStates(sheet.source, REAL_TABLES)).toEqual(['open'])
+  })
+
+  test('buildRegistry emits uniform canonical meta.states across the real skins', async () => {
+    const { registry } = await buildRegistry()
+    const states = Object.fromEntries(
+      registry.items.map((i) => [i.name, i.meta?.states])
+    )
+    // source-scanned + extraStates-merged, all canonical A1 names
+    expect(states.button).toEqual(['disabled', 'pressed'])
+    expect(states.sheet).toEqual(['open'])
+    // extraStates escape hatch: on-state via activeStyle -> checked
+    expect(states.togglegroup).toEqual(['checked', 'pressed'])
+    // extraStates: v2-compat `active` selection prop -> selected
+    expect(states.listitem).toEqual(['disabled', 'pressed', 'selected'])
+
+    // the join: every state any item emits resolves to a Tailwind modifier.
+    for (const item of registry.items) {
+      for (const state of item.meta?.states ?? []) {
+        expect(stateToModifier[state], `${item.name} state ${state}`).toBeTruthy()
+      }
+    }
   })
 })


### PR DESCRIPTION
T4 of the v3 beta campaign — un-dormant the A1 state vocabulary.

## What landed already (reassembly merge 61ab5e4b84)
The registry generator wiring was merged: \`emit.ts\` feeds the real \`@tamagui/style-grammar\` state tables into \`buildItem\`, so every registry item emits uniform \`meta.states\` (canonical A1 names). The 10 skins already derive correctly.

## The bug this fixes
The Registry CI \`generate\` job is \"pure source reads, no workspace build\" — but the generator now imports \`@tamagui/style-grammar\`, whose exports map resolves to \`dist/\`. Without a build the job fails with \`Cannot find module '@tamagui/style-grammar'\`. This builds that one leaf package (no runtime deps) before the registry steps.

## Tests
- \`style-grammar/src/__tests__/states.test.ts\` — pins the A1 vocabulary joins (state→modifier/selector/pseudo-prop and the reverse incl. aliases; the \`active\`→pressed-not-selected guard). states.ts had no coverage.
- \`registry.test.ts\` — integration tests using the **real** style-grammar tables + real skin sources: proves the reassembly join is live (table shapes match, three authoring tiers derive on Button/Sheet, buildRegistry emits canonical meta.states incl. extraStates for ToggleGroup→checked and ListItem→selected, every emitted state joins back to a modifier).
- kitchen-sink browser tests: copied Sheet skin resolves the canonical \`[data-state="open"]\` web selector end to end; copied Button skin's canonical \`disabled\` state styles the frame (opacity 0.35).

## Runtime / drift sweep finding
The behavior-package emitters already conform to the vocabulary (states.ts was \"grounded against the source\"): open/closed→\`open\`, active/inactive→\`selected\`, on/off→\`checked\`, checked/unchecked→\`checked\`. No emitter contradicts the vocabulary, so no format changes / no tests to update. One separate finding surfaced (not in scope here): the Sheet skin's \`variants: { open }\` on the Handle is authored but not runtime-driven (the behavior forwards \`open\` to its inner frame, not the outer styled wrapper) — flagged to the coordinator.

## Validation
monorepo typecheck ✓, style-grammar tests (44) ✓, registry:test (20) ✓, registry check/validate/drift ✓, kitchen-sink SheetSkin+ButtonSkin (9) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)