### PR TITLE
fix(build): guard ts.sys access so --skip-types works on TypeScript 7

### DIFF
--- a/code/packages/build/tamagui-build.js
+++ b/code/packages/build/tamagui-build.js
@@ -840,8 +840,11 @@ async function compileTypeScript(fileNames, options) {
 
 const formatHost = {
   getCanonicalFileName: (path) => path,
-  getCurrentDirectory: ts.sys.getCurrentDirectory,
-  getNewLine: () => ts.sys.newLine,
+  // TypeScript 7 (the native compiler) ships no `ts.sys`. This object is built
+  // at module scope, so reading it unguarded throws before `--skip-types` can
+  // take effect and breaks JS-only builds.
+  getCurrentDirectory: ts.sys?.getCurrentDirectory ?? (() => process.cwd()),
+  getNewLine: () => ts.sys?.newLine ?? '\n',
 }
 
 function reportDiagnostics(diagnostics) {


### PR DESCRIPTION
### Problem

`tamagui-build --skip-types` throws on TypeScript 7:

```
/node_modules/@tamagui/build/tamagui-build.js:843
TypeError: Cannot read properties of undefined (reading 'getCurrentDirectory')
```

TypeScript 7 (the native Go compiler) ships without `ts.sys`. `formatHost` is constructed at module scope and reads `ts.sys.getCurrentDirectory` and `ts.sys.newLine` eagerly, so the file throws as it loads — before `--skip-types` has any chance to take effect.

That makes the JS-only build path unusable on TS 7 even though it never needs the type program. In our monorepo it stops `pnpm build:packages` at the package that builds with `tamagui-build --skip-types`.

### Fix

Guard both reads with optional chaining and a fallback. `formatHost` is only consumed by `reportDiagnostics`, which `--skip-types` never reaches, so this is inert when `ts.sys` exists and simply lets the module load when it doesn't.

### Notes

- Behavior is unchanged on TypeScript 5/6: `ts.sys?.getCurrentDirectory` yields the same unbound reference the current code passes.
- Only the `--skip-types` path is restored. A full type build still needs a TypeScript with the legacy compiler API; this doesn't attempt to make `buildTsc` work under TS 7.
- Verified against `@tamagui/build@2.4.2` and confirmed the same code is present in `2.7.7`.
