### PR TITLE
fix(toast): map accessibilityLabel to aria-label on web

### DIFF
--- a/code/ui/components-test/Toast.web.test.tsx
+++ b/code/ui/components-test/Toast.web.test.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom'
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { PortalProvider } from '@tamagui/portal'
+import { toast, Toaster } from '@tamagui/toast/v2'
+import { act, render } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+afterEach(() => {
+  toast.dismiss()
+  vi.restoreAllMocks()
+})
+
+function renderToaster() {
+  return render(
+    <TamaguiProvider config={conf} defaultTheme="light">
+      <PortalProvider shouldAddRootHost>
+        <Toaster duration={Number.POSITIVE_INFINITY} />
+      </PortalProvider>
+    </TamaguiProvider>
+  )
+}
+
+describe('Toast v2 web accessibility props', () => {
+  test('does not forward accessibilityLabel to the DOM', async () => {
+    // react warns on the presence of the camelCased key, value or not
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { container } = renderToaster()
+    await act(async () => {
+      toast('hello')
+    })
+
+    expect(container.querySelector('[accessibilitylabel]')).toBeNull()
+    const warned = errorSpy.mock.calls.some((args) =>
+      args.some((arg) => typeof arg === 'string' && arg.includes('accessibilityLabel'))
+    )
+    expect(warned).toBe(false)
+  })
+})

--- a/code/ui/toast/src/ToastComposable.tsx
+++ b/code/ui/toast/src/ToastComposable.tsx
@@ -901,7 +901,7 @@ export interface ToastItemProps extends GetProps<typeof ToastItemFrame> {
 
 const ToastItemInner = ToastItemFrame.styleable<ToastItemProps>(
   function ToastItem(props, ref) {
-    const { toast, index, children, ...rest } = props
+    const { toast, index, children, accessibilityLabel, ...rest } = props
     const ctx = useToastContext('Toast.Item')
 
     const [mounted, setMounted] = React.useState(false)
@@ -1163,7 +1163,8 @@ const ToastItemInner = ToastItemFrame.styleable<ToastItemProps>(
       <ToastPositionWrapper
         ref={ref}
         testID={rest.testID}
-        accessibilityLabel={rest.accessibilityLabel}
+        {...(accessibilityLabel != null &&
+          (isWeb ? { 'aria-label': accessibilityLabel } : { accessibilityLabel }))}
         {...dataAttributes}
         transition={
           isDragging || ctx.reducedMotion ? undefined : removed ? '200ms' : '400ms'


### PR DESCRIPTION
Fixes #4160

### Problem

Every toast logs a React warning on web:

```
React does not recognize the `accessibilityLabel` prop on a DOM element.
```

Two things combine:

1. v2 dropped the RN `accessibility*` → ARIA mapping (see the note in `core/web/src/types.tsx`) — `getSplitStyles` only special-cases `disabled` / `testID` / `id`, and `createComponent` reads `accessibilityLabel` purely for the press-debug name. So the key passes straight to the DOM element.
2. React 19 warns on the **presence** of the camelCased key, even when the value is `undefined`.

`ToastItem` forwarded it unconditionally:

```tsx
const { toast, index, children, ...rest } = props
...
<ToastPositionWrapper testID={rest.testID} accessibilityLabel={rest.accessibilityLabel}
```

so the key was always there, and it also rode along in `{...rest}` onto `ToastItemFrame`. `testID` on the same line is fine because `getSplitStyles` maps it to `data-testid`.

### Fix

Pull `accessibilityLabel` out of the destructure and only emit it when it is actually defined — as `aria-label` on web, as the RN prop on native:

```tsx
const { toast, index, children, accessibilityLabel, ...rest } = props
...
{...(accessibilityLabel != null &&
  (isWeb ? { 'aria-label': accessibilityLabel } : { accessibilityLabel }))}
```

Pulling it out of `rest` also stops the second copy from landing on `ToastItemFrame`, so the label now sits once on the outer wrapper instead of on two nested elements.

### Test

`code/ui/components-test/Toast.web.test.tsx` renders the v2 `Toaster`, fires a toast, and asserts no `[accessibilitylabel]` attribute reaches the DOM and that React logged no `accessibilityLabel` warning.

Verified red before the change (`expected true to be false` on the warning assertion).

### Checks

- `bun run typecheck` ✅
- `bun run lint` ✅
- `@tamagui/components-test` web suite: 6 files / 31 tests ✅