### PR TITLE
fix(animations): reliable accordion + reanimated color/layout handling

### DIFF
--- a/.github/workflows/test-native.yml
+++ b/.github/workflows/test-native.yml
@@ -72,7 +72,7 @@ jobs:
           # check-ios-detox-shards.mjs, still runs in the android job). Coverage
           # validated by that script (every e2e test assigned exactly once).
           - shard_name: '1/4'
-            test_files: 'e2e/CompilerExtraction.test.ts e2e/SafeArea.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetFitKeyboardSafeArea.test.ts e2e/SheetPressResponderSheetRngh.test.ts'
+            test_files: 'e2e/Accordion.test.ts e2e/CompilerExtraction.test.ts e2e/SafeArea.test.ts e2e/SheetKeyboardDrag.test.ts e2e/SheetFitKeyboardSafeArea.test.ts e2e/SheetPressResponderSheetRngh.test.ts'
           - shard_name: '2/4'
             test_files: 'e2e/PressStyleNative.noRngh.test.ts e2e/CompilerTernaryActive.test.ts e2e/TabsOnInteraction.test.ts e2e/PointerEvents.test.ts e2e/GroupPressNative.test.ts e2e/ShorthandVariables.test.ts e2e/check-rngh-status.test.ts'
           - shard_name: '3/4'

--- a/bun.lock
+++ b/bun.lock
@@ -3464,6 +3464,7 @@
     "uuid": "11.1.1",
     "vite": "8.0.16",
     "vitest": "4.1.0",
+    "websocket-driver": "0.7.5",
     "whatwg-url": "14.1.1",
     "ws": "8.21.0",
     "yaml": "2.8.3",
@@ -8725,7 +8726,7 @@
 
     "webpack-sources": ["webpack-sources@3.3.4", "", {}, "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q=="],
 
-    "websocket-driver": ["websocket-driver@0.7.4", "", { "dependencies": { "http-parser-js": ">=0.5.1", "safe-buffer": ">=5.1.0", "websocket-extensions": ">=0.1.1" } }, "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg=="],
+    "websocket-driver": ["websocket-driver@0.7.5", "", { "dependencies": { "http-parser-js": ">=0.5.1", "safe-buffer": ">=5.1.0", "websocket-extensions": ">=0.1.1" } }, "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA=="],
 
     "websocket-extensions": ["websocket-extensions@0.1.4", "", {}, "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="],
 

--- a/code/core/animations-react-native/src/createAnimations.tsx
+++ b/code/core/animations-react-native/src/createAnimations.tsx
@@ -340,6 +340,13 @@ export function createAnimations<A extends AnimationsConfig>(
             continue
           }
 
+          // layout dimension keys only animate numbers — 'auto' (an open
+          // accordion at rest) and percent strings apply as static styles
+          if (layoutStyleKey[key] && typeof val !== 'number') {
+            nonAnimatedStyle[key] = val
+            continue
+          }
+
           // unparseable themed colors (var(), calc(), empty) crash RN
           // interpolation — apply them as a static style instead
           if (colorStyleKey[key] && !isAnimatableColor(val)) {
@@ -582,8 +589,10 @@ export function createAnimations<A extends AnimationsConfig>(
             costlyToAnimateStyleKey[key] ||
             layoutStyleKey[key]
           ) {
-            // unparseable themed colors can't be interpolated — skip here and
+            // layout keys only animate numbers ('auto'/percents are static);
+            // unparseable themed colors can't be interpolated — skip both and
             // let the next render apply them statically
+            if (layoutStyleKey[key] && typeof val !== 'number') continue
             if (colorStyleKey[key] && !isAnimatableColor(val)) continue
             animateStyles.current[key] = update(key, animateStyles.current[key], val)
           }

--- a/code/core/animations-react-native/src/createAnimations.tsx
+++ b/code/core/animations-react-native/src/createAnimations.tsx
@@ -63,6 +63,29 @@ const colorStyleKey = {
   borderBottomColor: true,
 }
 
+// layout dimension keys. these must run on the JS driver (useNativeDriver:false)
+// because the native animated module can't drive layout props.
+const layoutStyleKey = {
+  height: true,
+  width: true,
+  minHeight: true,
+  maxHeight: true,
+  minWidth: true,
+  maxWidth: true,
+}
+
+// a color string that RN's color interpolation can actually parse. var(...),
+// calc(...) and empty strings reach createInterpolationFromStringOutputRange /
+// mapStringToNumericComponents and throw ('.map of null' / 'outputRange must
+// contain color or value with numeric component'). those must be applied as a
+// static style instead of entering interpolation.
+function isAnimatableColor(value: unknown): value is string {
+  if (typeof value !== 'string') return false
+  if (value === '') return false
+  if (value.includes('var(') || value.includes('calc(')) return false
+  return true
+}
+
 // these style keys are costly to animate and only work with native driver on Fabric
 const costlyToAnimateStyleKey = {
   borderRadius: true,
@@ -295,12 +318,23 @@ export function createAnimations<A extends AnimationsConfig>(
             continue
           }
 
-          if (animatedStyleKey[key] == null && !costlyToAnimateStyleKey[key]) {
+          if (
+            animatedStyleKey[key] == null &&
+            !costlyToAnimateStyleKey[key] &&
+            !layoutStyleKey[key]
+          ) {
             nonAnimatedStyle[key] = val
             continue
           }
 
           if (hasTransitionOnly && !animateOnly.includes(key)) {
+            nonAnimatedStyle[key] = val
+            continue
+          }
+
+          // unparseable themed colors (var(), calc(), empty) crash RN
+          // interpolation — apply them as a static style instead
+          if (colorStyleKey[key] && !isAnimatableColor(val)) {
             nonAnimatedStyle[key] = val
             continue
           }
@@ -416,7 +450,8 @@ export function createAnimations<A extends AnimationsConfig>(
               function getAnimation() {
                 return Animated[animationConfig.type || 'spring'](value, {
                   toValue: animateToValue,
-                  useNativeDriver: nativeDriver,
+                  // layout dimension keys can't run on the native driver
+                  useNativeDriver: nativeDriver && !layoutStyleKey[key],
                   ...animationConfig,
                 })
               }
@@ -515,7 +550,14 @@ export function createAnimations<A extends AnimationsConfig>(
                 [tkey]: update(tkey, currentTransform, transform[tkey]),
               }
             }
-          } else if (animatedStyleKey[key] != null || costlyToAnimateStyleKey[key]) {
+          } else if (
+            animatedStyleKey[key] != null ||
+            costlyToAnimateStyleKey[key] ||
+            layoutStyleKey[key]
+          ) {
+            // unparseable themed colors can't be interpolated — skip here and
+            // let the next render apply them statically
+            if (colorStyleKey[key] && !isAnimatableColor(val)) continue
             animateStyles.current[key] = update(key, animateStyles.current[key], val)
           }
         }
@@ -572,7 +614,8 @@ export function createAnimations<A extends AnimationsConfig>(
             value.stopAnimation()
             const anim = Animated[animationConfig.type || 'spring'](value, {
               toValue: animateToValue,
-              useNativeDriver: nativeDriver,
+              // layout dimension keys can't run on the native driver
+              useNativeDriver: nativeDriver && !layoutStyleKey[key],
               ...animationConfig,
             })
             ;(animationConfig.delay

--- a/code/core/animations-react-native/src/createAnimations.tsx
+++ b/code/core/animations-react-native/src/createAnimations.tsx
@@ -308,6 +308,14 @@ export function createAnimations<A extends AnimationsConfig>(
 
         const nonAnimatedStyle = {}
 
+        // track which animated keys/transforms the incoming style actually
+        // carries this pass, so entries that left the style can be dropped
+        // below (an Animated.Value that persisted forever would keep painting
+        // a stale pixel value, e.g. a released-to-auto accordion height)
+        const seenAnimateKeys = new Set<string>()
+        let sawTransform = false
+        let transformCount = 0
+
         for (const key in style) {
           const rawVal = style[key]
           // Resolve dynamic theme values (like $theme-dark)
@@ -341,6 +349,7 @@ export function createAnimations<A extends AnimationsConfig>(
 
           if (key !== 'transform') {
             animateStyles.current[key] = update(key, animateStyles.current[key], val)
+            seenAnimateKeys.add(key)
             continue
           }
           // key: 'transform'
@@ -351,6 +360,8 @@ export function createAnimations<A extends AnimationsConfig>(
             continue
           }
 
+          sawTransform = true
+          transformCount = val.length
           for (const [index, transform] of val.entries()) {
             if (!transform) continue
             // tkey: e.g: 'translateX'
@@ -360,6 +371,22 @@ export function createAnimations<A extends AnimationsConfig>(
               [tkey]: update(tkey, currentTransform, transform[tkey]),
             }
             animatedTranforms.current = [...animatedTranforms.current]
+          }
+        }
+
+        // drop stale Animated.Values whose keys left the incoming style, so the
+        // key genuinely leaves the rendered style object (a released height goes
+        // back to auto instead of staying pinned at its last pixel value). skip
+        // while exiting (presence still animates the leaving keys) and while
+        // disabled (the loop above intentionally skips every key)
+        if (!isExiting && !isDisabled) {
+          for (const k in animateStyles.current) {
+            if (!seenAnimateKeys.has(k)) delete animateStyles.current[k]
+          }
+          if (!sawTransform) {
+            if (animatedTranforms.current.length) animatedTranforms.current = []
+          } else if (animatedTranforms.current.length > transformCount) {
+            animatedTranforms.current = animatedTranforms.current.slice(0, transformCount)
           }
         }
 

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -73,6 +73,16 @@ const silenceAnimatedComponentDevCheck = (style: unknown) => {
 
 type ReanimatedAnimatedNumber = SharedValue<number>
 
+type AnimationSnapshot = {
+  animated: Record<string, unknown>
+  statics: Record<string, unknown>
+  transforms: Array<Record<string, unknown>>
+  newKeys: Record<string, boolean>
+  removedKeys: Record<string, boolean>
+  removeTransform: boolean
+  clearValue: '' | null
+}
+
 /** Spring animation configuration */
 type SpringConfig = {
   type?: 'spring'
@@ -130,8 +140,67 @@ const cloneAnimationValue = (value: unknown): unknown => {
   return value
 }
 
+const cloneStyleRecord = (
+  style: Record<string, unknown>
+): Record<string, unknown> => {
+  const next: Record<string, unknown> = {}
+  for (const key in style) {
+    next[key] = cloneAnimationValue(style[key])
+  }
+  return next
+}
+
+const cloneTransforms = (
+  transforms: Array<Record<string, unknown>>
+): Array<Record<string, unknown>> => transforms.map(cloneStyleRecord)
+
 const cloneTransitionConfig = (config: TransitionConfig): TransitionConfig => {
   return cloneAnimationValue(config) as TransitionConfig
+}
+
+const getAnimatedTransforms = (value: unknown): Array<Record<string, unknown>> => {
+  if (!Array.isArray(value)) return []
+  return value.filter(
+    (item): item is Record<string, unknown> =>
+      item !== null && typeof item === 'object' && !Array.isArray(item)
+  )
+}
+
+const getAnimatedKeySet = (
+  animated: Record<string, unknown>,
+  transforms: Array<Record<string, unknown>>
+): Set<string> => {
+  const keys = new Set<string>()
+  for (const key in animated) {
+    if (key !== 'transform') keys.add(key)
+  }
+  for (const transform of transforms) {
+    const key = Object.keys(transform)[0]
+    if (key) keys.add(`transform:${key}`)
+  }
+  return keys
+}
+
+const getNewAnimatedKeys = (
+  current: Set<string>,
+  previous: Set<string>
+): Record<string, boolean> => {
+  const newKeys: Record<string, boolean> = {}
+  for (const key of current) {
+    if (!previous.has(key)) newKeys[key] = true
+  }
+  return newKeys
+}
+
+const getRemovedAnimatedKeys = (
+  current: Set<string>,
+  previous: Set<string>
+): Record<string, boolean> => {
+  const removedKeys: Record<string, boolean> = {}
+  for (const key of previous) {
+    if (!current.has(key)) removedKeys[key] = true
+  }
+  return removedKeys
 }
 
 const createReanimatedConfig = (config: TransitionConfig): Record<string, unknown> => {
@@ -692,12 +761,6 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
       // =========================================================================
       // avoidRerenders: SharedValues for style updates without re-renders
       // =========================================================================
-      const animatedTargetsRef = useSharedValue<Record<string, unknown> | null>(null)
-      const staticTargetsRef = useSharedValue<Record<string, unknown> | null>(null)
-      const transformTargetsRef = useSharedValue<Array<Record<string, unknown>> | null>(
-        null
-      )
-
       // Separate styles into animated and static
       const { animatedStyles, staticStyles } = useMemo(() => {
         const animated: Record<string, unknown> = {}
@@ -725,18 +788,84 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         // During mount, include animated values in static to prevent flicker
         if (isMounting) {
           for (const key in animated) {
-            staticStyles[key] = animated[key]
+            staticStyles[key] = cloneAnimationValue(animated[key])
           }
         }
 
         return { animatedStyles: animated, staticStyles }
       }, [disableAnimation, style, isDark, isMounting, props.animateOnly])
 
+      const committedRenderKeysRef = useRef(new Set<string>())
+      const committedRenderBaselineRef = useRef<Record<string, unknown>>({})
+      const renderSnapshot = useMemo(() => {
+        const transforms = getAnimatedTransforms(animatedStyles.transform)
+        const regularAnimated: Record<string, unknown> = {}
+        for (const key in animatedStyles) {
+          if (key !== 'transform') regularAnimated[key] = animatedStyles[key]
+        }
+        const keys = getAnimatedKeySet(animatedStyles, transforms)
+        const newKeys = getNewAnimatedKeys(keys, committedRenderKeysRef.current)
+        const removedKeys = getRemovedAnimatedKeys(keys, committedRenderKeysRef.current)
+        // keep each key's first React value as a baseline for its active lifetime.
+        // the stable mapper paints over it after seeding, while pre-mapper rerenders
+        // cannot create an ownerless frame. transforms share one top-level baseline.
+        const baseline: Record<string, unknown> = {}
+        for (const key in animatedStyles) {
+          if (key === 'transform') continue
+          baseline[key] = Object.prototype.hasOwnProperty.call(
+            committedRenderBaselineRef.current,
+            key
+          )
+            ? committedRenderBaselineRef.current[key]
+            : animatedStyles[key]
+        }
+        if (transforms.length > 0) {
+          baseline.transform = Object.prototype.hasOwnProperty.call(
+            committedRenderBaselineRef.current,
+            'transform'
+          )
+            ? committedRenderBaselineRef.current.transform
+            : transforms
+        }
+        return {
+          value: {
+            animated: cloneStyleRecord(regularAnimated),
+            statics: cloneStyleRecord(staticStyles),
+            transforms: cloneTransforms(transforms),
+            newKeys: { ...newKeys },
+            removedKeys: { ...removedKeys },
+            removeTransform: Object.keys(removedKeys).some((key) =>
+              key.startsWith('transform:')
+            ),
+            clearValue: isWeb ? '' : null,
+          } satisfies AnimationSnapshot,
+          reactStatics: { ...staticStyles, ...baseline },
+          baseline,
+          keys,
+        }
+      }, [animatedStyles, staticStyles])
+      const renderSnapshotRef = useSharedValue<AnimationSnapshot>({
+        animated: {},
+        statics: {},
+        transforms: [],
+        newKeys: {},
+        removedKeys: {},
+        removeTransform: false,
+        clearValue: isWeb ? '' : null,
+      })
+      const emitterSnapshotRef = useSharedValue<AnimationSnapshot | null>(null)
+      const emitterKeysRef = useRef<Set<string> | null>(null)
+
+      useIsomorphicLayoutEffect(() => {
+        committedRenderKeysRef.current = renderSnapshot.keys
+        committedRenderBaselineRef.current = renderSnapshot.baseline
+      }, [renderSnapshot])
+
       // reconcile the emitter latch with real re-renders.
       //
       // the avoidReRenders fast path lets a pure pseudo change (hover/press/focus) push
       // styles straight to the worklet via useStyleEmitter with no React commit — it sets
-      // animatedTargetsRef. the worklet then treats `animatedTargetsRef !== null` as a
+      // emitterSnapshotRef. the worklet then treats `emitterSnapshotRef !== null` as a
       // permanent latch: once the emitter has fired even once, it reads its last-emitted
       // snapshot and IGNORES `animatedStyles` from every subsequent re-render. so a base
       // style that changes through React (e.g. a row's `backgroundColor` flipping with an
@@ -766,11 +895,25 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
       useIsomorphicLayoutEffect(() => {
         if (
           (isExiting || !pseudoActiveRef.current) &&
-          animatedTargetsRef.value !== null
+          emitterSnapshotRef.value !== null
         ) {
-          animatedTargetsRef.value = null
-          staticTargetsRef.value = null
-          transformTargetsRef.value = null
+          const emitterKeys = emitterKeysRef.current
+          if (emitterKeys) {
+            const removedKeys = {
+              ...renderSnapshot.value.removedKeys,
+              ...getRemovedAnimatedKeys(renderSnapshot.keys, emitterKeys),
+            }
+            renderSnapshotRef.value = {
+              ...renderSnapshot.value,
+              removedKeys,
+              removeTransform: Object.keys(removedKeys).some((key) =>
+                key.startsWith('transform:')
+              ),
+              clearValue: isWeb ? '' : null,
+            }
+          }
+          emitterSnapshotRef.value = null
+          emitterKeysRef.current = null
         }
       })
 
@@ -882,10 +1025,21 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
             }
           }
 
-          // update shared values - on web, the mapper watches these if passed in dependencies
-          animatedTargetsRef.value = animated
-          staticTargetsRef.value = statics
-          transformTargetsRef.value = transforms
+          const keys = getAnimatedKeySet(animated, transforms)
+          const previousKeys = emitterKeysRef.current ?? committedRenderKeysRef.current
+          const removedKeys = getRemovedAnimatedKeys(keys, previousKeys)
+          emitterSnapshotRef.value = {
+            animated: cloneStyleRecord(animated),
+            statics: cloneStyleRecord(statics),
+            transforms: cloneTransforms(transforms),
+            newKeys: { ...getNewAnimatedKeys(keys, previousKeys) },
+            removedKeys: { ...removedKeys },
+            removeTransform: Object.keys(removedKeys).some((key) =>
+              key.startsWith('transform:')
+            ),
+            clearValue: isWeb ? '' : null,
+          }
+          emitterKeysRef.current = keys
 
           if (
             process.env.NODE_ENV === 'development' &&
@@ -911,7 +1065,10 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         // regular animated properties
         for (const key in animatedStyles) {
           if (key === 'transform') continue
-          if (canAnimateProperty(key, animatedStyles[key], animateOnly)) {
+          if (
+            !renderSnapshot.value.newKeys[key] &&
+            canAnimateProperty(key, animatedStyles[key], animateOnly)
+          ) {
             exitKeys.push(key)
           }
         }
@@ -927,7 +1084,10 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
               if (animateOnly && !animateOnly.includes(tKey)) {
                 continue
               }
-              exitKeys.push(`transform:${tKey}`)
+              const exitKey = `transform:${tKey}`
+              if (!renderSnapshot.value.newKeys[exitKey]) {
+                exitKeys.push(exitKey)
+              }
             }
           }
         }
@@ -951,31 +1111,30 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
       }, [justStartedExiting, sendExitComplete])
 
       // Create animated style
-      const animatedStyle = useAnimatedStyle(
+      const animatedStyle = isWeb
+        ? useAnimatedStyle(
         () => {
           'worklet'
 
-          if (disableAnimation || isHydrating) {
+          const config = configRef.value
+          if (config.disableAnimation || config.isHydrating) {
             return {}
           }
 
           const result: Record<string, any> = {}
-          const config = configRef.value
 
           // Check if we have avoidRerenders updates from useStyleEmitter
-          const emitterAnimated = animatedTargetsRef.value
-          const emitterStatic = staticTargetsRef.value
-          const emitterTransforms = transformTargetsRef.value
-          const hasEmitterUpdates = emitterAnimated !== null
+          const emitterSnapshot = emitterSnapshotRef.value
+          const snapshot = emitterSnapshot ?? renderSnapshotRef.value
 
-          // Use emitter values if available, otherwise use React state values.
+          // Use emitter values if available, otherwise use the committed render snapshot.
           // statics must fall back to the render's staticStyles (not {}): once an
           // emitter snapshot has applied static keys, reanimated never unsets
           // them, so after the latch drops a stale emitted value (e.g. a border
           // color that missed animateOnly) would keep painting over the fresh
           // style prop forever
-          const animatedValues = hasEmitterUpdates ? emitterAnimated! : animatedStyles
-          const staticValues = hasEmitterUpdates ? emitterStatic! : staticStyles
+          const animatedValues = snapshot.animated
+          const staticValues = snapshot.statics
 
           // read exit state from shared values
           const currentlyExiting = isExitingRef.value
@@ -984,6 +1143,11 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
           // Include static values from emitter (for hover/press style changes)
           for (const key in staticValues) {
             result[key] = staticValues[key]
+          }
+          for (const key in snapshot.removedKeys) {
+            if (!key.startsWith('transform:') && !(key in staticValues)) {
+              result[key] = snapshot.clearValue
+            }
           }
 
           // Animate regular properties
@@ -1004,16 +1168,16 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
               }
             }
 
-            result[key] = applyAnimation(targetValue as number, propConfig, callback)
+            result[key] = snapshot.newKeys[key]
+              ? targetValue
+              : applyAnimation(targetValue as number, propConfig, callback)
           }
 
           // Handle transforms
-          const transforms = hasEmitterUpdates
-            ? emitterTransforms
-            : animatedStyles.transform
+          const transforms = snapshot.transforms
 
           // Animate transform properties with validation
-          if (transforms && Array.isArray(transforms)) {
+          if (transforms.length > 0 || snapshot.removeTransform) {
             const validTransforms: Record<string, unknown>[] = []
 
             for (const t of transforms) {
@@ -1043,16 +1207,14 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
                 }
 
                 validTransforms.push({
-                  [transformKey]: applyAnimation(
-                    targetValue as number,
-                    propConfig,
-                    callback
-                  ),
+                  [transformKey]: snapshot.newKeys[`transform:${transformKey}`]
+                    ? targetValue
+                    : applyAnimation(targetValue as number, propConfig, callback),
                 })
               }
             }
 
-            if (validTransforms.length > 0) {
+            if (validTransforms.length > 0 || !('transform' in staticValues)) {
               result.transform = validTransforms
             }
           }
@@ -1061,22 +1223,17 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         },
         isWeb
           ? [
-              animatedStyles,
-              staticStyles,
-              baseConfig,
-              propertyConfigs,
-              disableAnimation,
-              isHydrating,
-              // pass SharedValues so the mapper watches them on web (no babel plugin)
-              animatedTargetsRef,
-              staticTargetsRef,
-              transformTargetsRef,
+              // pass SharedValues so the stable mapper watches them on web (no babel plugin)
+              renderSnapshotRef,
+              emitterSnapshotRef,
+              configRef,
               isExitingRef,
               exitCycleIdShared,
               markExitKeyDone,
             ]
           : undefined
-      )
+          )
+        : {}
 
       silenceAnimatedComponentDevCheck(animatedStyle)
 

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -148,9 +148,7 @@ const cloneAnimationValue = (value: unknown): unknown => {
   return value
 }
 
-const cloneStyleRecord = (
-  style: Record<string, unknown>
-): Record<string, unknown> => {
+const cloneStyleRecord = (style: Record<string, unknown>): Record<string, unknown> => {
   const next: Record<string, unknown> = {}
   for (const key in style) {
     next[key] = cloneAnimationValue(style[key])
@@ -226,6 +224,14 @@ const COLOR_STYLE_KEYS: Record<string, boolean> = {
 // an animation descriptor from a color value that isn't clearly parseable.
 const toReanimatedColor = (value: unknown): unknown => {
   'worklet'
+  if (typeof value === 'number') {
+    const color = value >>> 0
+    const alpha = ((color >>> 24) & 255) / 255
+    const red = (color >>> 16) & 255
+    const green = (color >>> 8) & 255
+    const blue = color & 255
+    return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+  }
   if (typeof value !== 'string') return value
   const trimmed = value.trim()
   if (trimmed === 'transparent') return 'rgba(0, 0, 0, 0)'
@@ -234,9 +240,11 @@ const toReanimatedColor = (value: unknown): unknown => {
 
 const isInterpolatableColor = (value: unknown): boolean => {
   'worklet'
-  if (typeof value === 'number') return true
   if (typeof value !== 'string') return false
-  return /^(#[0-9a-fA-F]{3,8}$|rgba?\(|hsla?\(|hwb\()/.test(value)
+  return (
+    /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value) ||
+    /^(?:rgba?|hsla?|hwb)\([0-9+\-.,%/\s]+\)$/.test(value)
+  )
 }
 
 const getSeeds = (
@@ -278,7 +286,8 @@ const applyAnimation = (
   targetValue: number | string,
   config: TransitionConfig,
   callback?: AnimationCallback,
-  seedValue?: number | string
+  seedValue?: number | string,
+  validateStartAsColor = false
 ): number | string => {
   'worklet'
   const delay = config.delay
@@ -305,16 +314,23 @@ const applyAnimation = (
   // a painted predecessor: history may hold a stale clear-value ('') from when
   // the key was last removed, which poisons the start value (NaN frames). the
   // wrapper substitutes the seed for whatever start value reanimated passes.
-  if (seedValue !== undefined) {
+  // color history gets the same treatment only when reanimated's own parser
+  // rejects it, preserving valid in-flight values during interruption.
+  if (seedValue !== undefined || validateStartAsColor) {
     const innerOnStart = animatedValue.onStart
     animatedValue.onStart = (
       animation: unknown,
-      _value: unknown,
+      value: unknown,
       timestamp: number,
       previousAnimation: unknown
     ) => {
       'worklet'
-      innerOnStart(animation, seedValue, timestamp, previousAnimation)
+      const startValue = validateStartAsColor
+        ? isInterpolatableColor(toReanimatedColor(value))
+          ? toReanimatedColor(value)
+          : (seedValue ?? targetValue)
+        : seedValue
+      innerOnStart(animation, startValue, timestamp, previousAnimation)
     }
   }
 
@@ -940,7 +956,6 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         lastPaintedRef.current = renderSnapshot.painted
       }, [renderSnapshot])
 
-
       // reconcile the emitter latch with real re-renders.
       //
       // the avoidReRenders fast path lets a pure pseudo change (hover/press/focus) push
@@ -1292,9 +1307,8 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
             if (key === 'transform') continue
 
             let targetValue = animatedValues[key]
-            let seedValue: unknown = key in snapshot.seeds
-              ? snapshot.seeds[key]
-              : undefined
+            let seedValue: unknown =
+              key in snapshot.seeds ? snapshot.seeds[key] : undefined
             if (COLOR_STYLE_KEYS[key]) {
               targetValue = toReanimatedColor(targetValue)
               seedValue = toReanimatedColor(seedValue)
@@ -1329,13 +1343,20 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
 
             emitted[key] = true
             if (previouslyEmitted[key]) {
-              result[key] = applyAnimation(targetValue as number, propConfig, callback)
+              result[key] = applyAnimation(
+                targetValue as number,
+                propConfig,
+                callback,
+                undefined,
+                !!COLOR_STYLE_KEYS[key]
+              )
             } else if (seedValue !== undefined) {
               result[key] = applyAnimation(
                 targetValue as number,
                 propConfig,
                 callback,
-                seedValue as number | string
+                seedValue as number | string,
+                !!COLOR_STYLE_KEYS[key]
               )
             } else if (currentlyExiting && typeof targetValue === 'number') {
               // a key introduced by exitStyle with no painted predecessor must

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -77,7 +77,15 @@ type AnimationSnapshot = {
   animated: Record<string, unknown>
   statics: Record<string, unknown>
   transforms: Array<Record<string, unknown>>
-  newKeys: Record<string, boolean>
+  /**
+   * for each animated key (transform sub-keys as `transform:key`), the value the
+   * previous committed render painted for it, when one exists and is animatable.
+   * the worklet animates a mapper-fresh key FROM its seed instead of snapping —
+   * this is how an enterStyle value painted statically during mount becomes the
+   * start point once the key turns animated. keys with no seed paint their target
+   * directly (a key appearing from nothing has nothing to animate from).
+   */
+  seeds: Record<string, unknown>
   removedKeys: Record<string, boolean>
   removeTransform: boolean
   clearValue: '' | null
@@ -181,17 +189,6 @@ const getAnimatedKeySet = (
   return keys
 }
 
-const getNewAnimatedKeys = (
-  current: Set<string>,
-  previous: Set<string>
-): Record<string, boolean> => {
-  const newKeys: Record<string, boolean> = {}
-  for (const key of current) {
-    if (!previous.has(key)) newKeys[key] = true
-  }
-  return newKeys
-}
-
 const getRemovedAnimatedKeys = (
   current: Set<string>,
   previous: Set<string>
@@ -201,6 +198,22 @@ const getRemovedAnimatedKeys = (
     if (!current.has(key)) removedKeys[key] = true
   }
   return removedKeys
+}
+
+const getSeeds = (
+  keys: Set<string>,
+  previousPainted: Record<string, unknown>
+): Record<string, unknown> => {
+  const seeds: Record<string, unknown> = {}
+  for (const key of keys) {
+    const prev = previousPainted[key]
+    if (typeof prev !== 'number' && typeof prev !== 'string') continue
+    if (prev === 'auto' || (typeof prev === 'string' && prev.startsWith('calc'))) {
+      continue
+    }
+    seeds[key] = prev
+  }
+  return seeds
 }
 
 const createReanimatedConfig = (config: TransitionConfig): Record<string, unknown> => {
@@ -225,7 +238,8 @@ const createReanimatedConfig = (config: TransitionConfig): Record<string, unknow
 const applyAnimation = (
   targetValue: number | string,
   config: TransitionConfig,
-  callback?: AnimationCallback
+  callback?: AnimationCallback,
+  seedValue?: number | string
 ): number | string => {
   'worklet'
   const delay = config.delay
@@ -246,8 +260,19 @@ const applyAnimation = (
     )
   }
 
+  // reanimated starts a descriptor it has no history for from its own toValue
+  // (an instant snap). `current` is what prepareAnimation reads as the start
+  // point when there is no previous value, so a seeded descriptor animates
+  // from the seed instead.
+  if (seedValue !== undefined) {
+    animatedValue.current = seedValue
+  }
+
   if (delay && delay > 0) {
     animatedValue = withDelay(delay, animatedValue)
+    if (seedValue !== undefined) {
+      animatedValue.current = seedValue
+    }
   }
 
   return animatedValue
@@ -761,6 +786,15 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
       // =========================================================================
       // avoidRerenders: SharedValues for style updates without re-renders
       // =========================================================================
+      const committedRenderKeysRef = useRef(new Set<string>())
+      // full painted style of the last committed source (render or emitter):
+      // statics + animated targets, transform sub-keys flattened as `transform:key`.
+      // seeds read from it.
+      const lastPaintedRef = useRef<Record<string, unknown>>({})
+      // per-key first-animated values React keeps painting under the mapper —
+      // see the styles memo below
+      const carryRef = useRef<Record<string, unknown>>({})
+
       // Separate styles into animated and static
       const { animatedStyles, staticStyles } = useMemo(() => {
         const animated: Record<string, unknown> = {}
@@ -785,18 +819,29 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
           }
         }
 
-        // During mount, include animated values in static to prevent flicker
-        if (isMounting) {
-          for (const key in animated) {
-            staticStyles[key] = cloneAnimationValue(animated[key])
+        // every animated key keeps its FIRST animated value in React's style for
+        // as long as it stays animated. the value never changes across renders,
+        // so React's per-key style diff never touches the key again and the
+        // mapper's inline writes survive every commit — reanimated's Fabric
+        // commit hook provides this guarantee on native, web has no equivalent.
+        // during enter the carry is the enterStyle (the mapper animates over it);
+        // a key appearing post-mount (a just-measured height) paints its value in
+        // the same commit the mapper first sees it, a frame before the mapper's
+        // first write.
+        const carry = carryRef.current
+        for (const key in carry) {
+          if (!(key in animated)) delete carry[key]
+        }
+        for (const key in animated) {
+          if (!(key in carry)) {
+            carry[key] = cloneAnimationValue(animated[key])
           }
+          staticStyles[key] = carry[key]
         }
 
         return { animatedStyles: animated, staticStyles }
       }, [disableAnimation, style, isDark, isMounting, props.animateOnly])
 
-      const committedRenderKeysRef = useRef(new Set<string>())
-      const committedRenderBaselineRef = useRef<Record<string, unknown>>({})
       const renderSnapshot = useMemo(() => {
         const transforms = getAnimatedTransforms(animatedStyles.transform)
         const regularAnimated: Record<string, unknown> = {}
@@ -804,43 +849,30 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
           if (key !== 'transform') regularAnimated[key] = animatedStyles[key]
         }
         const keys = getAnimatedKeySet(animatedStyles, transforms)
-        const newKeys = getNewAnimatedKeys(keys, committedRenderKeysRef.current)
         const removedKeys = getRemovedAnimatedKeys(keys, committedRenderKeysRef.current)
-        // keep each key's first React value as a baseline for its active lifetime.
-        // the stable mapper paints over it after seeding, while pre-mapper rerenders
-        // cannot create an ownerless frame. transforms share one top-level baseline.
-        const baseline: Record<string, unknown> = {}
-        for (const key in animatedStyles) {
-          if (key === 'transform') continue
-          baseline[key] = Object.prototype.hasOwnProperty.call(
-            committedRenderBaselineRef.current,
-            key
-          )
-            ? committedRenderBaselineRef.current[key]
-            : animatedStyles[key]
+        const seeds = getSeeds(keys, lastPaintedRef.current)
+        const painted: Record<string, unknown> = { ...staticStyles }
+        for (const key in regularAnimated) {
+          painted[key] = regularAnimated[key]
         }
-        if (transforms.length > 0) {
-          baseline.transform = Object.prototype.hasOwnProperty.call(
-            committedRenderBaselineRef.current,
-            'transform'
-          )
-            ? committedRenderBaselineRef.current.transform
-            : transforms
+        delete painted.transform
+        for (const t of transforms) {
+          const tKey = Object.keys(t)[0]
+          if (tKey) painted[`transform:${tKey}`] = t[tKey]
         }
         return {
           value: {
             animated: cloneStyleRecord(regularAnimated),
             statics: cloneStyleRecord(staticStyles),
             transforms: cloneTransforms(transforms),
-            newKeys: { ...newKeys },
+            seeds: cloneStyleRecord(seeds),
             removedKeys: { ...removedKeys },
             removeTransform: Object.keys(removedKeys).some((key) =>
               key.startsWith('transform:')
             ),
             clearValue: isWeb ? '' : null,
           } satisfies AnimationSnapshot,
-          reactStatics: { ...staticStyles, ...baseline },
-          baseline,
+          painted,
           keys,
         }
       }, [animatedStyles, staticStyles])
@@ -848,7 +880,7 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         animated: {},
         statics: {},
         transforms: [],
-        newKeys: {},
+        seeds: {},
         removedKeys: {},
         removeTransform: false,
         clearValue: isWeb ? '' : null,
@@ -858,8 +890,9 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
 
       useIsomorphicLayoutEffect(() => {
         committedRenderKeysRef.current = renderSnapshot.keys
-        committedRenderBaselineRef.current = renderSnapshot.baseline
+        lastPaintedRef.current = renderSnapshot.painted
       }, [renderSnapshot])
+
 
       // reconcile the emitter latch with real re-renders.
       //
@@ -1039,11 +1072,12 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
           const keys = getAnimatedKeySet(animated, transforms)
           const previousKeys = emitterKeysRef.current ?? committedRenderKeysRef.current
           const removedKeys = getRemovedAnimatedKeys(keys, previousKeys)
+          const seeds = getSeeds(keys, lastPaintedRef.current)
           emitterSnapshotRef.value = {
             animated: cloneStyleRecord(animated),
             statics: cloneStyleRecord(statics),
             transforms: cloneTransforms(transforms),
-            newKeys: { ...getNewAnimatedKeys(keys, previousKeys) },
+            seeds: cloneStyleRecord(seeds),
             removedKeys: { ...removedKeys },
             removeTransform: Object.keys(removedKeys).some((key) =>
               key.startsWith('transform:')
@@ -1051,6 +1085,13 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
             clearValue: isWeb ? '' : null,
           }
           emitterKeysRef.current = keys
+          const painted: Record<string, unknown> = { ...statics, ...animated }
+          delete painted.transform
+          for (const t of transforms) {
+            const tKey = Object.keys(t)[0]
+            if (tKey) painted[`transform:${tKey}`] = t[tKey]
+          }
+          lastPaintedRef.current = painted
 
           if (
             process.env.NODE_ENV === 'development' &&
@@ -1073,11 +1114,16 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         const exitKeys: string[] = []
         const animateOnly = props.animateOnly as string[] | undefined
 
-        // regular animated properties
+        // regular animated properties. a key fresh to the mapper with no seed
+        // paints its target directly (no animation), so it must not gate exit
+        // completion; a seeded fresh key animates and counts.
         for (const key in animatedStyles) {
           if (key === 'transform') continue
+          const freshWithoutSeed =
+            !committedRenderKeysRef.current.has(key) &&
+            !(key in renderSnapshot.value.seeds)
           if (
-            !renderSnapshot.value.newKeys[key] &&
+            !freshWithoutSeed &&
             canAnimateProperty(key, animatedStyles[key], animateOnly)
           ) {
             exitKeys.push(key)
@@ -1096,7 +1142,10 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
                 continue
               }
               const exitKey = `transform:${tKey}`
-              if (!renderSnapshot.value.newKeys[exitKey]) {
+              const freshWithoutSeed =
+                !committedRenderKeysRef.current.has(exitKey) &&
+                !(exitKey in renderSnapshot.value.seeds)
+              if (!freshWithoutSeed) {
                 exitKeys.push(exitKey)
               }
             }
@@ -1121,15 +1170,32 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         }
       }, [justStartedExiting, sendExitComplete])
 
+      // the worklet's own record of which animated keys it has emitted (mirrors
+      // reanimated's per-view style history, which resets whenever a key leaves
+      // the output). a key not in here is fresh to the mapper no matter what
+      // React has committed — several renders can coalesce into one mapper run.
+      // mutated in place from the worklet; never watched, so writes don't
+      // retrigger the mapper.
+      const mapperStateRef = useSharedValue<{ emitted: Record<string, boolean> }>({
+        emitted: {},
+      })
+
       // Create animated style
       const animatedStyle = useAnimatedStyle(
         () => {
           'worklet'
 
+          const mapperState = mapperStateRef.value
           const config = configRef.value
           if (config.disableAnimation || config.isHydrating) {
+            // the empty return wipes reanimated's per-key history, so ours
+            // resets with it
+            mapperState.emitted = {}
             return {}
           }
+
+          const previouslyEmitted = mapperState.emitted
+          const emitted: Record<string, boolean> = {}
 
           const result: Record<string, any> = {}
 
@@ -1178,9 +1244,19 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
               }
             }
 
-            result[key] = snapshot.newKeys[key]
-              ? targetValue
-              : applyAnimation(targetValue as number, propConfig, callback)
+            emitted[key] = true
+            if (previouslyEmitted[key]) {
+              result[key] = applyAnimation(targetValue as number, propConfig, callback)
+            } else if (key in snapshot.seeds) {
+              result[key] = applyAnimation(
+                targetValue as number,
+                propConfig,
+                callback,
+                snapshot.seeds[key] as number | string
+              )
+            } else {
+              result[key] = targetValue
+            }
           }
 
           // Handle transforms
@@ -1216,10 +1292,19 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
                   }
                 }
 
+                const subKey = `transform:${transformKey}`
+                emitted[subKey] = true
                 validTransforms.push({
-                  [transformKey]: snapshot.newKeys[`transform:${transformKey}`]
-                    ? targetValue
-                    : applyAnimation(targetValue as number, propConfig, callback),
+                  [transformKey]: previouslyEmitted[subKey]
+                    ? applyAnimation(targetValue as number, propConfig, callback)
+                    : subKey in snapshot.seeds
+                      ? applyAnimation(
+                          targetValue as number,
+                          propConfig,
+                          callback,
+                          snapshot.seeds[subKey] as number | string
+                        )
+                      : targetValue,
                 })
               }
             }
@@ -1228,6 +1313,8 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
               result.transform = validTransforms
             }
           }
+
+          mapperState.emitted = emitted
 
           return result
         },
@@ -1263,11 +1350,9 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         })
       }
 
-      // paint each animated key's first React value underneath the worklet until the mapper
-      // owns it. reanimated only snapshots its animated handle on the component's first
-      // render, so a later render can drop the previous static value and commit before the
-      // restarted mapper writes anything — a default-open accordion collapses to 0 for those
-      // frames. the baseline sits under animatedStyle, so the mapper still wins once it runs.
+      // staticStyles carries animated keys only while mounting or on a key's
+      // first post-mount appearance; after that the mapper owns them and the
+      // commit bridge above keeps React commits from wiping its inline writes.
       return {
         style: [staticStyles, animatedStyle],
       }

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -209,6 +209,36 @@ const getImplicitDefault = (key: string): number => {
     : 0
 }
 
+const COLOR_STYLE_KEYS: Record<string, boolean> = {
+  backgroundColor: true,
+  borderColor: true,
+  borderLeftColor: true,
+  borderRightColor: true,
+  borderTopColor: true,
+  borderBottomColor: true,
+  color: true,
+}
+
+// reanimated interpolates only color strings its own parser accepts. anything
+// else falls through to its generic prefix/suffix string handler, which
+// mangles the value into '<letters>NaN' — the browser silently drops that,
+// native processColor throws a redbox. normalize what we can and never build
+// an animation descriptor from a color value that isn't clearly parseable.
+const toReanimatedColor = (value: unknown): unknown => {
+  'worklet'
+  if (typeof value !== 'string') return value
+  const trimmed = value.trim()
+  if (trimmed === 'transparent') return 'rgba(0, 0, 0, 0)'
+  return trimmed
+}
+
+const isInterpolatableColor = (value: unknown): boolean => {
+  'worklet'
+  if (typeof value === 'number') return true
+  if (typeof value !== 'string') return false
+  return /^(#[0-9a-fA-F]{3,8}$|rgba?\(|hsla?\(|hwb\()/.test(value)
+}
+
 const getSeeds = (
   keys: Set<string>,
   previousPainted: Record<string, unknown>
@@ -1135,12 +1165,21 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         // fresh key with a seed or a numeric target (exitStyle-introduced keys
         // animate from their implicit default) gates completion; only fresh
         // non-numeric keys with no seed paint directly and are excluded.
+        const snapshotSeeds = renderSnapshot.value.seeds
         for (const key in animatedStyles) {
           if (key === 'transform') continue
+          // mirror the worklet: color seeds/targets the worklet refuses to
+          // interpolate paint plain and must not gate exit completion
+          const hasUsableSeed =
+            key in snapshotSeeds &&
+            (!COLOR_STYLE_KEYS[key] ||
+              isInterpolatableColor(toReanimatedColor(snapshotSeeds[key])))
           const paintsDirectly =
-            !committedRenderKeysRef.current.has(key) &&
-            !(key in renderSnapshot.value.seeds) &&
-            typeof animatedStyles[key] !== 'number'
+            (!committedRenderKeysRef.current.has(key) &&
+              !hasUsableSeed &&
+              typeof animatedStyles[key] !== 'number') ||
+            (COLOR_STYLE_KEYS[key] &&
+              !isInterpolatableColor(toReanimatedColor(animatedStyles[key])))
           if (
             !paintsDirectly &&
             canAnimateProperty(key, animatedStyles[key], animateOnly)
@@ -1238,7 +1277,9 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
 
           // Include static values from emitter (for hover/press style changes)
           for (const key in staticValues) {
-            result[key] = staticValues[key]
+            result[key] = COLOR_STYLE_KEYS[key]
+              ? toReanimatedColor(staticValues[key])
+              : staticValues[key]
           }
           for (const key in snapshot.removedKeys) {
             if (!key.startsWith('transform:') && !(key in staticValues)) {
@@ -1250,7 +1291,29 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
           for (const key in animatedValues) {
             if (key === 'transform') continue
 
-            const targetValue = animatedValues[key]
+            let targetValue = animatedValues[key]
+            let seedValue: unknown = key in snapshot.seeds
+              ? snapshot.seeds[key]
+              : undefined
+            if (COLOR_STYLE_KEYS[key]) {
+              targetValue = toReanimatedColor(targetValue)
+              seedValue = toReanimatedColor(seedValue)
+              if (!isInterpolatableColor(targetValue)) {
+                // interpolating this would corrupt it into '<letters>NaN'
+                // (native processColor throws) — paint it plain instead
+                console.warn(
+                  '[animations-reanimated] non-interpolatable color painted plain:',
+                  key,
+                  JSON.stringify(animatedValues[key])
+                )
+                emitted[key] = true
+                result[key] = targetValue
+                continue
+              }
+              if (seedValue !== undefined && !isInterpolatableColor(seedValue)) {
+                seedValue = undefined
+              }
+            }
             const propConfig = config.propertyConfigs[key] ?? config.baseConfig
 
             // create callback for exit tracking
@@ -1267,12 +1330,12 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
             emitted[key] = true
             if (previouslyEmitted[key]) {
               result[key] = applyAnimation(targetValue as number, propConfig, callback)
-            } else if (key in snapshot.seeds) {
+            } else if (seedValue !== undefined) {
               result[key] = applyAnimation(
                 targetValue as number,
                 propConfig,
                 callback,
-                snapshot.seeds[key] as number | string
+                seedValue as number | string
               )
             } else if (currentlyExiting && typeof targetValue === 'number') {
               // a key introduced by exitStyle with no painted predecessor must

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -892,26 +892,37 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
       const pseudoActiveRef = useRef(false)
       const isExitingJSRef = useRef(false)
       isExitingJSRef.current = isExiting
+      // the committed render is the worklet's source of truth whenever the emitter is not
+      // latched, so every render must publish its snapshot — not just the renders that drop
+      // a latch. animated keys live only in this snapshot after mount (staticStyles carries
+      // them during mount only), so a render that never publishes leaves the worklet reading
+      // an empty snapshot and the animated properties never reach the screen at all.
+      const publishedSnapshotRef = useRef<object | null>(null)
       useIsomorphicLayoutEffect(() => {
-        if (
-          (isExiting || !pseudoActiveRef.current) &&
-          emitterSnapshotRef.value !== null
-        ) {
-          const emitterKeys = emitterKeysRef.current
-          if (emitterKeys) {
-            const removedKeys = {
-              ...renderSnapshot.value.removedKeys,
-              ...getRemovedAnimatedKeys(renderSnapshot.keys, emitterKeys),
-            }
-            renderSnapshotRef.value = {
-              ...renderSnapshot.value,
-              removedKeys,
-              removeTransform: Object.keys(removedKeys).some((key) =>
-                key.startsWith('transform:')
-              ),
-              clearValue: isWeb ? '' : null,
-            }
+        const droppingLatch =
+          (isExiting || !pseudoActiveRef.current) && emitterSnapshotRef.value !== null
+        // when the latch drops, keys the emitter owned that this render no longer has must
+        // be cleared too, otherwise reanimated keeps painting the stale emitted value
+        const emitterKeys = droppingLatch ? emitterKeysRef.current : null
+
+        if (droppingLatch || publishedSnapshotRef.current !== renderSnapshot.value) {
+          const removedKeys = emitterKeys
+            ? {
+                ...renderSnapshot.value.removedKeys,
+                ...getRemovedAnimatedKeys(renderSnapshot.keys, emitterKeys),
+              }
+            : renderSnapshot.value.removedKeys
+          renderSnapshotRef.value = {
+            ...renderSnapshot.value,
+            removedKeys,
+            removeTransform: Object.keys(removedKeys).some((key) =>
+              key.startsWith('transform:')
+            ),
           }
+          publishedSnapshotRef.current = renderSnapshot.value
+        }
+
+        if (droppingLatch) {
           emitterSnapshotRef.value = null
           emitterKeysRef.current = null
         }
@@ -1111,8 +1122,7 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
       }, [justStartedExiting, sendExitComplete])
 
       // Create animated style
-      const animatedStyle = isWeb
-        ? useAnimatedStyle(
+      const animatedStyle = useAnimatedStyle(
         () => {
           'worklet'
 
@@ -1232,8 +1242,7 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
               markExitKeyDone,
             ]
           : undefined
-          )
-        : {}
+      )
 
       silenceAnimatedComponentDevCheck(animatedStyle)
 
@@ -1254,6 +1263,11 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         })
       }
 
+      // paint each animated key's first React value underneath the worklet until the mapper
+      // owns it. reanimated only snapshots its animated handle on the component's first
+      // render, so a later render can drop the previous static value and commit before the
+      // restarted mapper writes anything — a default-open accordion collapses to 0 for those
+      // frames. the baseline sits under animatedStyle, so the mapper still wins once it runs.
       return {
         style: [staticStyles, animatedStyle],
       }

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -260,19 +260,27 @@ const applyAnimation = (
     )
   }
 
-  // reanimated starts a descriptor it has no history for from its own toValue
-  // (an instant snap). `current` is what prepareAnimation reads as the start
-  // point when there is no previous value, so a seeded descriptor animates
-  // from the seed instead.
+  // reanimated starts a descriptor from its per-view history for the key — the
+  // key's last output value, or the descriptor's own toValue when there is
+  // none (an instant snap). both are wrong for a key that turns animated with
+  // a painted predecessor: history may hold a stale clear-value ('') from when
+  // the key was last removed, which poisons the start value (NaN frames). the
+  // wrapper substitutes the seed for whatever start value reanimated passes.
   if (seedValue !== undefined) {
-    animatedValue.current = seedValue
+    const innerOnStart = animatedValue.onStart
+    animatedValue.onStart = (
+      animation: unknown,
+      _value: unknown,
+      timestamp: number,
+      previousAnimation: unknown
+    ) => {
+      'worklet'
+      innerOnStart(animation, seedValue, timestamp, previousAnimation)
+    }
   }
 
   if (delay && delay > 0) {
     animatedValue = withDelay(delay, animatedValue)
-    if (seedValue !== undefined) {
-      animatedValue.current = seedValue
-    }
   }
 
   return animatedValue

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -857,7 +857,7 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         }
 
         return { animatedStyles: animated, staticStyles }
-      }, [disableAnimation, style, isDark, isMounting, props.animateOnly])
+      }, [disableAnimation, style, isDark, props.animateOnly])
 
       const renderSnapshot = useMemo(() => {
         const transforms = getAnimatedTransforms(animatedStyles.transform)

--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -200,6 +200,15 @@ const getRemovedAnimatedKeys = (
   return removedKeys
 }
 
+// implicit start values for style keys that were never painted (e.g. a key
+// introduced by exitStyle with no base value). most numerics default to 0.
+const getImplicitDefault = (key: string): number => {
+  'worklet'
+  return key === 'opacity' || key === 'scale' || key === 'scaleX' || key === 'scaleY'
+    ? 1
+    : 0
+}
+
 const getSeeds = (
   keys: Set<string>,
   previousPainted: Record<string, unknown>
@@ -1122,16 +1131,18 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
         const exitKeys: string[] = []
         const animateOnly = props.animateOnly as string[] | undefined
 
-        // regular animated properties. a key fresh to the mapper with no seed
-        // paints its target directly (no animation), so it must not gate exit
-        // completion; a seeded fresh key animates and counts.
+        // regular animated properties. mirror the worklet: during exit every
+        // fresh key with a seed or a numeric target (exitStyle-introduced keys
+        // animate from their implicit default) gates completion; only fresh
+        // non-numeric keys with no seed paint directly and are excluded.
         for (const key in animatedStyles) {
           if (key === 'transform') continue
-          const freshWithoutSeed =
+          const paintsDirectly =
             !committedRenderKeysRef.current.has(key) &&
-            !(key in renderSnapshot.value.seeds)
+            !(key in renderSnapshot.value.seeds) &&
+            typeof animatedStyles[key] !== 'number'
           if (
-            !freshWithoutSeed &&
+            !paintsDirectly &&
             canAnimateProperty(key, animatedStyles[key], animateOnly)
           ) {
             exitKeys.push(key)
@@ -1150,10 +1161,11 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
                 continue
               }
               const exitKey = `transform:${tKey}`
-              const freshWithoutSeed =
+              const paintsDirectly =
                 !committedRenderKeysRef.current.has(exitKey) &&
-                !(exitKey in renderSnapshot.value.seeds)
-              if (!freshWithoutSeed) {
+                !(exitKey in renderSnapshot.value.seeds) &&
+                typeof t[tKey] !== 'number'
+              if (!paintsDirectly) {
                 exitKeys.push(exitKey)
               }
             }
@@ -1262,6 +1274,16 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
                 callback,
                 snapshot.seeds[key] as number | string
               )
+            } else if (currentlyExiting && typeof targetValue === 'number') {
+              // a key introduced by exitStyle with no painted predecessor must
+              // still animate over the exit (and gate exit completion) — start
+              // it from the property's implicit default
+              result[key] = applyAnimation(
+                targetValue,
+                propConfig,
+                callback,
+                getImplicitDefault(key)
+              )
             } else {
               result[key] = targetValue
             }
@@ -1312,7 +1334,14 @@ export function createAnimations<A extends Record<string, TransitionConfig>>(
                           callback,
                           snapshot.seeds[subKey] as number | string
                         )
-                      : targetValue,
+                      : currentlyExiting && typeof targetValue === 'number'
+                        ? applyAnimation(
+                            targetValue,
+                            propConfig,
+                            callback,
+                            getImplicitDefault(transformKey)
+                          )
+                        : targetValue,
                 })
               }
             }

--- a/code/kitchen-sink/e2e/Accordion.test.ts
+++ b/code/kitchen-sink/e2e/Accordion.test.ts
@@ -88,13 +88,14 @@ describe('Accordion (auto-height, native)', () => {
     )
 
     await element(by.id('grow-content')).tap()
-    await new Promise((resolve) => setTimeout(resolve, 90))
-    const resizing = await frame('def-height2')
-    await new Promise((resolve) => setTimeout(resolve, 300))
+    await new Promise((resolve) => setTimeout(resolve, 390))
     const open = await frame('def-height2')
+    // at rest the wrapper is auto height by design, so content growth applies
+    // fluidly (no pinned pixel to animate from) — assert the growth landed,
+    // not an intermediate frame
     assert.ok(
-      resizing.height > initialOpen.height && resizing.height < open.height,
-      `resizing height ${resizing.height} should be between ${initialOpen.height} and ${open.height}`
+      open.height > initialOpen.height + 10,
+      `grown height ${open.height} should exceed the settled height ${initialOpen.height}`
     )
 
     const trigger2 = await frame('def-trigger2')

--- a/code/kitchen-sink/e2e/Accordion.test.ts
+++ b/code/kitchen-sink/e2e/Accordion.test.ts
@@ -29,8 +29,8 @@ describe('Accordion (auto-height, native)', () => {
     })
     await waitFor(element(by.id('accordion-default-root')))
       .toExist()
-      .withTimeout(180000)
-  })
+      .withTimeout(10000)
+  }, 15000)
 
   it('default-open item shows content, closed sibling sits below it (no overlap)', async () => {
     await expect(element(by.id('def-content-text'))).toBeVisible()
@@ -51,11 +51,25 @@ describe('Accordion (auto-height, native)', () => {
     )
   })
 
-  it('closes the open item on tap (content hidden)', async () => {
+  it('closes the default-open item through an intermediate height', async () => {
+    const open = await frame('def-height')
     await element(by.id('def-trigger')).tap()
+    await new Promise((resolve) => setTimeout(resolve, 90))
+    const closing = await frame('def-height')
+    assert.ok(closing.height > 0, 'default-open close should stay above 0 mid-flight')
+    assert.ok(
+      closing.height < open.height,
+      `default-open close ${closing.height} should be below ${open.height}`
+    )
     await waitFor(element(by.id('def-content-text')))
       .not.toBeVisible()
       .withTimeout(4000)
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const closed = await frame('def-height')
+    assert.ok(
+      closed.height <= 1,
+      `default-open height ${closed.height} should settle at 0`
+    )
     await device.takeScreenshot('accordion-after-close')
   })
 
@@ -112,6 +126,10 @@ describe('Accordion (auto-height, native)', () => {
     assert.ok(
       reopening.height < open.height,
       'reversal should stay below the open endpoint'
+    )
+    assert.ok(
+      reopening.height > closingBeforeReverse.height,
+      `reversal height ${reopening.height} should rise above ${closingBeforeReverse.height}`
     )
 
     await new Promise((resolve) => setTimeout(resolve, 300))

--- a/code/kitchen-sink/e2e/Accordion.test.ts
+++ b/code/kitchen-sink/e2e/Accordion.test.ts
@@ -74,29 +74,54 @@ describe('Accordion (auto-height, native)', () => {
   })
 
   it('opens, reverses, and closes through intermediate numeric heights', async () => {
+    // poll instead of fixed offsets: animation start and settle timing vary
+    // with simulator/js-thread speed, so sample against observed motion
+    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+    const pollHeight = async (
+      predicate: (height: number) => boolean,
+      label: string,
+      timeoutMs = 5000
+    ) => {
+      const startedAt = Date.now()
+      let last = await frame('def-height2')
+      while (!predicate(last.height)) {
+        assert.ok(
+          Date.now() - startedAt < timeoutMs,
+          `timed out polling for ${label}, last height ${last.height}`
+        )
+        await sleep(50)
+        last = await frame('def-height2')
+      }
+      return last.height
+    }
+    const pollSettled = async (label: string) => {
+      let previous = await frame('def-height2')
+      for (let i = 0; i < 100; i++) {
+        await sleep(250)
+        const next = await frame('def-height2')
+        if (Math.abs(next.height - previous.height) < 1) {
+          return next.height
+        }
+        previous = next
+      }
+      assert.fail(`height never settled for ${label}`)
+      return 0
+    }
+
     await element(by.id('def-trigger2')).tap()
-    await new Promise((resolve) => setTimeout(resolve, 90))
-
-    const opening = await frame('def-height2')
-    assert.ok(opening.height > 0, `opening height ${opening.height} should be above 0`)
-
-    await new Promise((resolve) => setTimeout(resolve, 300))
-    const initialOpen = await frame('def-height2')
+    const opening = await pollHeight((h) => h > 0, 'open start')
+    const initialOpen = await pollSettled('open settle')
     assert.ok(
-      opening.height < initialOpen.height,
-      `opening height ${opening.height} should be below settled height ${initialOpen.height}`
+      opening < initialOpen,
+      `opening height ${opening} should be an intermediate below settled ${initialOpen}`
     )
 
     await element(by.id('grow-content')).tap()
-    await new Promise((resolve) => setTimeout(resolve, 390))
-    const open = await frame('def-height2')
     // at rest the wrapper is auto height by design, so content growth applies
-    // fluidly (no pinned pixel to animate from) — assert the growth landed,
+    // fluidly (no pinned pixel to animate from) — assert the growth lands,
     // not an intermediate frame
-    assert.ok(
-      open.height > initialOpen.height + 10,
-      `grown height ${open.height} should exceed the settled height ${initialOpen.height}`
-    )
+    await pollHeight((h) => h > initialOpen + 10, 'content growth')
+    const open = await pollSettled('grown settle')
 
     const trigger2 = await frame('def-trigger2')
     const content2 = await frame('def-content2')
@@ -112,41 +137,34 @@ describe('Accordion (auto-height, native)', () => {
     )
 
     await element(by.id('def-trigger2')).tap()
-    await new Promise((resolve) => setTimeout(resolve, 90))
-    const closingBeforeReverse = await frame('def-height2')
-    assert.ok(closingBeforeReverse.height > 0, 'close should have an intermediate height')
-    assert.ok(
-      closingBeforeReverse.height < open.height,
-      'close should move below open height'
+    const closingBeforeReverse = await pollHeight(
+      (h) => h > 1 && h < open - 5,
+      'close intermediate'
     )
 
     await element(by.id('def-trigger2')).tap()
-    await new Promise((resolve) => setTimeout(resolve, 90))
-    const reopening = await frame('def-height2')
-    assert.ok(reopening.height > 0, 'reversal should stay above the closed endpoint')
-    assert.ok(
-      reopening.height < open.height,
-      'reversal should stay below the open endpoint'
+    const reopening = await pollHeight(
+      (h) => h > closingBeforeReverse + 2,
+      'reversal rising'
     )
     assert.ok(
-      reopening.height > closingBeforeReverse.height,
-      `reversal height ${reopening.height} should rise above ${closingBeforeReverse.height}`
+      reopening <= open + 2,
+      `reversal height ${reopening} should stay at or below the open endpoint ${open}`
     )
-
-    await new Promise((resolve) => setTimeout(resolve, 300))
-    const reopened = await frame('def-height2')
+    const reopened = await pollSettled('reopen settle')
     assert.ok(
-      Math.abs(reopened.height - open.height) <= 2,
-      `reopened height ${reopened.height} should settle at ${open.height}`
+      Math.abs(reopened - open) <= 2,
+      `reopened height ${reopened} should settle at ${open}`
     )
 
     await element(by.id('def-trigger2')).tap()
-    await new Promise((resolve) => setTimeout(resolve, 90))
-    const closing = await frame('def-height2')
-    assert.ok(closing.height > 0, 'final close should have an intermediate height')
-    assert.ok(closing.height < open.height, 'final close should move below open height')
+    const closing = await pollHeight(
+      (h) => h > 1 && h < open - 5,
+      'final close intermediate'
+    )
+    assert.ok(closing > 0, 'final close should have an intermediate height')
 
-    await new Promise((resolve) => setTimeout(resolve, 300))
+    await pollHeight((h) => h <= 1, 'final close settle')
     const closed = await frame('def-height2')
     const closedMarker = await frame('after-accordion-marker')
     assert.ok(closed.height <= 1, `closed height ${closed.height} should settle at 0`)

--- a/code/kitchen-sink/e2e/Accordion.test.ts
+++ b/code/kitchen-sink/e2e/Accordion.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Native (Detox) verification for the accordion auto-height change.
+ *
+ * The wrapper caches its child's numeric layout and the collapse is driven by the
+ * reanimated driver (native default). This test confirms on a real iOS simulator that:
+ *  - a default-open item shows its content (open works),
+ *  - a default-closed sibling sits BELOW that content (no content-below-last-item /
+ *    no overlap regression),
+ *  - opening, closing, and reversing have intermediate numeric heights.
+ * Screenshots are captured as evidence.
+ */
+
+import * as assert from 'assert'
+import { by, device, element, expect, waitFor } from 'detox'
+import { safeLaunchApp } from './utils/detox'
+
+async function frame(id: string) {
+  const attrs: any = await element(by.id(id)).getAttributes()
+  // single element -> attrs.frame; if a collection, take first
+  const f = attrs.frame ?? attrs.elements?.[0]?.frame
+  return f as { x: number; y: number; width: number; height: number }
+}
+
+describe('Accordion (auto-height, native)', () => {
+  beforeAll(async () => {
+    await safeLaunchApp({
+      newInstance: true,
+      launchArgs: { directUseCase: 'AccordionDefaultOpenCase' },
+    })
+    await waitFor(element(by.id('accordion-default-root')))
+      .toExist()
+      .withTimeout(180000)
+  })
+
+  it('default-open item shows content, closed sibling sits below it (no overlap)', async () => {
+    await expect(element(by.id('def-content-text'))).toBeVisible()
+    await device.takeScreenshot('accordion-default-open')
+
+    const content = await frame('def-content')
+    const trigger2 = await frame('def-trigger2')
+    const marker = await frame('after-accordion-marker')
+    assert.ok(content.height > 10, `open content height ${content.height} should be > 10`)
+    // the second (closed) item's trigger must sit at or below the open content's bottom
+    assert.ok(
+      trigger2.y >= content.y + content.height - 2,
+      `trigger2.y ${trigger2.y} should be >= content bottom ${content.y + content.height}`
+    )
+    assert.ok(
+      marker.y >= trigger2.y + trigger2.height - 2,
+      `marker.y ${marker.y} should be below trigger2 bottom ${trigger2.y + trigger2.height}`
+    )
+  })
+
+  it('closes the open item on tap (content hidden)', async () => {
+    await element(by.id('def-trigger')).tap()
+    await waitFor(element(by.id('def-content-text')))
+      .not.toBeVisible()
+      .withTimeout(4000)
+    await device.takeScreenshot('accordion-after-close')
+  })
+
+  it('opens, reverses, and closes through intermediate numeric heights', async () => {
+    await element(by.id('def-trigger2')).tap()
+    await new Promise((resolve) => setTimeout(resolve, 90))
+
+    const opening = await frame('def-height2')
+    assert.ok(opening.height > 0, `opening height ${opening.height} should be above 0`)
+
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const initialOpen = await frame('def-height2')
+    assert.ok(
+      opening.height < initialOpen.height,
+      `opening height ${opening.height} should be below settled height ${initialOpen.height}`
+    )
+
+    await element(by.id('grow-content')).tap()
+    await new Promise((resolve) => setTimeout(resolve, 90))
+    const resizing = await frame('def-height2')
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const open = await frame('def-height2')
+    assert.ok(
+      resizing.height > initialOpen.height && resizing.height < open.height,
+      `resizing height ${resizing.height} should be between ${initialOpen.height} and ${open.height}`
+    )
+
+    const trigger2 = await frame('def-trigger2')
+    const content2 = await frame('def-content2')
+    const openMarker = await frame('after-accordion-marker')
+    assert.ok(content2.height > 10, `content2 height ${content2.height} should be > 10`)
+    assert.ok(
+      content2.y >= trigger2.y + trigger2.height - 2,
+      `content2 should render below its own trigger, not above/overlapping`
+    )
+    assert.ok(
+      openMarker.y >= content2.y + content2.height - 2,
+      `marker should render below the final item's content`
+    )
+
+    await element(by.id('def-trigger2')).tap()
+    await new Promise((resolve) => setTimeout(resolve, 90))
+    const closingBeforeReverse = await frame('def-height2')
+    assert.ok(closingBeforeReverse.height > 0, 'close should have an intermediate height')
+    assert.ok(
+      closingBeforeReverse.height < open.height,
+      'close should move below open height'
+    )
+
+    await element(by.id('def-trigger2')).tap()
+    await new Promise((resolve) => setTimeout(resolve, 90))
+    const reopening = await frame('def-height2')
+    assert.ok(reopening.height > 0, 'reversal should stay above the closed endpoint')
+    assert.ok(
+      reopening.height < open.height,
+      'reversal should stay below the open endpoint'
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const reopened = await frame('def-height2')
+    assert.ok(
+      Math.abs(reopened.height - open.height) <= 2,
+      `reopened height ${reopened.height} should settle at ${open.height}`
+    )
+
+    await element(by.id('def-trigger2')).tap()
+    await new Promise((resolve) => setTimeout(resolve, 90))
+    const closing = await frame('def-height2')
+    assert.ok(closing.height > 0, 'final close should have an intermediate height')
+    assert.ok(closing.height < open.height, 'final close should move below open height')
+
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const closed = await frame('def-height2')
+    const closedMarker = await frame('after-accordion-marker')
+    assert.ok(closed.height <= 1, `closed height ${closed.height} should settle at 0`)
+    assert.ok(
+      closedMarker.y < openMarker.y,
+      `marker.y ${closedMarker.y} should move above its open position ${openMarker.y}`
+    )
+    await expect(element(by.id('def-content2-text'))).not.toBeVisible()
+    await device.takeScreenshot('accordion-second-closed')
+  })
+})

--- a/code/kitchen-sink/e2e/Accordion.test.ts
+++ b/code/kitchen-sink/e2e/Accordion.test.ts
@@ -30,7 +30,7 @@ describe('Accordion (auto-height, native)', () => {
     await waitFor(element(by.id('accordion-default-root')))
       .toExist()
       .withTimeout(10000)
-  }, 15000)
+  })
 
   it('default-open item shows content, closed sibling sits below it (no overlap)', async () => {
     await expect(element(by.id('def-content-text'))).toBeVisible()

--- a/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
+++ b/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
@@ -1,0 +1,105 @@
+import { ChevronDown } from '@tamagui/lucide-icons-2'
+import { useState } from 'react'
+import { Accordion, Button, Paragraph, Square, YStack } from 'tamagui'
+
+// verifies first-paint of a defaultValue-open item shows content at full height
+// (no collapse-to-0 flash), which is the client-side equivalent of the SSR case.
+// used by both the web Accordion.test and the native Accordion.e2e (Detox), so
+// elements carry both `id` (web css selectors) and `testID` (native Detox).
+export function AccordionDefaultOpenCase() {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <YStack testID="accordion-default-root" p="$4">
+      <Accordion overflow="hidden" width="$20" type="multiple" defaultValue={['a1']}>
+        <Accordion.Item value="a1" mb={-1}>
+          <Accordion.Trigger
+            id="def-trigger"
+            testID="def-trigger"
+            flexDirection="row"
+            justify="space-between"
+            borderWidth={1}
+            borderColor="$borderColor"
+          >
+            {({ open }: { open: boolean }) => (
+              <>
+                <Paragraph>Open by default</Paragraph>
+                <Square transparent transition="quick" rotate={open ? '180deg' : '0deg'}>
+                  <ChevronDown size="$1" color="$color" />
+                </Square>
+              </>
+            )}
+          </Accordion.Trigger>
+          <Accordion.HeightAnimator
+            id="def-height"
+            testID="def-height"
+            transition="300ms"
+          >
+            <Accordion.Content
+              id="def-content"
+              testID="def-content"
+              borderWidth={1}
+              borderTopWidth={0}
+              borderColor="$borderColor"
+            >
+              <Paragraph testID="def-content-text">
+                This content should be visible immediately on first paint, at its full
+                natural height, with no collapse-to-zero flash.
+              </Paragraph>
+            </Accordion.Content>
+          </Accordion.HeightAnimator>
+        </Accordion.Item>
+
+        <Accordion.Item value="a2">
+          <Accordion.Trigger
+            id="def-trigger2"
+            testID="def-trigger2"
+            flexDirection="row"
+            justify="space-between"
+            borderWidth={1}
+            borderColor="$borderColor"
+          >
+            {({ open }: { open: boolean }) => (
+              <>
+                <Paragraph>Closed by default</Paragraph>
+                <Square transparent transition="quick" rotate={open ? '180deg' : '0deg'}>
+                  <ChevronDown size="$1" color="$color" />
+                </Square>
+              </>
+            )}
+          </Accordion.Trigger>
+          <Accordion.HeightAnimator
+            id="def-height2"
+            testID="def-height2"
+            transition="300ms"
+          >
+            <Accordion.Content
+              id="def-content2"
+              testID="def-content2"
+              borderWidth={1}
+              borderTopWidth={0}
+              borderColor="$borderColor"
+            >
+              <Paragraph testID="def-content2-text">
+                {expanded
+                  ? 'Second item content expanded across several lines to verify that an open HeightAnimator follows a changing intrinsic child measurement without losing its numeric animation target.'
+                  : 'Second item content.'}
+              </Paragraph>
+              <Button
+                id="grow-content"
+                testID="grow-content"
+                size="$2"
+                onPress={() => setExpanded((value) => !value)}
+              >
+                Resize content
+              </Button>
+            </Accordion.Content>
+          </Accordion.HeightAnimator>
+        </Accordion.Item>
+      </Accordion>
+      <Paragraph id="after-accordion-marker" testID="after-accordion-marker">
+        After accordion
+      </Paragraph>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
+++ b/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from '@tamagui/lucide-icons-2'
-import { useState } from 'react'
-import { Accordion, Button, Paragraph, Square, YStack } from 'tamagui'
+import { useLayoutEffect, useState } from 'react'
+import { Accordion, Button, Paragraph, Square, View, YStack } from 'tamagui'
 
 // verifies first-paint of a defaultValue-open item shows content at full height
 // (no collapse-to-0 flash), which is the client-side equivalent of the SSR case.
@@ -8,6 +8,12 @@ import { Accordion, Button, Paragraph, Square, YStack } from 'tamagui'
 // elements carry both `id` (web css selectors) and `testID` (native Detox).
 export function AccordionDefaultOpenCase() {
   const [expanded, setExpanded] = useState(false)
+  const [initialLayoutPass, setInitialLayoutPass] = useState(0)
+  const [probeVisible, setProbeVisible] = useState(true)
+
+  useLayoutEffect(() => {
+    if (initialLayoutPass === 1) setInitialLayoutPass(2)
+  }, [initialLayoutPass])
 
   return (
     <YStack testID="accordion-default-root" p="$4">
@@ -38,6 +44,7 @@ export function AccordionDefaultOpenCase() {
             <Accordion.Content
               id="def-content"
               testID="def-content"
+              onLayout={() => setInitialLayoutPass((pass) => (pass === 0 ? 1 : pass))}
               borderWidth={1}
               borderTopWidth={0}
               borderColor="$borderColor"
@@ -100,6 +107,22 @@ export function AccordionDefaultOpenCase() {
       <Paragraph id="after-accordion-marker" testID="after-accordion-marker">
         After accordion
       </Paragraph>
+      <View
+        id="animated-key-probe"
+        testID="animated-key-probe"
+        width={20}
+        height={probeVisible ? 40 : undefined}
+        x={probeVisible ? 40 : undefined}
+        bg="$backgroundHover"
+        transition="300ms"
+      />
+      <Button
+        id="toggle-key-probe"
+        testID="toggle-key-probe"
+        onPress={() => setProbeVisible((visible) => !visible)}
+      >
+        Toggle animated keys
+      </Button>
     </YStack>
   )
 }

--- a/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
+++ b/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
@@ -44,15 +44,18 @@ export function AccordionDefaultOpenCase() {
             <Accordion.Content
               id="def-content"
               testID="def-content"
-              onLayout={() => setInitialLayoutPass((pass) => (pass === 0 ? 1 : pass))}
               borderWidth={1}
               borderTopWidth={0}
               borderColor="$borderColor"
             >
-              <Paragraph testID="def-content-text">
-                This content should be visible immediately on first paint, at its full
-                natural height, with no collapse-to-zero flash.
-              </Paragraph>
+              <View
+                onLayout={() => setInitialLayoutPass((pass) => (pass === 0 ? 1 : pass))}
+              >
+                <Paragraph testID="def-content-text">
+                  This content should be visible immediately on first paint, at its full
+                  natural height, with no collapse-to-zero flash.
+                </Paragraph>
+              </View>
             </Accordion.Content>
           </Accordion.HeightAnimator>
         </Accordion.Item>

--- a/code/kitchen-sink/src/usecases/ExitStyleNewKeyCase.tsx
+++ b/code/kitchen-sink/src/usecases/ExitStyleNewKeyCase.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { AnimatePresence } from '@tamagui/animate-presence'
+import { Button, Paragraph, Square, XStack, YStack } from 'tamagui'
+
+// regression: a style key first introduced by exitStyle (no base value, never
+// painted) must still animate over the exit and gate exit completion. the bug
+// emitted such keys as plain values and excluded them from the pending exit
+// key set, so an element whose exitStyle only used new keys unmounted the same
+// cycle, skipping the exit entirely.
+export function ExitStyleNewKeyCase() {
+  const [show, setShow] = useState(true)
+
+  return (
+    <YStack gap="$4" padding="$4">
+      <Paragraph fontWeight="bold">ExitStyle-introduced key</Paragraph>
+      <XStack gap="$2">
+        <Button testID="exit-new-key-show" onPress={() => setShow(true)}>
+          Show
+        </Button>
+        <Button testID="exit-new-key-hide" onPress={() => setShow(false)}>
+          Hide
+        </Button>
+      </XStack>
+      <XStack height={120} items="center" justify="center">
+        <AnimatePresence>
+          {show ? (
+            <Square
+              key="exit-new-key-square"
+              id="exit-new-key-target"
+              testID="exit-new-key-target"
+              transition="300ms"
+              size={80}
+              bg="$blue10"
+              borderColor="$red10"
+              exitStyle={{
+                borderWidth: 10,
+                y: 40,
+              }}
+            />
+          ) : null}
+        </AnimatePresence>
+      </XStack>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/ToggleGroupFilledActiveCase.tsx
+++ b/code/kitchen-sink/src/usecases/ToggleGroupFilledActiveCase.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { SizableText, ToggleGroup, YStack, styled } from 'tamagui'
+
+// repro for community issue: a styled(ToggleGroup.Item) variant that sets a
+// resting backgroundColor breaks activeStyle. `filled` sets backgroundColor at
+// rest; `primary` sets no backgroundColor. Both pass activeStyle={{backgroundColor:'green'}}.
+// expected: the active item shows green. bug: filled item stays red on active.
+
+const FilledItem = styled(ToggleGroup.Item, {
+  variants: {
+    filled: {
+      true: {
+        backgroundColor: 'red',
+      },
+    },
+    primary: {
+      true: {
+        borderColor: 'blue',
+        borderWidth: 2,
+      },
+    },
+  } as const,
+})
+
+export function ToggleGroupFilledActiveCase() {
+  const [value, setValue] = React.useState('a')
+
+  return (
+    <YStack p="$4" gap="$4">
+      <ToggleGroup
+        id="tg-filled"
+        type="single"
+        value={value}
+        onValueChange={(v) => v && setValue(v)}
+        disableDeactivation
+      >
+        <FilledItem
+          filled
+          value="a"
+          id="filled-a"
+          width={120}
+          height={40}
+          activeStyle={{ backgroundColor: 'green' }}
+        >
+          <SizableText>filled-a</SizableText>
+        </FilledItem>
+        <FilledItem
+          filled
+          value="b"
+          id="filled-b"
+          width={120}
+          height={40}
+          activeStyle={{ backgroundColor: 'green' }}
+        >
+          <SizableText>filled-b</SizableText>
+        </FilledItem>
+        <FilledItem
+          primary
+          value="c"
+          id="primary-c"
+          width={120}
+          height={40}
+          activeStyle={{ backgroundColor: 'green' }}
+        >
+          <SizableText>primary-c</SizableText>
+        </FilledItem>
+      </ToggleGroup>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.native.ts
+++ b/code/kitchen-sink/src/usecases/index.native.ts
@@ -7,6 +7,8 @@
 import type { ComponentType } from 'react'
 
 const loaders: Record<string, () => ComponentType<any>> = {
+  AccordionDefaultOpenCase: () =>
+    require('./AccordionDefaultOpenCase').AccordionDefaultOpenCase,
   ActionsSheetComparison: () =>
     require('./ActionsSheetComparison').ActionsSheetComparison,
   AnimatedByProp: () => require('./AnimatedByProp').AnimatedByProp,

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -71,6 +71,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
     require('./DialogSheetAdaptUnmountCase').DialogSheetAdaptUnmountCase,
   Example: () => require('./Example').Example,
   ExitCompletionCase: () => require('./ExitCompletionCase').ExitCompletionCase,
+  ExitStyleNewKeyCase: () => require('./ExitStyleNewKeyCase').ExitStyleNewKeyCase,
   FocusVisibleButton: () => require('./FocusVisibleButton').FocusVisibleButton,
   FocusVisibleButtonPointer: () =>
     require('./FocusVisibleButtonPointer').FocusVisibleButtonPointer,

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -249,6 +249,10 @@ const loaders: Record<string, () => ComponentType<any>> = {
   ToggleGroupActiveProps: () =>
     require('./ToggleGroupActiveProps').ToggleGroupActiveProps,
   ToggleGroupXGroupCase: () => require('./ToggleGroupXGroupCase').ToggleGroupXGroupCase,
+  ToggleGroupFilledActiveCase: () =>
+    require('./ToggleGroupFilledActiveCase').ToggleGroupFilledActiveCase,
+  AccordionDefaultOpenCase: () =>
+    require('./AccordionDefaultOpenCase').AccordionDefaultOpenCase,
   TooltipAnimationCase: () => require('./TooltipAnimationCase').TooltipAnimationCase,
   TooltipCase: () => require('./TooltipCase').TooltipCase,
   TooltipGlobalPatternCase: () =>

--- a/code/kitchen-sink/tests/Accordion.test.tsx
+++ b/code/kitchen-sink/tests/Accordion.test.tsx
@@ -7,38 +7,73 @@ import { setupPage } from './test-utils'
 // height inline and cannot tween out of 'auto', so the wrapper froze at
 // height:auto -> collapsed to 0. the content (absolutely positioned) then spilled
 // out of layout and rendered below the last item, and nothing animated.
-// the demo drives collapse with the `transition` prop, which is a CSS-transition
-// the default-open layout check runs under css, while the frame-level motion check
-// runs under both css and reanimated so web cannot hide a native-driver snap.
-test('open item reserves height and pushes siblings below its content', async ({
-  page,
-}) => {
-  await setupPage(page, {
-    name: 'AccordionDefaultOpenCase',
-    type: 'useCase',
-    searchParams: { animationDriver: 'css' },
-  })
-  const content = page.locator('#def-content')
-  const marker = page.locator('#after-accordion-marker')
-  await expect(content).toBeVisible()
-
-  const contentBox = await content.boundingBox()
-  const trigger2Box = await page.locator('#def-trigger2').boundingBox()
-  const markerBox = await marker.boundingBox()
-  expect(contentBox).not.toBeNull()
-  expect(trigger2Box).not.toBeNull()
-  expect(markerBox).not.toBeNull()
-
-  // content of the open item has real height (not collapsed to 0)
-  expect(contentBox!.height).toBeGreaterThan(10)
-
-  // the next item's trigger sits at or below the open content bottom (no overlap,
-  // content is not rendering below the last item)
-  expect(trigger2Box!.y).toBeGreaterThanOrEqual(contentBox!.y + contentBox!.height - 2)
-  expect(markerBox!.y).toBeGreaterThanOrEqual(trigger2Box!.y + trigger2Box!.height - 2)
-})
-
 for (const animationDriver of ['css', 'reanimated']) {
+  test(`${animationDriver}: default-open layout never collapses on its first frames`, async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      globalThis['__accordionFirstFrames'] = []
+      const startedAt = performance.now()
+      const sample = () => {
+        const wrapper = document.getElementById('def-height')
+        const content = document.getElementById('def-content')
+        const marker = document.getElementById('after-accordion-marker')
+        if (wrapper && content && marker) {
+          const wrapperRect = wrapper.getBoundingClientRect()
+          const contentRect = content.getBoundingClientRect()
+          const markerRect = marker.getBoundingClientRect()
+          globalThis['__accordionFirstFrames'].push({
+            wrapperHeight: wrapperRect.height,
+            contentBottom: contentRect.y + contentRect.height,
+            markerY: markerRect.y,
+          })
+        }
+        if (performance.now() - startedAt < 2000) requestAnimationFrame(sample)
+      }
+      requestAnimationFrame(sample)
+    })
+
+    await setupPage(page, {
+      name: 'AccordionDefaultOpenCase',
+      type: 'useCase',
+      searchParams: { animationDriver },
+    })
+    await page.waitForTimeout(100)
+
+    const frames = await page.evaluate<
+      Array<{ wrapperHeight: number; contentBottom: number; markerY: number }>
+    >(() => globalThis['__accordionFirstFrames'])
+    expect(frames.length).toBeGreaterThan(1)
+    expect(
+      Math.min(...frames.map(({ wrapperHeight }) => wrapperHeight)),
+      JSON.stringify(frames)
+    ).toBeGreaterThan(10)
+    expect(
+      Math.min(...frames.map(({ markerY, contentBottom }) => markerY - contentBottom))
+    ).toBeGreaterThanOrEqual(-2)
+
+    const closing = await page.evaluate(async () => {
+      const trigger = document.getElementById('def-trigger')
+      const wrapper = document.getElementById('def-height')
+      if (!trigger || !wrapper) throw new Error('default-open accordion nodes missing')
+
+      const openHeight = wrapper.getBoundingClientRect().height
+      trigger.click()
+      const heights: number[] = []
+      const startedAt = performance.now()
+      do {
+        await new Promise(requestAnimationFrame)
+        heights.push(wrapper.getBoundingClientRect().height)
+      } while (performance.now() - startedAt < 450)
+      return { openHeight, heights }
+    })
+
+    expect(
+      closing.heights.some((height) => height > 1 && height < closing.openHeight - 1)
+    ).toBe(true)
+    expect(closing.heights.at(-1)).toBeLessThanOrEqual(1)
+  })
+
   test(`${animationDriver}: toggling and reversing samples numeric wrapper height`, async ({
     page,
   }) => {
@@ -116,7 +151,9 @@ for (const animationDriver of ['css', 'reanimated']) {
     expect(beforeReverse).toBeLessThan(result.openHeight - 1)
     expect(afterReverse).toBeGreaterThan(1)
     expect(afterReverse).toBeLessThan(result.openHeight - 1)
-    expect(Math.abs(afterReverse - beforeReverse)).toBeLessThan(15)
+    expect(Math.abs(afterReverse - beforeReverse)).toBeLessThan(
+      result.openHeight * 0.2
+    )
     expect(result.reopening.at(-1)?.height).toBeCloseTo(result.openHeight, 0)
 
     expect(
@@ -127,3 +164,32 @@ for (const animationDriver of ['css', 'reanimated']) {
     await expect(page.locator('#def-content2')).toHaveCount(0)
   })
 }
+
+test('reanimated clears absent keys and seeds them again on reappearance', async ({
+  page,
+}) => {
+  await setupPage(page, {
+    name: 'AccordionDefaultOpenCase',
+    type: 'useCase',
+    searchParams: { animationDriver: 'reanimated' },
+  })
+
+  const probe = page.locator('#animated-key-probe')
+  const initial = await probe.boundingBox()
+  expect(initial).not.toBeNull()
+  expect(initial!.height).toBeCloseTo(40, 0)
+
+  await page.locator('#toggle-key-probe').click()
+  await page.waitForTimeout(150)
+  const absent = await probe.boundingBox()
+  expect(absent).not.toBeNull()
+  expect(absent!.height).toBeLessThanOrEqual(1)
+  expect(absent!.x).toBeLessThan(initial!.x - 30)
+
+  await page.locator('#toggle-key-probe').click()
+  await page.waitForTimeout(150)
+  const reappeared = await probe.boundingBox()
+  expect(reappeared).not.toBeNull()
+  expect(reappeared!.height).toBeCloseTo(40, 0)
+  expect(reappeared!.x).toBeCloseTo(initial!.x, 0)
+})

--- a/code/kitchen-sink/tests/Accordion.test.tsx
+++ b/code/kitchen-sink/tests/Accordion.test.tsx
@@ -156,10 +156,10 @@ for (const animationDriver of ['css', 'reanimated']) {
       )
     ).toBe(true)
     // at rest the wrapper is auto height: content growth applies immediately
-    // and no inline pixel height lingers
-    expect(result.inlineAfterOpen).toBe('')
+    // and no inline pixel height lingers (drivers paint '' or an explicit auto)
+    expect(result.inlineAfterOpen.endsWith('px')).toBe(false)
     expect(result.openHeight).toBeGreaterThan(result.initialOpenHeight)
-    expect(result.inlineAfterResize).toBe('')
+    expect(result.inlineAfterResize.endsWith('px')).toBe(false)
 
     const beforeReverse = result.closingBeforeReverse.at(-1)?.height ?? 0
     const afterReverse = result.reopening[0]?.height ?? 0

--- a/code/kitchen-sink/tests/Accordion.test.tsx
+++ b/code/kitchen-sink/tests/Accordion.test.tsx
@@ -1,0 +1,129 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+// regression: Accordion.HeightAnimator used height:'auto' for the open-but-not-
+// yet-measured state. with a transition set, the CSS animation driver writes
+// height inline and cannot tween out of 'auto', so the wrapper froze at
+// height:auto -> collapsed to 0. the content (absolutely positioned) then spilled
+// out of layout and rendered below the last item, and nothing animated.
+// the demo drives collapse with the `transition` prop, which is a CSS-transition
+// the default-open layout check runs under css, while the frame-level motion check
+// runs under both css and reanimated so web cannot hide a native-driver snap.
+test('open item reserves height and pushes siblings below its content', async ({
+  page,
+}) => {
+  await setupPage(page, {
+    name: 'AccordionDefaultOpenCase',
+    type: 'useCase',
+    searchParams: { animationDriver: 'css' },
+  })
+  const content = page.locator('#def-content')
+  const marker = page.locator('#after-accordion-marker')
+  await expect(content).toBeVisible()
+
+  const contentBox = await content.boundingBox()
+  const trigger2Box = await page.locator('#def-trigger2').boundingBox()
+  const markerBox = await marker.boundingBox()
+  expect(contentBox).not.toBeNull()
+  expect(trigger2Box).not.toBeNull()
+  expect(markerBox).not.toBeNull()
+
+  // content of the open item has real height (not collapsed to 0)
+  expect(contentBox!.height).toBeGreaterThan(10)
+
+  // the next item's trigger sits at or below the open content bottom (no overlap,
+  // content is not rendering below the last item)
+  expect(trigger2Box!.y).toBeGreaterThanOrEqual(contentBox!.y + contentBox!.height - 2)
+  expect(markerBox!.y).toBeGreaterThanOrEqual(trigger2Box!.y + trigger2Box!.height - 2)
+})
+
+for (const animationDriver of ['css', 'reanimated']) {
+  test(`${animationDriver}: toggling and reversing samples numeric wrapper height`, async ({
+    page,
+  }) => {
+    await setupPage(page, {
+      name: 'AccordionDefaultOpenCase',
+      type: 'useCase',
+      searchParams: { animationDriver },
+    })
+
+    const result = await page.evaluate(async () => {
+      const trigger = document.getElementById('def-trigger2')
+      const wrapper = document.getElementById('def-height2')
+      const marker = document.getElementById('after-accordion-marker')
+      if (!trigger || !wrapper || !marker) throw new Error('accordion test nodes missing')
+
+      const sampleFor = async (durationMs: number) => {
+        const samples: Array<{ height: number; markerY: number }> = []
+        const startedAt = performance.now()
+        do {
+          await new Promise(requestAnimationFrame)
+          samples.push({
+            height: Number.parseFloat(getComputedStyle(wrapper).height),
+            markerY: marker.getBoundingClientRect().y,
+          })
+        } while (performance.now() - startedAt < durationMs)
+        return samples
+      }
+
+      trigger.click()
+      const opening = await sampleFor(450)
+      const initialOpenHeight = opening.at(-1)?.height ?? 0
+
+      const resize = document.getElementById('grow-content')
+      if (!resize) throw new Error('accordion resize control missing')
+      resize.click()
+      const resizing = await sampleFor(450)
+      const openHeight = resizing.at(-1)?.height ?? 0
+
+      trigger.click()
+      const closingBeforeReverse = await sampleFor(100)
+      trigger.click()
+      const reopening = await sampleFor(450)
+
+      trigger.click()
+      const closing = await sampleFor(450)
+
+      return {
+        opening,
+        initialOpenHeight,
+        resizing,
+        openHeight,
+        closingBeforeReverse,
+        reopening,
+        closing,
+      }
+    })
+
+    expect(result.initialOpenHeight).toBeGreaterThan(10)
+    expect(
+      result.opening.some(
+        ({ height }) => height > 1 && height < result.initialOpenHeight - 1
+      )
+    ).toBe(true)
+    expect(result.openHeight).toBeGreaterThan(result.initialOpenHeight)
+    expect(
+      result.resizing.some(
+        ({ height }) =>
+          height > result.initialOpenHeight + 1 && height < result.openHeight - 1
+      )
+    ).toBe(true)
+
+    const beforeReverse = result.closingBeforeReverse.at(-1)?.height ?? 0
+    const afterReverse = result.reopening[0]?.height ?? 0
+    expect(beforeReverse).toBeGreaterThan(1)
+    expect(beforeReverse).toBeLessThan(result.openHeight - 1)
+    expect(afterReverse).toBeGreaterThan(1)
+    expect(afterReverse).toBeLessThan(result.openHeight - 1)
+    expect(Math.abs(afterReverse - beforeReverse)).toBeLessThan(15)
+    expect(result.reopening.at(-1)?.height).toBeCloseTo(result.openHeight, 0)
+
+    expect(
+      result.closing.some(({ height }) => height > 1 && height < result.openHeight - 1)
+    ).toBe(true)
+    expect(result.closing.at(-1)?.height).toBeLessThanOrEqual(1)
+    expect(result.closing.at(-1)?.markerY).toBeLessThan(result.closing[0]?.markerY ?? 0)
+    await expect(page.locator('#def-content2')).toHaveCount(0)
+  })
+}

--- a/code/kitchen-sink/tests/Accordion.test.tsx
+++ b/code/kitchen-sink/tests/Accordion.test.tsx
@@ -13,12 +13,17 @@ for (const animationDriver of ['css', 'reanimated']) {
   }) => {
     await page.addInitScript(() => {
       globalThis['__accordionFirstFrames'] = []
-      const startedAt = performance.now()
+      // the sampling window starts at the first frame the accordion exists, not
+      // at script init — under load the page can take longer than any fixed
+      // budget to appear, and a window that expires early would assert on an
+      // empty array (a vacuous pass/fail)
+      let firstSampleAt: number | null = null
       const sample = () => {
         const wrapper = document.getElementById('def-height')
         const content = document.getElementById('def-content')
         const marker = document.getElementById('after-accordion-marker')
         if (wrapper && content && marker) {
+          if (firstSampleAt === null) firstSampleAt = performance.now()
           const wrapperRect = wrapper.getBoundingClientRect()
           const contentRect = content.getBoundingClientRect()
           const markerRect = marker.getBoundingClientRect()
@@ -28,7 +33,9 @@ for (const animationDriver of ['css', 'reanimated']) {
             markerY: markerRect.y,
           })
         }
-        if (performance.now() - startedAt < 2000) requestAnimationFrame(sample)
+        if (firstSampleAt === null || performance.now() - firstSampleAt < 1200) {
+          requestAnimationFrame(sample)
+        }
       }
       requestAnimationFrame(sample)
     })
@@ -38,12 +45,16 @@ for (const animationDriver of ['css', 'reanimated']) {
       type: 'useCase',
       searchParams: { animationDriver },
     })
-    await page.waitForTimeout(100)
+    await page.waitForFunction(
+      () => globalThis['__accordionFirstFrames'].length > 20,
+      undefined,
+      { timeout: 30_000 }
+    )
 
     const frames = await page.evaluate<
       Array<{ wrapperHeight: number; contentBottom: number; markerY: number }>
     >(() => globalThis['__accordionFirstFrames'])
-    expect(frames.length).toBeGreaterThan(1)
+    expect(frames.length).toBeGreaterThan(20)
     expect(
       Math.min(...frames.map(({ wrapperHeight }) => wrapperHeight)),
       JSON.stringify(frames)

--- a/code/kitchen-sink/tests/Accordion.test.tsx
+++ b/code/kitchen-sink/tests/Accordion.test.tsx
@@ -116,12 +116,17 @@ for (const animationDriver of ['css', 'reanimated']) {
       trigger.click()
       const opening = await sampleFor(450)
       const initialOpenHeight = opening.at(-1)?.height ?? 0
+      // once the open animation settles the wrapper releases back to auto
+      // (no inline height), so content and viewport changes stay fluid
+      await new Promise((resolve) => setTimeout(resolve, 300))
+      const inlineAfterOpen = (wrapper as HTMLElement).style.height
 
       const resize = document.getElementById('grow-content')
       if (!resize) throw new Error('accordion resize control missing')
       resize.click()
       const resizing = await sampleFor(450)
       const openHeight = resizing.at(-1)?.height ?? 0
+      const inlineAfterResize = (wrapper as HTMLElement).style.height
 
       trigger.click()
       const closingBeforeReverse = await sampleFor(100)
@@ -134,8 +139,10 @@ for (const animationDriver of ['css', 'reanimated']) {
       return {
         opening,
         initialOpenHeight,
+        inlineAfterOpen,
         resizing,
         openHeight,
+        inlineAfterResize,
         closingBeforeReverse,
         reopening,
         closing,
@@ -148,13 +155,11 @@ for (const animationDriver of ['css', 'reanimated']) {
         ({ height }) => height > 1 && height < result.initialOpenHeight - 1
       )
     ).toBe(true)
+    // at rest the wrapper is auto height: content growth applies immediately
+    // and no inline pixel height lingers
+    expect(result.inlineAfterOpen).toBe('')
     expect(result.openHeight).toBeGreaterThan(result.initialOpenHeight)
-    expect(
-      result.resizing.some(
-        ({ height }) =>
-          height > result.initialOpenHeight + 1 && height < result.openHeight - 1
-      )
-    ).toBe(true)
+    expect(result.inlineAfterResize).toBe('')
 
     const beforeReverse = result.closingBeforeReverse.at(-1)?.height ?? 0
     const afterReverse = result.reopening[0]?.height ?? 0

--- a/code/kitchen-sink/tests/Accordion.test.tsx
+++ b/code/kitchen-sink/tests/Accordion.test.tsx
@@ -167,9 +167,7 @@ for (const animationDriver of ['css', 'reanimated']) {
     expect(beforeReverse).toBeLessThan(result.openHeight - 1)
     expect(afterReverse).toBeGreaterThan(1)
     expect(afterReverse).toBeLessThan(result.openHeight - 1)
-    expect(Math.abs(afterReverse - beforeReverse)).toBeLessThan(
-      result.openHeight * 0.2
-    )
+    expect(Math.abs(afterReverse - beforeReverse)).toBeLessThan(result.openHeight * 0.2)
     expect(result.reopening.at(-1)?.height).toBeCloseTo(result.openHeight, 0)
 
     expect(

--- a/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
+++ b/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
@@ -68,3 +68,46 @@ test('native driver: accordion height opens through intermediate frames and clos
   ).toBe(true)
   expect(result.closing.at(-1)).toBeLessThanOrEqual(1)
 })
+
+// once an open item settles it releases its measured pixel height back to auto,
+// so later content growth stays fluid. the native driver previously kept the
+// settled height's Animated.Value forever, pinning the wrapper at the old pixel
+// value: released-to-auto never took effect and growing the content stayed
+// clipped. the driver now drops animated keys that left the incoming style.
+test('native driver: settled accordion releases to auto and follows content growth', async ({
+  page,
+}) => {
+  await setupPage(page, {
+    name: 'AccordionDefaultOpenCase',
+    type: 'useCase',
+    searchParams: { animationDriver: 'native' },
+  })
+
+  await page.waitForSelector('#def-trigger2', { timeout: 30_000 })
+
+  const wrapperHeight = () =>
+    page.$eval('#def-height2', (el) => Math.round(el.getBoundingClientRect().height))
+  const wrapperInlineHeight = () =>
+    page.$eval('#def-height2', (el) => (el as HTMLElement).style.height)
+
+  await page.click('#def-trigger2')
+  // open animation (300ms) + the 100ms quiet window before release to auto
+  await page.waitForTimeout(900)
+
+  const settledHeight = await wrapperHeight()
+  // released back to auto: the driver cleared the pinned inline pixel height
+  expect(await wrapperInlineHeight()).toBe('')
+  expect(settledHeight).toBeGreaterThan(10)
+
+  // grow the content: an auto wrapper must follow the taller measurement
+  await page.click('#grow-content')
+  await page.waitForTimeout(700)
+  const grownHeight = await wrapperHeight()
+  expect(grownHeight).toBeGreaterThan(settledHeight + 5)
+
+  // shrink back: the wrapper follows down again
+  await page.click('#grow-content')
+  await page.waitForTimeout(700)
+  const shrunkHeight = await wrapperHeight()
+  expect(shrunkHeight).toBeLessThan(grownHeight - 5)
+})

--- a/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
+++ b/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
@@ -95,8 +95,8 @@ test('native driver: settled accordion releases to auto and follows content grow
   await page.waitForTimeout(900)
 
   const settledHeight = await wrapperHeight()
-  // released back to auto: the driver cleared the pinned inline pixel height
-  expect(await wrapperInlineHeight()).toBe('')
+  // released back to auto: no pinned inline pixel height remains
+  expect((await wrapperInlineHeight()).endsWith('px')).toBe(false)
   expect(settledHeight).toBeGreaterThan(10)
 
   // grow the content: an auto wrapper must follow the taller measurement

--- a/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
+++ b/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
@@ -56,10 +56,7 @@ test('native driver: accordion height opens through intermediate frames and clos
   // no single frame covers the whole distance (would indicate a snap)
   const maxOpenJump = result.opening
     .slice(1)
-    .reduce(
-      (max, height, i) => Math.max(max, Math.abs(height - result.opening[i])),
-      0
-    )
+    .reduce((max, height, i) => Math.max(max, Math.abs(height - result.opening[i])), 0)
   expect(maxOpenJump).toBeLessThan(result.openHeight - 1)
 
   // closing tweens back down through intermediate heights and lands at 0

--- a/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
+++ b/code/kitchen-sink/tests/AccordionNativeDriver.test.tsx
@@ -1,0 +1,70 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+// the @tamagui/animations-react-native driver (animationDriver=native) previously
+// snapped Accordion.HeightAnimator open/closed: height was not in any animatable
+// key map so it landed in the static style and jumped 0 -> full in one frame.
+// layout dimension keys now animate on the JS driver. these assertions are
+// behavioral: opening must pass through intermediate heights, closing must tween
+// down to 0.
+test('native driver: accordion height opens through intermediate frames and closes to 0', async ({
+  page,
+}) => {
+  await setupPage(page, {
+    name: 'AccordionDefaultOpenCase',
+    type: 'useCase',
+    searchParams: { animationDriver: 'native' },
+  })
+
+  await page.waitForSelector('#def-trigger2', { timeout: 30_000 })
+
+  const result = await page.evaluate(async () => {
+    const trigger = document.getElementById('def-trigger2')
+    const wrapper = document.getElementById('def-height2')
+    if (!trigger || !wrapper) throw new Error('accordion test nodes missing')
+
+    const sampleFor = async (durationMs: number) => {
+      const heights: number[] = []
+      const startedAt = performance.now()
+      do {
+        await new Promise(requestAnimationFrame)
+        heights.push(wrapper.getBoundingClientRect().height)
+      } while (performance.now() - startedAt < durationMs)
+      return heights
+    }
+
+    trigger.click()
+    const opening = await sampleFor(600)
+    const openHeight = opening.at(-1) ?? 0
+
+    trigger.click()
+    const closing = await sampleFor(600)
+
+    return { opening, openHeight, closing }
+  })
+
+  // fully opens to a real height
+  expect(result.openHeight).toBeGreaterThan(10)
+
+  // opening is smooth: passes through heights strictly between 0 and the final,
+  // rather than a single jump straight to openHeight
+  expect(
+    result.opening.some((height) => height > 1 && height < result.openHeight - 1)
+  ).toBe(true)
+
+  // no single frame covers the whole distance (would indicate a snap)
+  const maxOpenJump = result.opening
+    .slice(1)
+    .reduce(
+      (max, height, i) => Math.max(max, Math.abs(height - result.opening[i])),
+      0
+    )
+  expect(maxOpenJump).toBeLessThan(result.openHeight - 1)
+
+  // closing tweens back down through intermediate heights and lands at 0
+  expect(
+    result.closing.some((height) => height > 1 && height < result.openHeight - 1)
+  ).toBe(true)
+  expect(result.closing.at(-1)).toBeLessThanOrEqual(1)
+})

--- a/code/kitchen-sink/tests/ExitStyleNewKey.test.tsx
+++ b/code/kitchen-sink/tests/ExitStyleNewKey.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+// a style key first introduced by exitStyle (borderWidth / y here, no base
+// value) must animate over the exit duration and gate exit completion. the
+// regression unmounted the element in the same cycle because such keys were
+// emitted as plain values and excluded from the pending exit key set.
+test('exitStyle-introduced keys animate and hold unmount for the exit duration', async ({
+  page,
+}) => {
+  await setupPage(page, {
+    name: 'ExitStyleNewKeyCase',
+    type: 'useCase',
+    searchParams: { animationDriver: 'reanimated' },
+  })
+
+  const target = page.locator('#exit-new-key-target')
+  await expect(target).toBeVisible()
+
+  const result = await page.evaluate(async () => {
+    const hide = document.querySelector<HTMLElement>(
+      '[data-testid="exit-new-key-hide"]'
+    )!
+    hide.click()
+    const samples: Array<{ t: number; borderWidth: number; y: number }> = []
+    const startedAt = performance.now()
+    let mountedAt150 = false
+    do {
+      await new Promise(requestAnimationFrame)
+      const el = document.getElementById('exit-new-key-target')
+      const elapsed = performance.now() - startedAt
+      if (el) {
+        if (elapsed >= 120) mountedAt150 = true
+        const cs = getComputedStyle(el)
+        const matrix = cs.transform !== 'none' ? new DOMMatrix(cs.transform) : null
+        samples.push({
+          t: Math.round(elapsed),
+          borderWidth: Number.parseFloat(cs.borderTopWidth) || 0,
+          y: matrix ? matrix.m42 : 0,
+        })
+      }
+    } while (performance.now() - startedAt < 1500)
+    const el = document.getElementById('exit-new-key-target')
+    return { samples, mountedAt150, mountedAtEnd: !!el }
+  })
+
+  // the exit duration (300ms) must be respected: still mounted mid-exit,
+  // unmounted once complete
+  expect(result.mountedAt150).toBe(true)
+  expect(result.mountedAtEnd).toBe(false)
+
+  // the exitStyle-introduced keys must actually animate: intermediate values
+  // strictly between the implicit start (0) and the exit target
+  expect(
+    result.samples.some(({ borderWidth }) => borderWidth > 0.5 && borderWidth < 9.5),
+    JSON.stringify(result.samples.slice(0, 25))
+  ).toBe(true)
+  expect(result.samples.some(({ y }) => y > 2 && y < 38)).toBe(true)
+})

--- a/code/kitchen-sink/tests/ExitStyleNewKey.test.tsx
+++ b/code/kitchen-sink/tests/ExitStyleNewKey.test.tsx
@@ -19,9 +19,7 @@ test('exitStyle-introduced keys animate and hold unmount for the exit duration',
   await expect(target).toBeVisible()
 
   const result = await page.evaluate(async () => {
-    const hide = document.querySelector<HTMLElement>(
-      '[data-testid="exit-new-key-hide"]'
-    )!
+    const hide = document.querySelector<HTMLElement>('[data-testid="exit-new-key-hide"]')!
     hide.click()
     const samples: Array<{ t: number; borderWidth: number; y: number }> = []
     const startedAt = performance.now()

--- a/code/kitchen-sink/tests/ToggleGroupFilledActive.test.tsx
+++ b/code/kitchen-sink/tests/ToggleGroupFilledActive.test.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test'
+
+import { setupPage } from './test-utils'
+
+// regression: a styled(ToggleGroup.Item) variant that sets a resting
+// backgroundColor used to override activeStyle, because that resting value
+// reached Toggle as a plain prop in buttonProps and was spread AFTER the
+// activeStyle merge. the active item stayed stuck at its resting color.
+test.beforeEach(async ({ page }) => {
+  await setupPage(page, { name: 'ToggleGroupFilledActiveCase', type: 'useCase' })
+})
+
+const GREEN = 'rgb(0, 128, 0)'
+const RED = 'rgb(255, 0, 0)'
+
+test('filled variant: activeStyle wins on the initially-active item', async ({
+  page,
+}) => {
+  // filled-a is active by default; activeStyle green must beat resting red
+  await expect(page.locator('#filled-a')).toHaveCSS('background-color', GREEN)
+  // inactive filled item keeps its resting red
+  await expect(page.locator('#filled-b')).toHaveCSS('background-color', RED)
+})
+
+test('filled variant: activeStyle follows selection changes', async ({ page }) => {
+  await page.click('#filled-b')
+  await page.mouse.move(2, 2) // move off so hover styles do not mask the resting color
+  await expect(page.locator('#filled-b')).toHaveCSS('background-color', GREEN)
+  await expect(page.locator('#filled-a')).toHaveCSS('background-color', RED)
+})

--- a/code/kitchen-sink/webpack.config.js
+++ b/code/kitchen-sink/webpack.config.js
@@ -27,6 +27,10 @@ module.exports = {
     minimize: false,
   },
   resolve: {
+    // workspace packages rebuild their dist while the dev server runs; the
+    // default resolver cache pins a failed resolution from mid-rebuild until
+    // restart, so trade a little resolve speed for correctness
+    unsafeCache: false,
     mainFields: ['module:jsx', 'browser', 'module', 'main'],
     extensions: ['.web.tsx', '.web.ts', '.ts', '.tsx', '.js'],
     alias: {
@@ -50,6 +54,12 @@ module.exports = {
       'react-native-web': path.resolve(__dirname, '../../node_modules/react-native-web'),
       'react-native-svg': '@tamagui/react-native-svg',
     },
+  },
+  // workspace package rebuilds delete and rewrite their dist while the dev
+  // server watches; compiling mid-rebuild caches a failed resolution. debounce
+  // long enough that a package rebuild finishes before webpack recompiles.
+  watchOptions: {
+    aggregateTimeout: 1500,
   },
   devServer: {
     client: {

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -624,15 +624,19 @@ const HeightAnimator = View.styleable((props, ref) => {
 
   React.useEffect(() => () => clearTimeout(settleTimerRef.current), [])
 
-  // web: measure the just-mounted content synchronously in the same commit so
-  // the open animation retargets immediately instead of waiting a couple of
-  // frames for the ResizeObserver-backed onLayout to report
+  // measure the just-mounted content synchronously in the same commit so the
+  // open animation retargets immediately instead of waiting a layout-event
+  // roundtrip (ResizeObserver on web, an onLayout bridge hop on native — that
+  // hop alone costs a few hundred ms on a dev simulator). getBoundingClientRect
+  // exists on web elements and on Fabric host components; anywhere it doesn't,
+  // the onLayout below still owns measurement.
   useIsomorphicLayoutEffect(() => {
-    if (!isWeb || !fixed || !open) return
-    const el = innerRef.current as HTMLElement | null
-    if (!el) return
-    const naturalHeight = el.offsetHeight
-    if (naturalHeight > 0 && naturalHeight !== contentHeight) {
+    if (!fixed || !open) return
+    const el = innerRef.current as
+      | { getBoundingClientRect?: () => { height: number } }
+      | null
+    const naturalHeight = el?.getBoundingClientRect?.().height
+    if (naturalHeight && naturalHeight > 0 && naturalHeight !== contentHeight) {
       setContentHeight(naturalHeight)
     }
   })

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -637,13 +637,17 @@ const HeightAnimator = View.styleable((props, ref) => {
     }
   })
 
+  // rest renders an explicit 'auto' rather than removing the height style:
+  // removal makes drivers clear the key themselves (reanimated emits a null
+  // clear-value on native whose yoga semantics are driver-internal), while a
+  // committed 'auto' is deterministic on every driver and platform
   const height = fixed
     ? pinned
       ? lastOuterHeightRef.current
       : open
         ? contentHeight
         : 0
-    : undefined
+    : ('auto' as const)
 
   return (
     <View

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -632,9 +632,9 @@ const HeightAnimator = View.styleable((props, ref) => {
   // the onLayout below still owns measurement.
   useIsomorphicLayoutEffect(() => {
     if (!fixed || !open) return
-    const el = innerRef.current as
-      | { getBoundingClientRect?: () => { height: number } }
-      | null
+    const el = innerRef.current as {
+      getBoundingClientRect?: () => { height: number }
+    } | null
     const naturalHeight = el?.getBoundingClientRect?.().height
     if (naturalHeight && naturalHeight > 0 && naturalHeight !== contentHeight) {
       setContentHeight(naturalHeight)

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -600,7 +600,7 @@ const HeightAnimator = View.styleable((props, ref) => {
     : 0
 
   return (
-    <View ref={ref} {...rest} position="relative" height={height} overflow="hidden">
+    <View ref={ref} position="relative" {...rest} height={height} overflow="hidden">
       <View
         position={measureInFlow ? 'relative' : 'absolute'}
         top={measureInFlow ? undefined : 0}

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -593,6 +593,7 @@ const HeightAnimator = View.styleable((props, ref) => {
   const [pinned, setPinned] = React.useState(false)
   const [contentHeight, setContentHeight] = React.useState(0)
   const outerRef = React.useRef<TamaguiElement | null>(null)
+  const innerRef = React.useRef<TamaguiElement | null>(null)
   const composedRef = useComposedRefs(outerRef, ref)
   const lastOuterHeightRef = React.useRef(0)
   const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -622,6 +623,19 @@ const HeightAnimator = View.styleable((props, ref) => {
   }, [pinned])
 
   React.useEffect(() => () => clearTimeout(settleTimerRef.current), [])
+
+  // web: measure the just-mounted content synchronously in the same commit so
+  // the open animation retargets immediately instead of waiting a couple of
+  // frames for the ResizeObserver-backed onLayout to report
+  useIsomorphicLayoutEffect(() => {
+    if (!isWeb || !fixed || !open) return
+    const el = innerRef.current as HTMLElement | null
+    if (!el) return
+    const naturalHeight = el.offsetHeight
+    if (naturalHeight > 0 && naturalHeight !== contentHeight) {
+      setContentHeight(naturalHeight)
+    }
+  })
 
   const height = fixed
     ? pinned
@@ -654,6 +668,7 @@ const HeightAnimator = View.styleable((props, ref) => {
       }}
     >
       <View
+        ref={innerRef}
         position={fixed ? 'absolute' : 'relative'}
         top={fixed ? 0 : undefined}
         left={fixed ? 0 : undefined}

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -1,7 +1,7 @@
 import { Collapsible } from '@tamagui/collapsible'
 import { createCollection } from '@tamagui/collection'
 import { useComposedRefs } from '@tamagui/compose-refs'
-import { isWeb } from '@tamagui/constants'
+import { isWeb, useIsomorphicLayoutEffect } from '@tamagui/constants'
 import type { GetProps, GetRef, TamaguiElement } from '@tamagui/core'
 import { View, createStyledContext, styled } from '@tamagui/core'
 import { composeEventHandlers, withStaticProperties } from '@tamagui/helpers'
@@ -581,35 +581,87 @@ const AccordionContent = AccordionContentFrame.styleable(function AccordionConte
 const HeightAnimator = View.styleable((props, ref) => {
   const itemContext = useAccordionItemContext()
   const { children, ...rest } = props
-  const useInitialNaturalLayout = React.useRef(itemContext.open)
-  const [measuredHeight, setMeasuredHeight] = React.useState<number>()
+  const open = !!itemContext.open
 
-  if (!itemContext.open || measuredHeight !== undefined) {
-    useInitialNaturalLayout.current = false
+  // at rest an open item renders auto height with the child in normal flow, so
+  // content and viewport changes stay fluid with no JS involved. any open/close
+  // animation switches to a measured pixel height over an absolutely positioned
+  // child, animates, and releases back to auto once the outer settles at its
+  // target. closing from rest pins the current measured height for one commit
+  // (so drivers see a numeric start value) before targeting 0.
+  const [fixed, setFixed] = React.useState(!open)
+  const [pinned, setPinned] = React.useState(false)
+  const [contentHeight, setContentHeight] = React.useState(0)
+  const outerRef = React.useRef<TamaguiElement | null>(null)
+  const composedRef = useComposedRefs(outerRef, ref)
+  const lastOuterHeightRef = React.useRef(0)
+  const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  )
+  const prevOpenRef = React.useRef(open)
+
+  if (prevOpenRef.current !== open) {
+    prevOpenRef.current = open
+    clearTimeout(settleTimerRef.current)
+    if (!fixed) {
+      setFixed(true)
+      setPinned(true)
+    }
   }
-  const measureInFlow = useInitialNaturalLayout.current
 
-  // default-open content contributes its intrinsic size until the first measurement,
-  // avoiding a collapsed first paint. initially-closed content stays clipped at zero
-  // until its mounted child reports a numeric height, which gives every animation
-  // driver numeric endpoints. after that first natural pass, the absolute measuring
-  // child is independent of the animated outer height and keeps its last open layout
-  // through close and unmount.
-  const height = itemContext.open
-    ? (measuredHeight ?? (measureInFlow ? undefined : 0))
-    : 0
+  // the pin commit paints the current height as a pixel value. flush styles,
+  // then retarget in a second pre-paint commit so drivers animate from the
+  // pinned number instead of jumping out of auto.
+  useIsomorphicLayoutEffect(() => {
+    if (!pinned) return
+    if (isWeb) {
+      // reading layout forces the style flush; the value itself is unused
+      void (outerRef.current as HTMLElement | null)?.offsetHeight
+    }
+    setPinned(false)
+  }, [pinned])
+
+  React.useEffect(() => () => clearTimeout(settleTimerRef.current), [])
+
+  const height = fixed
+    ? pinned
+      ? lastOuterHeightRef.current
+      : open
+        ? contentHeight
+        : 0
+    : undefined
 
   return (
-    <View ref={ref} position="relative" {...rest} height={height} overflow="hidden">
+    <View
+      ref={composedRef}
+      position="relative"
+      {...rest}
+      height={height}
+      overflow="hidden"
+      onLayout={({ nativeEvent }) => {
+        const outerHeight = nativeEvent.layout.height
+        lastOuterHeightRef.current = outerHeight
+        // release to auto shortly after the animated outer stays at the open
+        // target: layout events only fire on change, so a quiet 100ms inside
+        // the target band means the animation settled (an out-of-band event —
+        // a spring overshooting through the target — cancels the release)
+        clearTimeout(settleTimerRef.current)
+        if (fixed && !pinned && open && contentHeight > 0) {
+          if (Math.abs(outerHeight - contentHeight) < 1) {
+            settleTimerRef.current = setTimeout(() => setFixed(false), 100)
+          }
+        }
+      }}
+    >
       <View
-        position={measureInFlow ? 'relative' : 'absolute'}
-        top={measureInFlow ? undefined : 0}
-        left={measureInFlow ? undefined : 0}
-        right={measureInFlow ? undefined : 0}
+        position={fixed ? 'absolute' : 'relative'}
+        top={fixed ? 0 : undefined}
+        left={fixed ? 0 : undefined}
+        right={fixed ? 0 : undefined}
         onLayout={({ nativeEvent }) => {
-          const nextHeight = nativeEvent.layout.height
-          if (itemContext.open && nextHeight !== measuredHeight) {
-            setMeasuredHeight(nextHeight)
+          const naturalHeight = nativeEvent.layout.height
+          if (fixed && open && naturalHeight !== contentHeight) {
+            setContentHeight(naturalHeight)
           }
         }}
       >

--- a/code/ui/accordion/src/Accordion.tsx
+++ b/code/ui/accordion/src/Accordion.tsx
@@ -581,27 +581,35 @@ const AccordionContent = AccordionContentFrame.styleable(function AccordionConte
 const HeightAnimator = View.styleable((props, ref) => {
   const itemContext = useAccordionItemContext()
   const { children, ...rest } = props
-  const [measuredHeight, setMeasuredHeight] = React.useState<number>(0)
-  const hasMeasured = measuredHeight > 0
+  const useInitialNaturalLayout = React.useRef(itemContext.open)
+  const [measuredHeight, setMeasuredHeight] = React.useState<number>()
 
-  // when open and not measured yet, use auto so SSR shows content
-  // once measured, use numeric height for animations
-  const height = itemContext.open ? (hasMeasured ? measuredHeight : 'auto') : 0
+  if (!itemContext.open || measuredHeight !== undefined) {
+    useInitialNaturalLayout.current = false
+  }
+  const measureInFlow = useInitialNaturalLayout.current
 
-  // for SSR: when open but not yet measured, use static positioning so content
-  // contributes to parent height. after measurement, use absolute for animations.
-  const shouldAbsolutePosition = hasMeasured || !itemContext.open
+  // default-open content contributes its intrinsic size until the first measurement,
+  // avoiding a collapsed first paint. initially-closed content stays clipped at zero
+  // until its mounted child reports a numeric height, which gives every animation
+  // driver numeric endpoints. after that first natural pass, the absolute measuring
+  // child is independent of the animated outer height and keeps its last open layout
+  // through close and unmount.
+  const height = itemContext.open
+    ? (measuredHeight ?? (measureInFlow ? undefined : 0))
+    : 0
 
   return (
-    <View ref={ref} height={height} position="relative" {...rest}>
+    <View ref={ref} {...rest} position="relative" height={height} overflow="hidden">
       <View
-        position={shouldAbsolutePosition ? 'absolute' : 'relative'}
-        top={shouldAbsolutePosition ? 0 : undefined}
-        left={shouldAbsolutePosition ? 0 : undefined}
-        right={shouldAbsolutePosition ? 0 : undefined}
+        position={measureInFlow ? 'relative' : 'absolute'}
+        top={measureInFlow ? undefined : 0}
+        left={measureInFlow ? undefined : 0}
+        right={measureInFlow ? undefined : 0}
         onLayout={({ nativeEvent }) => {
-          if (nativeEvent.layout.height && nativeEvent.layout.height !== measuredHeight) {
-            setMeasuredHeight(nativeEvent.layout.height)
+          const nextHeight = nativeEvent.layout.height
+          if (itemContext.open && nextHeight !== measuredHeight) {
+            setMeasuredHeight(nextHeight)
           }
         }}
       >

--- a/code/ui/toggle-group/src/Toggle.tsx
+++ b/code/ui/toggle-group/src/Toggle.tsx
@@ -129,13 +129,17 @@ export const Toggle = React.forwardRef<TamaguiElement, ToggleProps>(
           !unstyled && {
             defaultActiveStyle: true,
           })}
+        {...buttonProps}
+        // spread activeStyle after buttonProps so it wins when active: a styled()
+        // variant (e.g. a resting `backgroundColor`) forwards that value as a plain
+        // prop into buttonProps, which would otherwise clobber the activeStyle merge
+        // on overlapping keys and leave the active item stuck at its resting style.
         {...(active &&
           activeStyle && {
             ...(activeStyle as any),
             hoverStyle: activeStyle,
             focusStyle: activeStyle,
           })}
-        {...buttonProps}
         ref={forwardedRef}
         onPress={composeEventHandlers(props.onPress ?? undefined, () => {
           if (!props.disabled) {

--- a/package.json
+++ b/package.json
@@ -188,6 +188,7 @@
     "uuid": "11.1.1",
     "vite": "8.0.16",
     "vitest": "4.1.0",
+    "websocket-driver": "0.7.5",
     "whatwg-url": "14.1.1",
     "ws": "8.21.0",
     "yaml": "2.8.3"


### PR DESCRIPTION
Bundle of v2 animation reliability fixes, validated before the v3 campaign and parked since. Opening now to re-validate against current `main`.

## Reanimated driver
- Normalize processed native colors, and never interpolate colors reanimated can't parse (fixes the native `transparentNaN` redbox).
- `exitStyle`-introduced keys animate from implicit defaults, and exit completion is gated properly.
- Persistent key carry + mapper-fresh seeding closes the enter/accordion ownership gap.
- Drop an unused `isMounting` dep from the styles memo.

## React Native driver
- Animate layout dimension keys with the JS driver; guard unparseable colors.
- Drop animated values whose keys left the style, so released layout keys return to `auto`.

## Accordion
- `HeightAnimator` releases to auto height at rest and pins pixels only while animating.
- Rest renders explicit auto height, so release never depends on driver clear-value semantics.
- Web: measure mounted content synchronously so the open animation starts in the same commit.
- Native: sync-measure content via Fabric `getBoundingClientRect`, with poll-based e2e sampling.

## Other
- Toggle preserves active styles.
- Pin `websocket-driver` to a patched version.

## Status

CI was green on this branch at `1d53ccf7f3` before it was parked. `main` has moved since, so this PR exists to re-validate against it. **Not requesting a release** — merge and publish are separate calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)