### PR TITLE
fix(text): join adjacent text children into one Text, and wrap numbers

### DIFF
--- a/code/ui/text-test/wrapChildrenInText.test.tsx
+++ b/code/ui/text-test/wrapChildrenInText.test.tsx
@@ -7,20 +7,23 @@ const Comp = () => {}
 const re = <div data-id={Math.random()} />
 const reID = re.props['data-id']
 
-test('should wrap all string children', () => {
+test('should wrap string children, joining adjacent ones', () => {
   const out = wrapChildrenInText(Comp, {
     children: [re, 'a', 'b', re, 'c', re, 'd'],
   }) as any
 
+  // 'a' and 'b' are adjacent, so they share a single Text
+  expect(out).toHaveLength(6)
+
   expect(out[0].props['data-id']).toBe(reID)
 
   expect(out[1].type).toBe(Comp)
-  expect(out[1].props.children).toStrictEqual('a')
-  expect(out[2].props.children).toStrictEqual('b')
-  expect(out[3].props['data-id']).toBe(reID)
-  expect(out[4].props.children).toStrictEqual('c')
-  expect(out[5].props['data-id']).toBe(reID)
-  expect(out[6].props.children).toStrictEqual('d')
+  expect(out[1].props.children).toStrictEqual('ab')
+
+  expect(out[2].props['data-id']).toBe(reID)
+  expect(out[3].props.children).toStrictEqual('c')
+  expect(out[4].props['data-id']).toBe(reID)
+  expect(out[5].props.children).toStrictEqual('d')
 })
 
 test('should first child string', () => {
@@ -31,5 +34,46 @@ test('should first child string', () => {
   expect(out[0].type).toBe(Comp)
   expect(out[0].props.children).toStrictEqual('a')
 
+  expect(out[1].props['data-id']).toBe(reID)
+})
+
+// `<Button>increment {name}</Button>` is children ['increment ', name]. Wrapping each
+// separately renders sibling text nodes with a visible gap, and breaks ellipsis,
+// wrapping and accessible-label matching across the whole string.
+test('should join an interpolated string into one text node', () => {
+  const out = wrapChildrenInText(Comp, {
+    children: ['increment ', 'slot'],
+  }) as any
+
+  expect(out).toHaveLength(1)
+  expect(out[0].type).toBe(Comp)
+  expect(out[0].props.children).toStrictEqual('increment slot')
+})
+
+// numbers are text too — left unwrapped they throw
+// "Text strings must be rendered within a <Text> component" on native
+test('should wrap numeric children and join them with adjacent strings', () => {
+  const out = wrapChildrenInText(Comp, {
+    children: ['Count: ', 5],
+  }) as any
+
+  expect(out).toHaveLength(1)
+  expect(out[0].type).toBe(Comp)
+  expect(out[0].props.children).toStrictEqual('Count: 5')
+})
+
+test('should wrap a lone numeric child', () => {
+  const out = wrapChildrenInText(Comp, { children: 5 }) as any
+
+  expect(out).toHaveLength(1)
+  expect(out[0].type).toBe(Comp)
+  expect(out[0].props.children).toStrictEqual(5)
+})
+
+test('should keep non-text children untouched and unjoined', () => {
+  const out = wrapChildrenInText(Comp, { children: [re, re] }) as any
+
+  expect(out).toHaveLength(2)
+  expect(out[0].props['data-id']).toBe(reID)
   expect(out[1].props['data-id']).toBe(reID)
 })

--- a/code/ui/text/src/wrapChildrenInText.tsx
+++ b/code/ui/text/src/wrapChildrenInText.tsx
@@ -49,14 +49,37 @@ export function wrapChildrenInText(
   if (ellipsis !== undefined) props.ellipsis = ellipsis
   if (maxFontSizeMultiplier != null) props.maxFontSizeMultiplier = maxFontSizeMultiplier
 
-  return React.Children.toArray(children).map((child, index) => {
-    return typeof child === 'string' ? (
+  // adjacent text children are joined into ONE TextComponent. `<Button>hi {name}</Button>`
+  // is two children ('hi ', name), and wrapping each separately renders them as sibling
+  // text nodes: they lay out with a gap, ellipsis/wrapping applies per fragment instead of
+  // to the whole string, and assistive tech (plus native test matchers) sees fragments
+  // rather than one label. Numbers count as text too — leaving them unwrapped throws
+  // "Text strings must be rendered within a <Text>" on native.
+  const out: React.ReactNode[] = []
+  let run: (string | number)[] = []
+  let runKey = 0
+
+  const flushRun = () => {
+    if (!run.length) return
+    out.push(
       // data-disable-theme keeps wrapped text from adding another theme boundary
-      <TextComponent key={index} {...props} {...textProps}>
-        {child}
+      <TextComponent key={`text-${runKey}`} {...props} {...textProps}>
+        {run.length === 1 ? run[0] : run.join('')}
       </TextComponent>
-    ) : (
-      child
     )
+    run = []
+  }
+
+  React.Children.toArray(children).forEach((child, index) => {
+    if (typeof child === 'string' || typeof child === 'number') {
+      if (!run.length) runKey = index
+      run.push(child)
+      return
+    }
+    flushRun()
+    out.push(child)
   })
+  flushRun()
+
+  return out
 }


### PR DESCRIPTION
`wrapChildrenInText` wrapped **each** string child in its own `Text` and ignored numbers entirely. Both are visible to users.

## What was wrong

Verified at runtime against the current implementation:

```
['increment ', 'slot']  ->  2 separate <Text> elements
['Count: ', 5]          ->  <Text>"Count: "</Text> + a RAW, unwrapped 5
```

**Adjacent strings weren't joined.** `<Button>increment {name}</Button>` is JSX for children `['increment ', name]`, so it rendered as sibling text nodes. That lays out with a visible gap, applies `ellipsis`/wrapping per fragment instead of across the whole string, and shows assistive tech (and native test matchers) fragments rather than one label. It was found via a Detox screenshot showing a button rendering as "increment&nbsp;&nbsp;&nbsp;slot".

**Numbers weren't wrapped at all.** The check was `typeof child === 'string'`, so `<Button>Count: {5}</Button>` leaks a bare number into the frame — on native that throws *"Text strings must be rendered within a `<Text>` component"*.

iOS hid the first one by merging fragments into a single accessibility element; Android's stricter matcher exposed it.

## Change

Group **adjacent** string and numeric children into a single `Text`. Non-text children are untouched and never joined across.

## Tests

`code/ui/text-test/wrapChildrenInText.test.tsx` previously asserted the buggy behaviour (`['a','b']` -> two elements); it now asserts joining, plus new cases for the interpolation, a number adjacent to a string, a lone number, and non-text children.

## Validation

Run locally on this branch:

- `wrapChildrenInText` — 6/6 pass
- compiler `static-tests` — 98 passed, 1 skipped
- compiler `webpack.test.tsx` — 18 passed
- `next-webpack` exports snapshots (cold cache) — 8/8 pass

**No snapshot changes were needed**, which is the useful signal here: the compiled output of real Button-containing screens is unaffected, so this corrects rendering without churning extracted styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)