### PR TITLE
fix(select): use composedPath for outside pointerdown dismiss so shadow DOM item presses dont close the listbox

### DIFF
--- a/code/core/floating/src/index.ts
+++ b/code/core/floating/src/index.ts
@@ -75,6 +75,9 @@ export { useFloating as useFloatingRaw } from './Floating'
 // event emitter for hook coordination
 export { createFloatingEvents } from './interactions/createFloatingEvents'
 
+// shadow-DOM-safe event target (uses composedPath, like the interaction hooks)
+export { getTarget } from './interactions/utils'
+
 // multi-trigger coordination
 export { PopupTriggerMap } from './interactions/PopupTriggerMap'
 

--- a/code/core/floating/types/index.d.ts
+++ b/code/core/floating/types/index.d.ts
@@ -3,6 +3,7 @@ export { arrow, autoPlacement, autoUpdate, detectOverflow, flip, getOverflowAnce
 export { useFloating, FloatingOverrideContext, type UseFloatingReturn, type UseFloatingProps, type UseFloatingFn, type UseFloatingOverrideFn, } from './useFloating';
 export { useFloating as useFloatingRaw } from './Floating';
 export { createFloatingEvents } from './interactions/createFloatingEvents';
+export { getTarget } from './interactions/utils';
 export { PopupTriggerMap } from './interactions/PopupTriggerMap';
 export { useInteractions } from './interactions/useInteractions';
 export { useHover } from './interactions/useHover';

--- a/code/ui/components-test/Select.web.test.tsx
+++ b/code/ui/components-test/Select.web.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { Select } from '@tamagui/select'
+import { act, render } from '@testing-library/react'
+import { describe, expect, it, vitest } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+global.ResizeObserver = class ResizeObserver {
+  cb: any
+  constructor(cb: any) {
+    this.cb = cb
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function SelectTest(props: { onOpenChange: (open: boolean) => void }) {
+  return (
+    <TamaguiProvider config={conf} defaultTheme="light">
+      <Select open value="apple" onOpenChange={props.onOpenChange}>
+        <Select.Trigger>
+          <Select.Value placeholder="Fruit" />
+        </Select.Trigger>
+
+        <Select.Content>
+          <Select.Viewport>
+            <Select.Item index={0} value="apple">
+              <Select.ItemText>Apple</Select.ItemText>
+            </Select.Item>
+            <Select.Item index={1} value="pear">
+              <Select.ItemText>Pear</Select.ItemText>
+            </Select.Item>
+          </Select.Viewport>
+        </Select.Content>
+      </Select>
+    </TamaguiProvider>
+  )
+}
+
+const pointerDown = (node: Node) =>
+  act(() => {
+    node.dispatchEvent(new Event('pointerdown', { bubbles: true, composed: true }))
+  })
+
+describe('Select outside-press dismiss (web)', () => {
+  it('does not dismiss when pressing an item inside a shadow root', async () => {
+    const onOpenChange = vitest.fn()
+    render(<SelectTest onOpenChange={onOpenChange} />)
+
+    const listbox = document.body.querySelector('[role=listbox]')
+    expect(listbox).toBeTruthy()
+
+    // simulate the floating content living inside a shadow tree, as happens
+    // when an app portals its overlays into a shadow root (e.g. a browser
+    // extension UI): move the portaled root hosting the listbox in there
+    const portalRoot = Array.from(document.body.children).find((el) =>
+      el.contains(listbox!)
+    )!
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const shadow = host.attachShadow({ mode: 'open' })
+    shadow.appendChild(portalRoot)
+
+    const option = shadow.querySelector('[role=option]')
+    expect(option).toBeTruthy()
+
+    // document-level listeners see this event retargeted to the shadow host —
+    // composedPath()[0] must be used for the "inside the listbox?" check
+    pointerDown(option!)
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    // presses genuinely outside the listbox still dismiss
+    pointerDown(document.body)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+
+    // hand the portal root back to document.body so React can unmount it
+    document.body.appendChild(portalRoot)
+    host.remove()
+  })
+
+  it('dismisses on outside press in a regular DOM', async () => {
+    const onOpenChange = vitest.fn()
+    render(<SelectTest onOpenChange={onOpenChange} />)
+
+    const listbox = document.body.querySelector('[role=listbox]')
+    expect(listbox).toBeTruthy()
+
+    const option = document.body.querySelector('[role=option]')
+    expect(option).toBeTruthy()
+    pointerDown(option!)
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+
+    pointerDown(document.body)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+})

--- a/code/ui/select/src/SelectImpl.tsx
+++ b/code/ui/select/src/SelectImpl.tsx
@@ -1,6 +1,7 @@
 import {
   autoUpdate,
   flip,
+  getTarget,
   inner,
   offset,
   shift,
@@ -325,7 +326,11 @@ export const SelectInlineImpl = (props: SelectImplProps) => {
   // dismiss on outside pointer down (arrows are outside the floating DOM tree)
   useIsomorphicLayoutEffect(() => {
     function onPointerDown(e: PointerEvent) {
-      const target = e.target as Node
+      // getTarget, not e.target: this listener sits on the document, so a press
+      // inside a shadow root is retargeted to the shadow host and would fail the
+      // contains() checks below, dismissing the listbox on every item press.
+      // composedPath()[0] === e.target when no shadow boundary is involved.
+      const target = getTarget(e) as Node
       if (
         !(
           refs.floating.current?.contains(target) ||


### PR DESCRIPTION
### Problem

`SelectInlineImpl` dismisses the open listbox with a **document-level** `pointerdown` listener that reads `e.target`:

```tsx
// code/ui/select/src/SelectImpl.tsx
function onPointerDown(e: PointerEvent) {
  const target = e.target as Node
  if (
    !(
      refs.floating.current?.contains(target) ||
      upArrowRef.current?.contains(target) ||
      downArrowRef.current?.contains(target)
    )
  ) {
    setOpen(false)
    setControlledScrolling(false)
  }
}
// …
document.addEventListener('pointerdown', onPointerDown)
```

When the floating listbox lives inside a shadow tree (a browser-extension UI, an embedded widget — any setup where overlays are kept inside a shadow root), shadow-DOM **event retargeting** rewrites `e.target` for listeners above the boundary: a listener on `document` sees the shadow **host** element, never the real node that was pressed. `refs.floating.current.contains(shadowHost)` is `false`, so the check treats every press **inside** the listbox as an outside press — **the listbox dismisses on every item press** and selection is impossible.

Measured against `@tamagui/select@2.0.0-rc.41` inside a browser-extension shadow root (still present in the 2.7.4 npm tarball; the listener is unchanged on current `main`).

`event.composedPath()[0]` is the standard fix: it returns the true innermost target even across open shadow boundaries, and it is **identical to `e.target` when no shadow boundary is involved**, so regular-DOM behavior is untouched.

This repo already ships exactly this helper in its floating-ui port — `getTarget` in `code/core/floating/src/interactions/utils.ts` — used by `safePolygon` and `useFocus` for the same reason. The select listener just wasn't using it.

### Repro

1. Mount a Tamagui app inside a shadow root and keep its overlays inside the shadow root (portal container override, or any custom portal arrangement).
2. Open a `<Select>`, press any item.
3. The `pointerdown` listener on `document` sees `e.target === shadowHost`, the `contains()` check fails, and the listbox closes before the item's press/selection completes — for every item, every time.

jsdom (v28) reproduces the browser behavior exactly: for a composed `pointerdown` dispatched from inside an open shadow root, a document-level listener observes `e.target === host` while `composedPath()[0]` is the pressed element.

### Fix

Export the existing `getTarget` helper from `@tamagui/floating` (one line, next to the other interaction exports) and use it in the listener:

```tsx
const target = getTarget(e) as Node
```

`getTarget` is `'composedPath' in event ? event.composedPath()[0] : event.target` — the same helper `safePolygon` and `useFocus` already rely on. (If you'd rather not grow `@tamagui/floating`'s public exports, inlining `e.composedPath?.()[0] ?? e.target` in `SelectImpl` works identically.)

### Compatibility

- `composedPath()[0] === e.target` whenever no shadow boundary is crossed → behavior-identical in regular DOM.
- `composedPath` is supported by every evergreen browser; `getTarget` falls back to `event.target` when absent.
- Web-only listener; `SelectImpl.native.tsx` untouched.

### Tests / verification

- New `code/ui/components-test/Select.web.test.tsx` (vitest + jsdom):
  1. **Shadow-root scenario:** renders an open `Select`, relocates the portaled listbox into a shadow root, dispatches a composed `pointerdown` on an option → asserts the listbox is **not** dismissed; then a genuine outside press → asserts it **is** dismissed (no over-fix).
  2. **Regular-DOM scenario:** item press does not dismiss; outside press dismisses.
- **Falsification:** with the fix reverted (stash + rebuild), the shadow test fails exactly at the item-press assertion (`onOpenChange` called with `false`) while the regular-DOM test still passes — i.e. the test captures precisely this bug.
- `bun run test:web` in `code/ui/components-test`: 6 files / 32 tests pass.
- Turbo build of the `@tamagui/select` dependency closure (54 tasks, includes `@tamagui/floating`; esbuild + tsc type emit) passes; `oxfmt` + `oxlint` clean.
- Not run: the kitchen-sink Playwright suite (needs a dev server + browsers; CI will cover it).
