### PR TITLE
fix(sheet): track keyboard state without provider

### DIFF
--- a/code/ui/sheet/src/useKeyboardControllerSheet.native.ts
+++ b/code/ui/sheet/src/useKeyboardControllerSheet.native.ts
@@ -1,12 +1,12 @@
 /**
- * Native implementation of keyboard controller sheet hook.
+ * native implementation of keyboard controller sheet hook.
  *
- * Simplified to just track keyboard state (height, visibility).
- * Position animation is handled by SheetImplementationCustom via
- * keyboard-adjusted positions — matching the react-native-actions-sheet pattern.
+ * simplified to just track keyboard state (height, visibility).
+ * position animation is handled by SheetImplementationCustom via
+ * keyboard-adjusted positions, matching the react-native-actions-sheet pattern.
  *
- * Uses react-native-keyboard-controller events when available,
- * falls back to basic Keyboard API otherwise.
+ * uses React Native keyboard events for state. The optional keyboard-controller
+ * integration is only used for imperative dismissal.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -67,40 +67,11 @@ export function useKeyboardControllerSheet(
     }
   }, [])
 
-  // keyboard-controller event listeners (preferred when available)
-  useEffect(() => {
-    if (!enabled || !keyboardControllerEnabled) return
-
-    const { KeyboardEvents } = getKeyboardControllerState()
-    if (!KeyboardEvents?.addListener) return
-
-    const showSub = KeyboardEvents.addListener('keyboardWillShow', (e: any) => {
-      const height = e?.height ?? 0
-      if (height > 0) {
-        setKeyboardHeight(height)
-      }
-      setIsKeyboardVisible(true)
-    })
-
-    const hideSub = KeyboardEvents.addListener('keyboardWillHide', () => {
-      if (pauseKeyboardHandler.current) {
-        pendingHide.current = true
-        return
-      }
-      setIsKeyboardVisible(false)
-      setKeyboardHeight(0)
-    })
-
-    return () => {
-      showSub?.remove?.()
-      hideSub?.remove?.()
-    }
-  }, [enabled, keyboardControllerEnabled])
-
-  // fallback to basic Keyboard API when keyboard-controller not available
+  // module availability does not prove that KeyboardProvider is mounted. Its
+  // event emitter is silent without the provider, while React Native's keyboard
+  // notifications are available in both configurations.
   useEffect(() => {
     if (!enabled) return
-    if (keyboardControllerEnabled) return
 
     const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow'
     const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide'
@@ -123,7 +94,7 @@ export function useKeyboardControllerSheet(
       showListener.remove()
       hideListener.remove()
     }
-  }, [enabled, keyboardControllerEnabled])
+  }, [enabled])
 
   return {
     keyboardControllerEnabled,

--- a/code/ui/sheet/types/useKeyboardControllerSheet.native.d.ts
+++ b/code/ui/sheet/types/useKeyboardControllerSheet.native.d.ts
@@ -1,12 +1,12 @@
 /**
- * Native implementation of keyboard controller sheet hook.
+ * native implementation of keyboard controller sheet hook.
  *
- * Simplified to just track keyboard state (height, visibility).
- * Position animation is handled by SheetImplementationCustom via
- * keyboard-adjusted positions — matching the react-native-actions-sheet pattern.
+ * simplified to just track keyboard state (height, visibility).
+ * position animation is handled by SheetImplementationCustom via
+ * keyboard-adjusted positions, matching the react-native-actions-sheet pattern.
  *
- * Uses react-native-keyboard-controller events when available,
- * falls back to basic Keyboard API otherwise.
+ * uses React Native keyboard events for state. The optional keyboard-controller
+ * integration is only used for imperative dismissal.
  */
 import type { KeyboardControllerSheetOptions, KeyboardControllerSheetResult } from './types';
 export declare function useKeyboardControllerSheet(options: KeyboardControllerSheetOptions): KeyboardControllerSheetResult;


### PR DESCRIPTION
## Root cause

`useKeyboardControllerSheet` selected `react-native-keyboard-controller` events whenever the module was configured. Those events only fire while `KeyboardProvider` is mounted. Detox deliberately launches without that provider, so the sheet stayed at its pre-keyboard position even though the keyboard was visible. The safe-area path remained live and reported the correct top inset.

## Fix

Use React Native keyboard notifications as the single source for sheet visibility and height. Keep keyboard-controller only for imperative dismissal when configured.

## Validation

- `bun run build` in `code/ui/sheet`
- `SheetKeyboardFitContent.test.ts`: 1 passed
- `SheetPressRegression.test.ts`: 4 passed, including the keyboard movement regression

No test assertions, thresholds, timeouts, retries, or swipe behavior changed.