### PR TITLE
fix(toast): forward aria-label instead of the removed accessibilityLabel prop

### DIFF
--- a/code/ui/toast/src/ToastComposable.tsx
+++ b/code/ui/toast/src/ToastComposable.tsx
@@ -1136,7 +1136,10 @@ const ToastItemInner = createStyledHOC(ToastItemFrame)<ToastItemProps>(
       <ToastPositionWrapper
         ref={ref}
         testID={rest.testID}
-        accessibilityLabel={rest.accessibilityLabel}
+        // v2 removed the deprecated a11y props in favour of web standards, so
+        // `accessibilityLabel` is no longer mapped and reaches the DOM verbatim —
+        // React then warns about an unrecognised prop on every toast.
+        aria-label={rest['aria-label']}
         {...dataAttributes}
         transition={
           isDragging || ctx.reducedMotion ? undefined : removed ? '200ms' : '400ms'


### PR DESCRIPTION
Every toast logged a React warning in the consumer's console:

> React does not recognize the `accessibilityLabel` prop on a DOM element...

## Cause

v2 removed the deprecated a11y props in favour of web standards — see the note in `code/core/web/src/types.tsx` (`accessibilityLabel → aria-label`, `accessibilityRole → role`, ...). `ToastComposable.tsx` still hoisted `accessibilityLabel` onto the position wrapper, so it is no longer mapped and reaches the DOM verbatim.

React warns even though our own demo leaves the value `undefined`, because the key is still forwarded.

The rest of this same file already uses `aria-label` (lines 583, 1260) — this one line was the odd one out.

## Verified

Measured with a headless Playwright probe counting `accessibilityLabel` console warnings on the kitchen-sink Toast demo:

| | warnings |
|---|---|
| before | **1** |
| after | **0** |

Also confirmed it was toast-specific rather than ambient: the same probe against `?demo=Button` reported **0** both before and after.

No in-repo caller passes `accessibilityLabel` to `Toast.Item`, so this changes no working usage. Consumers on v3 should use `aria-label`, which is the documented replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)