### PR TITLE
fix(portal): support overriding the default web portal container via setDefaultPortalContainer

### DIFF
--- a/code/ui/components-test/Portal.web.test.tsx
+++ b/code/ui/components-test/Portal.web.test.tsx
@@ -1,0 +1,74 @@
+import '@testing-library/jest-dom'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { Portal, setDefaultPortalContainer } from '@tamagui/portal'
+import { render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+const CONTENT_TEST_ID = 'portal-content'
+
+function PortalTest() {
+  return (
+    <TamaguiProvider config={conf} defaultTheme="light">
+      <Portal>
+        <div data-testid={CONTENT_TEST_ID} />
+      </Portal>
+    </TamaguiProvider>
+  )
+}
+
+// querySelector does not pierce shadow roots, so a match inside document.body
+// proves the portal escaped the shadow boundary
+const findInBody = () => document.body.querySelector(`[data-testid=${CONTENT_TEST_ID}]`)
+
+afterEach(() => {
+  setDefaultPortalContainer(null)
+})
+
+describe('Portal (web)', () => {
+  it('renders into document.body by default', () => {
+    render(<PortalTest />)
+    expect(findInBody()).toBeTruthy()
+  })
+
+  it('renders into the container set via setDefaultPortalContainer', () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const shadow = host.attachShadow({ mode: 'open' })
+    const overlay = document.createElement('div')
+    shadow.appendChild(overlay)
+
+    setDefaultPortalContainer(overlay)
+
+    const bodyChildrenBefore = document.body.childElementCount
+    render(<PortalTest />)
+
+    expect(overlay.querySelector(`[data-testid=${CONTENT_TEST_ID}]`)).toBeTruthy()
+    expect(findInBody()).toBeNull()
+    // no portal root was appended to document.body (only the RTL container)
+    expect(document.body.childElementCount).toBe(bodyChildrenBefore + 1)
+
+    host.remove()
+  })
+
+  it('accepts a getter and restores document.body when reset to null', () => {
+    const overlay = document.createElement('div')
+    document.body.appendChild(overlay)
+
+    setDefaultPortalContainer(() => overlay)
+    const first = render(<PortalTest />)
+    expect(overlay.querySelector(`[data-testid=${CONTENT_TEST_ID}]`)).toBeTruthy()
+    first.unmount()
+
+    setDefaultPortalContainer(null)
+    render(<PortalTest />)
+    const content = findInBody()
+    expect(content).toBeTruthy()
+    expect(overlay.contains(content)).toBe(false)
+
+    overlay.remove()
+  })
+})

--- a/code/ui/portal/src/Portal.tsx
+++ b/code/ui/portal/src/Portal.tsx
@@ -6,6 +6,7 @@ import { useStackedZIndex, ZIndexHardcodedContext } from '@tamagui/z-index-stack
 import * as React from 'react'
 import { createPortal } from 'react-dom'
 import { getStackedZIndexProps } from './helpers'
+import { resolveDefaultPortalContainer } from './portalContainer'
 import type { PortalProps } from './PortalProps'
 
 export const Portal = React.memo((propsIn: PortalProps) => {
@@ -43,6 +44,6 @@ export const Portal = React.memo((propsIn: PortalProps) => {
         {children}
       </ZIndexHardcodedContext.Provider>
     </TamaguiRoot>,
-    globalThis.document?.body
+    resolveDefaultPortalContainer()
   )
 })

--- a/code/ui/portal/src/index.ts
+++ b/code/ui/portal/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Portal'
+export * from './portalContainer'
 export * from './PortalProps'
 export * from './GorhomPortal'
 export { GorhomPortalItem as PortalItem } from './GorhomPortalItem'

--- a/code/ui/portal/src/portalContainer.ts
+++ b/code/ui/portal/src/portalContainer.ts
@@ -1,0 +1,29 @@
+export type PortalContainer = Element | DocumentFragment
+
+let defaultPortalContainer:
+  | PortalContainer
+  | (() => PortalContainer | null | undefined)
+  | null = null
+
+/**
+ * Redirect every web <Portal /> that would otherwise render into document.body
+ * into `container` instead — for example an element inside a shadow root, where
+ * portaling to document.body would escape the shadow boundary and lose its
+ * styles. Accepts an element or a getter (useful when the container mounts
+ * late). Opt-in and global: apps that never call this keep the document.body
+ * behavior unchanged. Pass null (or return null/undefined from the getter) to
+ * restore the default. Has no effect on native.
+ */
+export function setDefaultPortalContainer(
+  container: PortalContainer | (() => PortalContainer | null | undefined) | null
+): void {
+  defaultPortalContainer = container
+}
+
+export function resolveDefaultPortalContainer(): PortalContainer {
+  const container =
+    typeof defaultPortalContainer === 'function'
+      ? defaultPortalContainer()
+      : defaultPortalContainer
+  return container ?? globalThis.document?.body
+}

--- a/code/ui/portal/types/index.d.ts
+++ b/code/ui/portal/types/index.d.ts
@@ -1,4 +1,5 @@
 export * from './Portal';
+export * from './portalContainer';
 export * from './PortalProps';
 export * from './GorhomPortal';
 export { GorhomPortalItem as PortalItem } from './GorhomPortalItem';

--- a/code/ui/portal/types/portalContainer.d.ts
+++ b/code/ui/portal/types/portalContainer.d.ts
@@ -1,0 +1,13 @@
+export type PortalContainer = Element | DocumentFragment;
+/**
+ * Redirect every web <Portal /> that would otherwise render into document.body
+ * into `container` instead — for example an element inside a shadow root, where
+ * portaling to document.body would escape the shadow boundary and lose its
+ * styles. Accepts an element or a getter (useful when the container mounts
+ * late). Opt-in and global: apps that never call this keep the document.body
+ * behavior unchanged. Pass null (or return null/undefined from the getter) to
+ * restore the default. Has no effect on native.
+ */
+export declare function setDefaultPortalContainer(container: PortalContainer | (() => PortalContainer | null | undefined) | null): void;
+export declare function resolveDefaultPortalContainer(): PortalContainer;
+//# sourceMappingURL=portalContainer.d.ts.map


### PR DESCRIPTION
### Problem

On web, `Portal` hardcodes its container:

```tsx
// code/ui/portal/src/Portal.tsx
return createPortal(<TamaguiRoot …>{children}</TamaguiRoot>, globalThis.document?.body)
```

Every built-in overlay funnels through this component — Dialog, Popover, Select, Sheet, Toast, and the menus. When a Tamagui app is mounted inside a shadow root (browser-extension content UIs, embeddable widgets, micro-frontends), its styles live inside the shadow root but every overlay escapes into the host page's `document.body`, so:

- overlays render unstyled (the Tamagui CSS is inside the shadow root, `document.body` is outside it)
- host-page CSS bleeds into the overlays
- the widget/extension leaks DOM into the page it is injected into

Measured against `@tamagui/portal@2.0.0-rc.41` inside a browser-extension shadow root (still present in the 2.7.4 npm tarball, and the same hardcoded `document.body` is on current `main`): opening a single popover grew `document.body.children` from **7 to 8** — the overlay was appended to the host page's body while the app's styles stayed contained in the shadow root, rendering it unstyled.

There is currently no opt-out: `PortalProps` has no container option, and the named-host system (`PortalItem`/`PortalHost`) is a separate mechanism that the built-in overlays don't use for their default web portal.

### Repro

```tsx
const host = document.getElementById('widget-root')!
const shadow = host.attachShadow({ mode: 'open' })
const mount = document.createElement('div')
shadow.appendChild(mount) // Tamagui CSS is injected inside the shadow root

createRoot(mount).render(
  <TamaguiProvider config={config}>
    <Popover open>
      <Popover.Trigger asChild>
        <Button>open</Button>
      </Popover.Trigger>
      <Popover.Content>
        <Paragraph>I escape into the host page body</Paragraph>
      </Popover.Content>
    </Popover>
  </TamaguiProvider>
)

// document.body.childElementCount goes 7 → 8: the popover content lands in the
// light-DOM body, outside the shadow boundary, unstyled
```

### Fix

An opt-in, module-level override in `@tamagui/portal`:

```ts
import { setDefaultPortalContainer } from '@tamagui/portal'

// once at app setup — e.g. an overlay layer inside the shadow root
setDefaultPortalContainer(overlayElement)

// or a getter, for containers that mount late
setDefaultPortalContainer(() => shadowRoot.querySelector('#overlays'))

// restore the default
setDefaultPortalContainer(null)
```

The web `Portal` now resolves its container as `override ?? globalThis.document?.body` (new `code/ui/portal/src/portalContainer.ts`, used by `Portal.tsx`).

Why this shape:

- **One call fixes every overlay at once.** Dialog/Popover/Select/Sheet/Toast/menus all portal through this single component; a per-component `container` prop would need new props threaded through each of their APIs.
- **Matches existing precedent** for global environment configuration in this repo: `setNonce`, `setOnLayoutStrategy`, `setMediaShouldUpdate`, `setConfig`, ….
- A context-based alternative would need `TamaguiProvider` (which renders `PortalProvider` without forwarding any configuration) to grow a new prop across two packages. Happy to rework in that direction if you prefer.

### Compatibility

- **Opt-in:** apps that never call `setDefaultPortalContainer` keep the exact current `document.body` behavior — zero behavior change.
- **Native untouched:** `Portal.native.tsx` doesn't use DOM containers; the export exists on native builds but is inert.
- No changes to `PortalProps` or any component API; no new dependencies.

### Tests / verification

- New `code/ui/components-test/Portal.web.test.tsx` (vitest + jsdom):
  1. default renders into `document.body`
  2. with an override set to an element inside a shadow root, content renders inside the shadow root and **nothing** is appended to `document.body`
  3. getter form works, and resetting to `null` restores `document.body`
- `bun run test:web` in `code/ui/components-test`: 6 files / 33 tests pass.
- `tamagui-build` on `@tamagui/portal` (esbuild + tsc type emit) passes; `oxfmt` + `oxlint` clean; `check:exports:web` reports no new issues (the 2 it flags exist on pristine `main`, in `code/ui/tamagui`).
- Not run: the kitchen-sink Playwright suite (needs a dev server + browsers; heavier than this change warrants — CI will cover it).
