### PR TITLE
fix(image): resolve Tamagui props before rendering native images

### DIFF
--- a/code/ui/components-test/Image.native.test.tsx
+++ b/code/ui/components-test/Image.native.test.tsx
@@ -1,0 +1,120 @@
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { createImage } from '@tamagui/image'
+import { TamaguiProvider, createTamagui, setMediaState } from '@tamagui/core'
+import React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import { afterEach, expect, test, vi } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig('native'))
+const HostImage = React.forwardRef<any, any>((props, ref) =>
+  React.createElement('image-host', { ...props, ref })
+)
+const Image = createImage({ Component: HostImage })
+
+afterEach(() => {
+  setMediaState({})
+})
+
+function flattenStyle(style: any): Record<string, any> {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style.map(flattenStyle))
+  }
+
+  return style || {}
+}
+
+test('Image resolves Tamagui styles and preserves native image props', async () => {
+  const source = { uri: 'https://example.com/image.png' }
+  const onLoad = vi.fn()
+  let rendered: TestRenderer.ReactTestRenderer
+  setMediaState({ sm: true } as any)
+
+  await act(async () => {
+    rendered = TestRenderer.create(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <Image
+          source={source}
+          objectFit="contain"
+          position="absolute"
+          t={1}
+          l={2}
+          r={3}
+          b={4}
+          bg="$background"
+          br="$4"
+          aspectRatio={2}
+          $sm={{ opacity: 0.5 }}
+          accessibilityLabel="test image"
+          onLoad={onLoad}
+        />
+      </TamaguiProvider>
+    )
+  })
+
+  const hostImage = rendered!.root.findByType('image-host')
+  const style = flattenStyle(hostImage.props.style)
+
+  expect(style).toMatchObject({
+    position: 'absolute',
+    top: 1,
+    left: 2,
+    right: 3,
+    bottom: 4,
+    aspectRatio: 2,
+    opacity: 0.5,
+  })
+  expect(style.backgroundColor).toBeTruthy()
+  expect(style.borderTopLeftRadius).toBeTypeOf('number')
+  expect(style.borderTopRightRadius).toBe(style.borderTopLeftRadius)
+  expect(style.borderBottomLeftRadius).toBe(style.borderTopLeftRadius)
+  expect(style.borderBottomRightRadius).toBe(style.borderTopLeftRadius)
+  expect(hostImage.props.source).toEqual(source)
+  expect(hostImage.props.resizeMode).toBe('contain')
+  expect(hostImage.props.accessibilityLabel).toBe('test image')
+
+  await act(async () => {
+    hostImage.props.onLoad({
+      nativeEvent: {
+        source: {
+          width: 100,
+          height: 50,
+        },
+      },
+    })
+  })
+
+  expect(onLoad).toHaveBeenCalledWith({
+    target: {
+      naturalHeight: 50,
+      naturalWidth: 100,
+    },
+    type: 'load',
+  })
+
+  await act(async () => {
+    rendered!.unmount()
+  })
+})
+
+test('Image prefers src when both source props are provided', async () => {
+  let rendered: TestRenderer.ReactTestRenderer
+
+  await act(async () => {
+    rendered = TestRenderer.create(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <Image
+          src="https://example.com/preferred.png"
+          source={{ uri: 'https://example.com/deprecated.png' }}
+        />
+      </TamaguiProvider>
+    )
+  })
+
+  expect(rendered!.root.findByType('image-host').props.source).toMatchObject({
+    uri: 'https://example.com/preferred.png',
+  })
+
+  await act(async () => {
+    rendered!.unmount()
+  })
+})

--- a/code/ui/image/src/createImage.tsx
+++ b/code/ui/image/src/createImage.tsx
@@ -62,8 +62,15 @@ const defaultTransformSource = (props: {
   height?: any
 }) => {
   const { src, source, width, height } = props
-  if (source) return source
-  if (src && typeof src !== 'string') return src
+  if (typeof src === 'string') {
+    return {
+      uri: src,
+      width,
+      height,
+    }
+  }
+  if (source !== undefined && source !== null) return source
+  if (src !== undefined && src !== null) return src
   return {
     uri: src,
     width,
@@ -142,6 +149,7 @@ export function createImage<C extends ComponentType<any>>(
     const props = incomingProps as any
     const {
       src,
+      source,
       width,
       height,
       borderRadius,
@@ -171,6 +179,7 @@ export function createImage<C extends ComponentType<any>>(
 
     const finalSource = transformSource({
       src,
+      source,
       width: resolvedWidth,
       height: resolvedHeight,
     })
@@ -228,8 +237,7 @@ export function createImage<C extends ComponentType<any>>(
       }
     }
 
-    // Render the underlying Component directly to ensure all props pass through
-    return <Component ref={ref} {...finalProps} />
+    return <StyledImage ref={ref} {...finalProps} />
   }) as unknown as ImageType & React.FC<CombinedProps>
 
   // Add static methods if the component has them


### PR DESCRIPTION
## Summary

- render the styled image from the native styleable callback so Tamagui props resolve normally
- preserve image pass-through props and restore source handling
- add a native behavioral regression test for shorthands, themes, media styles, image props, and load events

## Source behavior note

This PR also restores the deprecated source prop because createImage currently overwrites source with a generated object without passing source to transformSource.

String src remains preferred when both props are supplied. For numeric asset src values, source wins when both are supplied, matching the v1 implementation. An AST scan found no existing Tamagui call site that explicitly supplies both props. If source removal was intentional for a stricter src-only API, the source hunk can be reviewed separately from the StyledImage fix.

## Validation

- reproduced the regression against unpatched 2.5.1: host style was {}
- @tamagui/image build passed
- focused native Image tests: 2 passed
- monorepo build: 162 of 162 tasks passed
- ImageTokenStyle Playwright tests: 3 passed
- oxfmt and oxlint passed
- downstream SootSim checks matched existing references: login grain spread 13, progress hatch spread 77

The broader native component run had 18 passing tests, while Select.native.test.tsx and SheetReanimated.native.test.tsx failed during collection in the fake React Native codegenNativeComponent setup.