### PR TITLE
fix(release): stop setup-node poisoning OIDC with a placeholder token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,18 @@ jobs:
       github.event.workflow_run.head_branch == 'v3-beta'
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # human gate: this job otherwise auto-publishes the first time Checks goes
-    # green on a v3-beta push. the environment pauses the job until a required
-    # reviewer approves it in the Actions UI. the protection rule lives in repo
-    # settings, not here: Settings -> Environments -> npm-publish-beta ->
-    # "Required reviewers" (add the approvers) or the job runs unpaused.
-    # if npmjs.com trusted publishing pins an environment name for these
-    # packages, it must match npm-publish-beta (or stay unset).
-    environment: npm-publish-beta
+    # this job publishes a beta automatically every time Checks goes green on a
+    # v3-beta push.
+    #
+    # it declares no environment. every package's trusted publisher on npmjs.com
+    # pins repository + release.yml with the environment left unset, and github
+    # adds an `environment` claim to the OIDC token whenever a job names one, so
+    # leaving it off is what certainly matches. the previous npm-publish-beta
+    # environment was removed while chasing the 404 below and was NOT its cause;
+    # whether npm treats an unset environment as "any" was never established.
+    #
+    # re-adding one to get protection rules means checking that against all 166
+    # npm configs first, and the stable job below names none either.
     permissions:
       contents: read
       id-token: write
@@ -67,12 +71,20 @@ jobs:
             echo "release=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # deliberately no registry-url. it makes setup-node write an .npmrc holding
+      # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} and export
+      # NODE_AUTH_TOKEN as the placeholder XXXXX-XXXXX-XXXXX-XXXXX, because no
+      # real token exists here. npm then sends that placeholder, authenticates as
+      # nobody, and the registry answers a PUT with 404 rather than 401 so it does
+      # not reveal whether the package exists. that 404 is what stopped every beta
+      # cut. a configured credential also pre-empts OIDC, so trusted publishing
+      # never ran at all. registry.npmjs.org is npm's default, so nothing here
+      # needed the setting.
       - name: Setup Node.js
         if: steps.candidate.outputs.release == 'true'
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: '.node-version'
-          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
       - name: Setup Bun
@@ -246,11 +258,11 @@ jobs:
           [[ -n "$base_ref" ]]
           echo "base-ref=$base_ref" >> "$GITHUB_OUTPUT"
 
+      # no registry-url, for the same reason as the beta job above
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: '.node-version'
-          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
       - name: Setup Bun


### PR DESCRIPTION
No v3 beta has ever published. Every attempt dies with `404 Not Found - PUT` on the first package.

## Cause

`actions/setup-node`'s `registry-url` writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}` and exports `NODE_AUTH_TOKEN` as its placeholder `XXXXX-XXXXX-XXXXX-XXXXX`, because this repo has no npm token. npm sends the placeholder, authenticates as nobody, and the registry answers a PUT with 404 rather than 401 so it will not reveal whether the package exists.

A configured credential also pre-empts OIDC, so trusted publishing never ran at all.

`registry.npmjs.org` is npm's default, so nothing needed the setting.

Evidence: the failing job's env block shows `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX`, and no workflow references a token secret.

## Why this must land on main

A `workflow_run` job always executes the workflow definition from the **default branch**. The beta job that runs on a v3-beta push is main's copy of this file, so the identical fix sitting on v3-beta had no effect across two consecutive runs.

## Also

Drops the `npm-publish-beta` environment. It is **not** the cause of the 404 — removing it changed nothing on its own. The trusted publishers pin no environment, so omitting it is the setting that certainly matches, and the environment already carried no protection rules by owner instruction.

## Not included

The trusted publishers themselves are correctly configured (verified by a 409 on create and a direct `npm trust list` read). The six package names that were missing from the registry have been claimed separately.

The beta job is otherwise unchanged and still gated on Checks going green.