### PR TITLE
fix(babel-plugin-fully-specified): never rewrite bare package specifiers

### DIFF
--- a/code/packages/babel-plugin-fully-specified/__tests__/fixtures/bare-package-collision/tamagui.js
+++ b/code/packages/babel-plugin-fully-specified/__tests__/fixtures/bare-package-collision/tamagui.js
@@ -1,0 +1,4 @@
+// a local file whose basename collides with a real package name ("tamagui").
+// its existence must not cause bare `import ... from 'tamagui'` in sibling
+// files to be rewritten to `tamagui.mjs`.
+export const config = 'local'

--- a/code/packages/babel-plugin-fully-specified/__tests__/fixtures/bare-package-collision/test.mjs
+++ b/code/packages/babel-plugin-fully-specified/__tests__/fixtures/bare-package-collision/test.mjs
@@ -1,0 +1,3 @@
+import { config } from 'tamagui'
+
+export * from './tamagui'

--- a/code/packages/babel-plugin-fully-specified/__tests__/index.test.ts
+++ b/code/packages/babel-plugin-fully-specified/__tests__/index.test.ts
@@ -100,6 +100,27 @@ describe('local re-exports', () => {
   })
 })
 
+describe('bare package specifiers', () => {
+  test('bare import is never rewritten', () => {
+    const example = "import { createTamagui } from 'tamagui'"
+    expect(getTransformResult(example)?.code).toBe(
+      "import { createTamagui } from 'tamagui';"
+    )
+  })
+
+  test('bare re-export is never rewritten', () => {
+    const example = "export * from 'tamagui'"
+    expect(getTransformResult(example)?.code).toBe("export * from 'tamagui';")
+  })
+
+  test('bare dynamic import() is never rewritten', () => {
+    const example = "const tamagui = await import('tamagui')"
+    expect(getTransformResult(example)?.code).toBe(
+      "const tamagui = await import('tamagui');"
+    )
+  })
+})
+
 describe('transforming actual files', () => {
   test('multiple extensions exists', () => {
     const { code } =
@@ -123,6 +144,20 @@ describe('transforming actual files', () => {
       ) || {}
 
     expect(code).toBe('export * from "./modules/tamagui.dev.config.mjs";')
+  })
+
+  test('bare specifier colliding with a local sibling file is not rewritten', () => {
+    const { code } =
+      transformFileSync(
+        path.join(__dirname, 'fixtures', 'bare-package-collision', 'test.mjs'),
+        getTransformOptions({
+          pluginOptions: { ensureFileExists: true },
+        })
+      ) || {}
+
+    expect(code).toBe(
+      ["import { config } from 'tamagui';", 'export * from "./tamagui.mjs";'].join('\n')
+    )
   })
 
   test('native output extension resolves native sibling files', () => {

--- a/code/packages/babel-plugin-fully-specified/permanent/cjs/index.js
+++ b/code/packages/babel-plugin-fully-specified/permanent/cjs/index.js
@@ -146,6 +146,11 @@ function getFullySpecifiedModuleSpecifier(
   originalModuleSpecifier,
   { filePath, options }
 ) {
+  if (
+    !originalModuleSpecifier.startsWith('.') &&
+    !originalModuleSpecifier.startsWith('/')
+  )
+    return null
   const fileExt = (0, import_node_path.extname)(filePath),
     fileDir = (0, import_node_path.dirname)(filePath),
     isDirectory = isLocalDirectory(

--- a/code/packages/babel-plugin-fully-specified/permanent/cjs/index.mjs
+++ b/code/packages/babel-plugin-fully-specified/permanent/cjs/index.mjs
@@ -159,6 +159,11 @@ function getFullySpecifiedModuleSpecifier(
   originalModuleSpecifier,
   { filePath, options }
 ) {
+  if (
+    !originalModuleSpecifier.startsWith('.') &&
+    !originalModuleSpecifier.startsWith('/')
+  )
+    return null
   const fileExt = (0, import_node_path.extname)(filePath),
     fileDir = (0, import_node_path.dirname)(filePath),
     isDirectory = isLocalDirectory(

--- a/code/packages/babel-plugin-fully-specified/permanent/esm/index.js
+++ b/code/packages/babel-plugin-fully-specified/permanent/esm/index.js
@@ -107,6 +107,11 @@ function getFullySpecifiedModuleSpecifier(
   originalModuleSpecifier,
   { filePath, options }
 ) {
+  if (
+    !originalModuleSpecifier.startsWith('.') &&
+    !originalModuleSpecifier.startsWith('/')
+  )
+    return null
   const fileExt = extname(filePath),
     fileDir = dirname(filePath),
     isDirectory = isLocalDirectory(resolve(fileDir, originalModuleSpecifier)),

--- a/code/packages/babel-plugin-fully-specified/permanent/esm/index.mjs
+++ b/code/packages/babel-plugin-fully-specified/permanent/esm/index.mjs
@@ -107,6 +107,11 @@ function getFullySpecifiedModuleSpecifier(
   originalModuleSpecifier,
   { filePath, options }
 ) {
+  if (
+    !originalModuleSpecifier.startsWith('.') &&
+    !originalModuleSpecifier.startsWith('/')
+  )
+    return null
   const fileExt = extname(filePath),
     fileDir = dirname(filePath),
     isDirectory = isLocalDirectory(resolve(fileDir, originalModuleSpecifier)),

--- a/code/packages/babel-plugin-fully-specified/src/index.ts
+++ b/code/packages/babel-plugin-fully-specified/src/index.ts
@@ -204,6 +204,19 @@ function getFullySpecifiedModuleSpecifier(
     options: FullySpecifiedOptions
   }
 ): string | null {
+  // bare package specifiers (e.g. `tamagui`, `react`) must never be rewritten:
+  // appending an extension produces an unresolvable package path. only
+  // relative/absolute specifiers are eligible (mirrors the guard in
+  // ./commonjs.ts). without this, a bare import that collides with a local
+  // sibling file of the same basename (e.g. `src/tamagui.ts` next to a file
+  // doing `import ... from 'tamagui'`) gets rewritten to `tamagui.mjs`.
+  if (
+    !originalModuleSpecifier.startsWith('.') &&
+    !originalModuleSpecifier.startsWith('/')
+  ) {
+    return null
+  }
+
   const fileExt = extname(filePath)
   const fileDir = dirname(filePath)
 


### PR DESCRIPTION
## Symptom

When a package's source directory contains a file whose basename equals a real package name — e.g. a `src/tamagui.ts` sitting next to a module that does `import { ... } from 'tamagui'` — the plugin rewrites the **bare** specifier `tamagui` to `from "tamagui.mjs"` in the emitted dist.

That specifier is unresolvable for every consumer of the published `dist/` (it's neither a relative path nor a valid package subpath), so every downstream import of the affected package fails. We hit this in production: it broke the web/SPA builds of our app the moment a file named `tamagui.ts` landed next to a module importing the real `tamagui` package.

## Root cause

`getFullySpecifiedModuleSpecifier()` in `src/index.ts` probes the filesystem (`isLocalDirectory`, `tryExtensions` candidates) for **any** specifier without first checking that the specifier is relative (`./…`) or absolute (`/…`). Bare package specifiers (`tamagui`, `react`, …) must never be extension-rewritten — appending an extension always produces an unresolvable package path. Whether the bug fires depends on whether a same-named local file happens to exist, which makes it a nasty action-at-a-distance failure.

The sibling `commonjs.ts` transform already has exactly this guard:

```ts
// Skip built-in modules and node_modules
if (moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('/')) {
```

The ESM path in `index.ts` lacks it.

## Fix

Add the same relative/absolute guard at the top of `getFullySpecifiedModuleSpecifier()` so only relative/absolute specifiers are eligible for rewriting. Since the committed `permanent/` outputs are what consumers actually load (and what `@tamagui/build` bootstraps from), the identical guard is applied to all four flavors there as well, matching their compiled style (sourcemaps not regenerated — happy to rebuild if you have a preferred flow for `permanent/`).

## Tests

Added regression tests:

- bare `import` / `export * from` / dynamic `import()` are left untouched (these were previously rewritten even with `ensureFileExists: false`)
- a `bare-package-collision` fixture reproducing the incident: a local `tamagui.js` sibling next to a `test.mjs` importing bare `tamagui` — the bare import stays intact while the relative `./tamagui` still rewrites to `./tamagui.mjs`

`vitest --run` for the package: 15/15 pass with the guard; the 4 new tests fail without it. Also smoke-tested both `permanent/cjs` and `permanent/esm` builds directly through `@babel/core` against the collision fixture.

## Downstream verification

We've been carrying this exact guard as a pnpm patch (`patchedDependencies`) in production in the multiplatform.one framework (observed on `2.0.0-rc.41`, still present on `2.7.6`): with the guard, a package containing `src/tamagui.ts` builds a `dist/` whose emitted imports keep `from 'tamagui'` intact; without it, the emitted `from "tamagui.mjs"` fails to resolve in every consumer. This PR would let us drop the carried patch.

Made with [Cursor](https://cursor.com)