### PR TITLE
ci: gate the v3 beta publish behind a required-reviewer environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,14 @@ jobs:
       github.event.workflow_run.head_branch == 'v3-beta'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # human gate: this job otherwise auto-publishes the first time Checks goes
+    # green on a v3-beta push. the environment pauses the job until a required
+    # reviewer approves it in the Actions UI. the protection rule lives in repo
+    # settings, not here: Settings -> Environments -> npm-publish-beta ->
+    # "Required reviewers" (add the approvers) or the job runs unpaused.
+    # if npmjs.com trusted publishing pins an environment name for these
+    # packages, it must match npm-publish-beta (or stay unset).
+    environment: npm-publish-beta
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
The beta publish job in release.yml fires automatically the first time Checks succeeds on a v3-beta push, with no human gate. This adds `environment: npm-publish-beta` to the job so it pauses for approval in the Actions UI before running.

Setup required after merge (repo Settings, not YAML): **Settings → Environments → New environment → `npm-publish-beta` → Required reviewers** (add approvers). Without the protection rule the environment exists but does not pause anything.

One interaction to verify: if the npm trusted-publisher config for these packages pins a GitHub environment name, it must be `npm-publish-beta` (or left unset). The job's OIDC claims will now carry this environment.

Deliberately NOT changed here: `BETA_VERSION` format and dist-tag logic (semantic beta numbering is a separate open decision).

The v3-beta copy of release.yml will be synced to match (the file is deliberately kept on both branches; only main's copy is evaluated for workflow_run).