### PR TITLE
test(native): stop gating the accordion layout assertion on animation frames

### DIFF
--- a/code/demos/src/AccordionDemo.tsx
+++ b/code/demos/src/AccordionDemo.tsx
@@ -4,8 +4,7 @@ import { Accordion, Paragraph, Square } from 'tamagui'
 export function AccordionDemo() {
   return (
     <Accordion overflow="hidden" width="$20" type="multiple">
-      {/* negative margin prevents double border between items */}
-      <Accordion.Item value="a1" mb={-1}>
+      <Accordion.Item value="a1">
         <Accordion.Trigger
           flexDirection="row"
           justify="space-between"
@@ -42,6 +41,7 @@ export function AccordionDemo() {
           flexDirection="row"
           justify="space-between"
           borderWidth={1}
+          borderTopWidth={0}
           borderColor="$borderColor"
         >
           {({ open }: { open: boolean }) => (

--- a/code/kitchen-sink/e2e/Accordion.test.ts
+++ b/code/kitchen-sink/e2e/Accordion.test.ts
@@ -59,10 +59,9 @@ async function launchDefaultOpenCase() {
     .withTimeout(30000)
 }
 
-// resting layout, so it holds on any platform whether or not it animates. This
-// must NOT sit behind describeAnimated: the emulator's animation scale has no
-// bearing on whether an open item's content overlaps the next trigger, and
-// skipping it there hides a real layout defect.
+// resting layout holds on every platform whether or not it animates. the
+// emulator's animation scale has no bearing on whether an open item's content
+// overlaps the next trigger, so keep this outside describeAnimated.
 describe('Accordion (auto-height, native) layout', () => {
   beforeEach(launchDefaultOpenCase)
 

--- a/code/kitchen-sink/e2e/Accordion.test.ts
+++ b/code/kitchen-sink/e2e/Accordion.test.ts
@@ -49,16 +49,22 @@ async function pollLabel(id: string, predicate: (label: string) => boolean) {
   return attrs.label as string
 }
 
-describeAnimated('Accordion (auto-height, native)', () => {
-  beforeEach(async () => {
-    await safeLaunchApp({
-      newInstance: true,
-      launchArgs: { directUseCase: 'AccordionDefaultOpenCase' },
-    })
-    await waitFor(element(by.id('accordion-default-root')))
-      .toExist()
-      .withTimeout(30000)
+async function launchDefaultOpenCase() {
+  await safeLaunchApp({
+    newInstance: true,
+    launchArgs: { directUseCase: 'AccordionDefaultOpenCase' },
   })
+  await waitFor(element(by.id('accordion-default-root')))
+    .toExist()
+    .withTimeout(30000)
+}
+
+// resting layout, so it holds on any platform whether or not it animates. This
+// must NOT sit behind describeAnimated: the emulator's animation scale has no
+// bearing on whether an open item's content overlaps the next trigger, and
+// skipping it there hides a real layout defect.
+describe('Accordion (auto-height, native) layout', () => {
+  beforeEach(launchDefaultOpenCase)
 
   it('default-open item shows content, closed sibling sits below it (no overlap)', async () => {
     await expect(element(by.id('def-content-text'))).toBeVisible()
@@ -78,6 +84,12 @@ describeAnimated('Accordion (auto-height, native)', () => {
       `marker.y ${marker.y} should be below trigger2 bottom ${trigger2.y + trigger2.height}`
     )
   })
+})
+
+// these two sample the height WHILE the accordion animates, so they need a
+// platform that actually paints intermediate frames.
+describeAnimated('Accordion (auto-height, native)', () => {
+  beforeEach(launchDefaultOpenCase)
 
   it('closes the default-open item through an intermediate height', async () => {
     const open = await frame('def-height')

--- a/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
+++ b/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
@@ -67,7 +67,7 @@ export function AccordionDefaultOpenCase() {
   return (
     <YStack testID="accordion-default-root" p="$4">
       <Accordion overflow="hidden" width="$20" type="multiple" defaultValue={['a1']}>
-        <Accordion.Item value="a1" mb={-1}>
+        <Accordion.Item value="a1">
           <Accordion.Trigger
             id="def-trigger"
             testID="def-trigger"
@@ -118,6 +118,7 @@ export function AccordionDefaultOpenCase() {
             flexDirection="row"
             justify="space-between"
             borderWidth={1}
+            borderTopWidth={0}
             borderColor="$borderColor"
           >
             {({ open }: { open: boolean }) => (


### PR DESCRIPTION
## What

Keep the resting Accordion layout check outside `describeAnimated`. Only the two tests that sample intermediate animation frames remain behind the Android animation-capability gate.

## Root cause

The corrected Android experiment ran on exact head `3d53904a6b` as workflow run `32682069896`. The assertion failed on both attempts with the same values:

```text
trigger2.y 574 should be >= content bottom 577
```

The retained device log reports `qemu.sf.lcd_density=440`, or 2.75 physical pixels per logical pixel. The shared demo and fixture deliberately used `mb={-1}` to collapse adjacent borders. Detox reports Android frames in physical pixels, so that intentional one-logical-pixel overlap rounds to the exact three physical pixels observed. The failure did not come from `Accordion.HeightAnimator`.

## Change

- Run the resting layout assertion on every platform without weakening it.
- Remove the negative item margin from `AccordionDemo` and the exact native fixture.
- Put `borderTopWidth={0}` on the second trigger instead, preserving one shared border without geometrically overlapping the items.
- Keep intermediate-height animation tests behind `describeAnimated`.

## Validation

Local:

- `bun install --frozen-lockfile`
- `bun x oxfmt --check` on all three changed files
- `bun x oxlint` on all three changed files
- `bun run build` in `code/demos`
- `git diff --check`

Android native, exact head `2fd79bfc74`, run `32688353545`, job `97322299643`:

- static Accordion layout assertion passed on the first attempt
- Accordion suite passed in 12.798 seconds
- 24 suites passed, 5 skipped, 0 failed
- 93 tests passed, 40 skipped, 0 failed
- Detox body ran for 846.325 seconds; Android job wall time was 20 minutes 22 seconds

The overall native workflow remains in progress on the four iOS shards.