### PR TITLE
ci: run Checks on merge_group so the merge queue can complete

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -3,6 +3,7 @@ name: Checks
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
   push:
     paths-ignore:
       - 'assets/**'


### PR DESCRIPTION
The merge queue can never merge anything today.

The ruleset requires the `checks` status check, but `.github/workflows/checks.yaml` triggers only on `workflow_dispatch`, `pull_request` and `push`. Nothing in the repo triggers on `merge_group`, so when a PR enters the queue GitHub creates a merge group, no workflow runs against it, the required check never reports, and the entry is eventually dropped.

Evidence: `GET /repos/tamagui/tamagui/actions/runs?event=merge_group` returns `total_count: 0` — no merge-group run has ever existed in this repo. PR #4173 has been enqueued twice today and fell out both times, each time sitting at `AWAITING_CHECKS` at position 1 until it was dropped.

This adds the `merge_group:` trigger. The existing `concurrency` group is keyed on `github.ref`, which is the unique per-entry `gh-readonly-queue/...` ref for merge-group runs, so PR runs and queue runs will not cancel each other.

Note this PR cannot merge through the queue itself, for the reason it fixes. It needs an admin merge that bypasses the queue.