### PR TITLE
fix(toast): stop leaking accessibilityLabel onto the DOM on web

### DIFF
--- a/code/ui/toast/src/ToastComposable.tsx
+++ b/code/ui/toast/src/ToastComposable.tsx
@@ -1163,7 +1163,6 @@ const ToastItemInner = ToastItemFrame.styleable<ToastItemProps>(
       <ToastPositionWrapper
         ref={ref}
         testID={rest.testID}
-        accessibilityLabel={rest.accessibilityLabel}
         {...dataAttributes}
         transition={
           isDragging || ctx.reducedMotion ? undefined : removed ? '200ms' : '400ms'


### PR DESCRIPTION
Fixes #4160.

### The warning

`ToastItem` hoists `accessibilityLabel` onto `ToastPositionWrapper` unconditionally:

```tsx
<ToastPositionWrapper
  ref={ref}
  testID={rest.testID}
  accessibilityLabel={rest.accessibilityLabel}
```

Two things combine, as #4160 works out:

1. v2's web pipeline no longer maps RN `accessibility*` props to ARIA — `getSplitStyles` special-cases only `disabled` / `testID` / `id` — so the key passes straight through to the `div`. (`testID` on the line above is fine: it becomes `data-testid`.)
2. React warns on the *presence* of the camelCased key, not on its value, so `undefined` still warns.

So every toast logs `React does not recognize the 'accessibilityLabel' prop on a DOM element` in apps that never pass the prop.

### The fix

Delete the line. `accessibilityLabel` is still in `rest`, which is spread onto `ToastItemFrame` a few lines below, so a caller who does pass one still reaches an element — the hoist was a duplicate and the accessible tree is unchanged.

### Why not map it to `aria-label`

#4160 suggests emitting `aria-label` on the wrapper when the prop is set. That trades the warning for a subtler bug. The Escape handler walks up from the focused toast:

```tsx
const container = current.closest('[aria-label]') as HTMLElement
```

looking for the **viewport**, which carries `aria-label={`${label} ${hotkeyLabel}`}`, so it can move focus to the next toast before dismissing. A labelled `ToastPositionWrapper` captures that lookup one level too low: `querySelectorAll('[tabindex="0"]')` then only sees the toast being dismissed and focus goes nowhere. Dropping the prop keeps the lookup landing on the viewport.

The same trap applies to a caller-supplied `aria-label`, which lands on `ToastItemFrame` today — tightening that selector to the viewport looks worthwhile, but it's pre-existing behaviour and I've left it alone here.

### Verification

Applied this as a package patch on `@tamagui/toast@2.7.3` in a Tamagui v2 + Expo-web app (react / react-dom 19.2.3) and triggered each toast variant from a Storybook story:

- **before** — `React does not recognize the 'accessibilityLabel' prop on a DOM element…` in the console on every toast
- **after** — console clean, toast renders, stacks and dismisses identically

Independently confirmed the React half in isolation: `<div accessibilityLabel={undefined} />` warns on react-dom 19.2.3, `<div aria-label={undefined} />` does not.
