### PR TITLE
ci: release stable versions through protected PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,90 +132,9 @@ jobs:
           --skip-native-tests
           --skip-checks
 
-  ensure-ci:
-    name: Approve main release source
-    if: github.event_name == 'workflow_dispatch' && inputs.release != 'canary'
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      # a canary is a throwaway version on its own dist-tag that nothing installs
-      # unless asked for by name, so it is cuttable from any branch and does not
-      # wait on a full CI run. requiring current main meant merging a change just
-      # to test it. a stable release still needs both.
-      - name: Require current main and successful full CI
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TARGET_SHA: ${{ github.sha }}
-          WORKFLOW_FILE: checks.yaml
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$GITHUB_REF" == "refs/heads/main" ]]
-
-          main_sha=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq .object.sha)
-          [[ "$TARGET_SHA" == "$main_sha" ]]
-
-          get_runs() {
-            gh api --method GET "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW_FILE/runs" \
-              -f head_sha="$TARGET_SHA" -f per_page=20
-          }
-
-          wait_for_run() {
-            local run_id="$1"
-            for ((attempt = 1; attempt <= 40; attempt++)); do
-              read -r status conclusion < <(
-                gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id" \
-                  --jq '[.status, (.conclusion // "pending")] | @tsv'
-              )
-              if [[ "$status" == "completed" ]]; then
-                [[ "$conclusion" == "success" ]]
-                return
-              fi
-              sleep 120
-            done
-            echo "Timed out waiting for CI run $run_id" >&2
-            return 1
-          }
-
-          runs=$(get_runs)
-          run_id=$(jq -r '.workflow_runs | sort_by(.created_at) | last | .id // empty' <<< "$runs")
-          if [[ -n "$run_id" ]]; then
-            status=$(jq -r --argjson id "$run_id" '.workflow_runs[] | select(.id == $id) | .status' <<< "$runs")
-            conclusion=$(jq -r --argjson id "$run_id" '.workflow_runs[] | select(.id == $id) | .conclusion // "pending"' <<< "$runs")
-            if [[ "$status" == "completed" && "$conclusion" == "success" ]]; then
-              echo "Full CI already passed for $TARGET_SHA."
-              exit 0
-            fi
-            if [[ "$status" != "completed" ]] && wait_for_run "$run_id"; then
-              echo "Existing full CI passed for $TARGET_SHA."
-              exit 0
-            fi
-          fi
-
-          started=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          gh api --method POST \
-            "repos/$GITHUB_REPOSITORY/actions/workflows/$WORKFLOW_FILE/dispatches" \
-            -f ref=main
-
-          run_id=''
-          for ((attempt = 1; attempt <= 12; attempt++)); do
-            sleep 10
-            runs=$(get_runs)
-            run_id=$(jq -r --arg started "$started" \
-              '[.workflow_runs[] | select(.event == "workflow_dispatch" and .created_at >= $started)] | sort_by(.created_at) | last | .id // empty' \
-              <<< "$runs")
-            [[ -n "$run_id" ]] && break
-          done
-          [[ -n "$run_id" ]]
-          wait_for_run "$run_id"
-
   prepare_stable:
     name: Merge stable version commit
     if: github.event_name == 'workflow_dispatch' && inputs.release != 'canary'
-    needs: ensure-ci
     runs-on: ubuntu-latest
     timeout-minutes: 180
     outputs:
@@ -288,10 +207,10 @@ jobs:
           version=$(node -p "require('./code/ui/tamagui/package.json').version")
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Run release PR through full CI and the merge queue
+      - name: Run release PR through full CI and protected main
         id: merge
         # pushes made with github.token do not start workflows. the coordinator
-        # dispatches Checks on the exact release commit before enqueueing the PR.
+        # dispatches Checks on the exact release commit before squash-merging the PR.
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
 
   ensure-ci:
     name: Approve main release source
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && inputs.release != 'canary'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
@@ -146,7 +146,6 @@ jobs:
       # wait on a full CI run. requiring current main meant merging a change just
       # to test it. a stable release still needs both.
       - name: Require current main and successful full CI
-        if: inputs.release != 'canary'
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ github.sha }}
@@ -213,14 +212,177 @@ jobs:
           [[ -n "$run_id" ]]
           wait_for_run "$run_id"
 
-  publish:
-    name: Publish approved main release
-    if: github.event_name == 'workflow_dispatch'
+  prepare_stable:
+    name: Merge stable version commit
+    if: github.event_name == 'workflow_dispatch' && inputs.release != 'canary'
     needs: ensure-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    outputs:
+      base_ref: ${{ steps.source.outputs.base-ref }}
+      merged_sha: ${{ steps.merge.outputs.merged-sha }}
+      version: ${{ steps.version.outputs.version }}
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+
+      - name: Validate release source and select baseline
+        id: source
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]]
+
+          tag_ref=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)
+          canary_ref=$(git log --grep='^canary' --format='%H' -1)
+          if [[ -z "$tag_ref" ]]; then
+            base_ref="$canary_ref"
+          elif [[ -z "$canary_ref" ]]; then
+            base_ref="$tag_ref"
+          elif (( $(git log -1 --format=%ct "$canary_ref") > $(git log -1 --format=%ct "$tag_ref") )); then
+            base_ref="$canary_ref"
+          else
+            base_ref="$tag_ref"
+          fi
+          [[ -n "$base_ref" ]]
+          echo "base-ref=$base_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: '.node-version'
+          package-manager-cache: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: 'package.json'
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Prepare release commit
+        env:
+          RELEASE_KIND: ${{ inputs.release }}
+          RELEASE_BASE_REF: ${{ steps.source.outputs.base-ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          bun scripts/release.ts "--$RELEASE_KIND" --ci --dirty --skip-publish --skip-push --skip-tests --skip-native-tests --skip-checks --skip-build
+
+      - name: Read prepared version
+        id: version
+        shell: bash
+        run: |
+          version=$(node -p "require('./code/ui/tamagui/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run release PR through full CI and the merge queue
+        id: merge
+        # pushes made with github.token do not start workflows. the coordinator
+        # dispatches Checks on the exact release commit before enqueueing the PR.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          TARGET_SHA: ${{ github.sha }}
+        run: bun scripts/release-github.ts
+
+  publish_stable:
+    name: Publish merged stable release
+    if: github.event_name == 'workflow_dispatch' && inputs.release != 'canary'
+    needs: prepare_stable
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout merged release source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.prepare_stable.outputs.merged_sha }}
+
+      - name: Validate merged release source
+        env:
+          MERGED_SHA: ${{ needs.prepare_stable.outputs.merged_sha }}
+          RELEASE_VERSION: ${{ needs.prepare_stable.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          [[ "$(git rev-parse HEAD)" == "$MERGED_SHA" ]]
+          git merge-base --is-ancestor "$MERGED_SHA" origin/main
+          version=$(node -p "require('./code/ui/tamagui/package.json').version")
+          [[ "$version" == "$RELEASE_VERSION" ]]
+
+      # no registry-url, for the same reason as the beta job above
+      - name: Setup Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version-file: '.node-version'
+          package-manager-cache: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: 'package.json'
+
+      - name: Install npm with trusted publishing support
+        run: npm install --global npm@12.0.2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build merged release source
+        run: bun run build:force
+
+      - name: Publish prepared version
+        env:
+          RELEASE_BASE_REF: ${{ needs.prepare_stable.outputs.base_ref }}
+        run: bun scripts/release.ts --republish --ci --dirty --skip-finish
+
+      - name: Push stable tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGED_SHA: ${{ needs.prepare_stable.outputs.merged_sha }}
+          RELEASE_VERSION: ${{ needs.prepare_stable.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/v$RELEASE_VERSION" >/dev/null; then
+            git fetch --no-tags origin "refs/tags/v$RELEASE_VERSION:refs/tags/v$RELEASE_VERSION"
+            [[ "$(git rev-list -n 1 "v$RELEASE_VERSION")" == "$MERGED_SHA" ]]
+          else
+            git tag "v$RELEASE_VERSION" "$MERGED_SHA"
+            auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+            trap 'git config --local --unset-all http.https://github.com/.extraheader || true' EXIT
+            git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $auth"
+            git push origin "v$RELEASE_VERSION"
+          fi
+          if ! gh release view "v$RELEASE_VERSION" >/dev/null 2>&1; then
+            gh release create "v$RELEASE_VERSION" --verify-tag --generate-notes --title "v$RELEASE_VERSION"
+          fi
+
+  publish_canary:
+    name: Publish canary
+    if: github.event_name == 'workflow_dispatch' && inputs.release == 'canary'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
       - name: Checkout release source
@@ -229,21 +391,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate release source and select baseline
+      - name: Select release baseline
         id: source
-        env:
-          RELEASE_KIND: ${{ inputs.release }}
         shell: bash
         run: |
           set -euo pipefail
-          git fetch --no-tags origin main
-          # baseline selection below is needed for every release kind; only the
-          # must-be-current-main assertion is stable-only (see ensure-ci).
-          if [[ "$RELEASE_KIND" != 'canary' ]]; then
-            [[ "$GITHUB_REF" == "refs/heads/main" ]]
-            [[ "$(git rev-parse HEAD)" == "$(git rev-parse origin/main)" ]]
-          fi
-
           tag_ref=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || true)
           canary_ref=$(git log --grep='^canary' --format='%H' -1)
           if [[ -z "$tag_ref" ]]; then
@@ -276,53 +428,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Prepare release commit
+      - name: Prepare canary version
         env:
-          RELEASE_KIND: ${{ inputs.release }}
           RELEASE_BASE_REF: ${{ steps.source.outputs.base-ref }}
         shell: bash
         run: |
           set -euo pipefail
           git config user.name 'Tamagui Release'
           git config user.email 'tamagui@users.noreply.github.com'
-          bun scripts/release.ts "--$RELEASE_KIND" --ci --dirty --skip-publish --skip-push --skip-tests --skip-native-tests --skip-checks
-
-      # a canary mutates no git at all, matching orez and takeout. pushing a
-      # throwaway version commit to main is what wedged the one repo: main
-      # requires a pull request and a merge queue there, so the push is rejected
-      # with GH006 and the publish step below never runs. the bump only has to
-      # exist in the tree for npm.
-      - name: Push release commit
-        if: inputs.release != 'canary'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TARGET_SHA: ${{ github.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin main
-          [[ "$(git rev-parse origin/main)" == "$TARGET_SHA" ]]
-          auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
-          trap 'git config --local --unset-all http.https://github.com/.extraheader || true' EXIT
-          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $auth"
-          git push origin HEAD:main
+          bun scripts/release.ts --canary --ci --dirty --skip-publish --skip-push --skip-tests --skip-native-tests --skip-checks
 
       - name: Publish prepared version
         env:
           RELEASE_BASE_REF: ${{ steps.source.outputs.base-ref }}
         run: bun scripts/release.ts --republish --ci --dirty --skip-finish
-
-      - name: Push stable tag
-        if: inputs.release != 'canary'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          version=$(node -p "require('./code/ui/tamagui/package.json').version")
-          [[ "$(git rev-list -n 1 "v$version")" == "$(git rev-parse HEAD)" ]]
-          auth=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
-          trap 'git config --local --unset-all http.https://github.com/.extraheader || true' EXIT
-          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic $auth"
-          git push origin "v$version"
-          gh release create "v$version" --verify-tag --generate-notes --title "v$version"

--- a/scripts/release-github.test.ts
+++ b/scripts/release-github.test.ts
@@ -219,7 +219,7 @@ describe('stable release pull request coordinator', () => {
       }
     )
 
-    await operations.squashPullRequest(makePullRequest())
+    await operations.squashPullRequest(42, releaseSha)
 
     expect(commands).toEqual([
       {
@@ -236,5 +236,38 @@ describe('stable release pull request coordinator', () => {
         ],
       },
     ])
+  })
+
+  test('rejects a pull request head that changes after Checks', async () => {
+    let squashMerged = false
+    const changedHeadSha = '5'.repeat(40)
+    const operations = makeOperations({
+      findPullRequests: async () => [makePullRequest()],
+      listChecksRuns: async () => [
+        {
+          id: 10,
+          event: 'workflow_dispatch',
+          head_sha: releaseSha,
+          status: 'completed',
+          conclusion: 'success',
+          created_at: '2026-08-24T00:00:00Z',
+        },
+      ],
+      getPullRequest: async () =>
+        makePullRequest({
+          head: {
+            ref: `release-v2.7.8-${targetSha}`,
+            sha: changedHeadSha,
+          },
+        }),
+      squashPullRequest: async () => {
+        squashMerged = true
+      },
+    })
+
+    await expect(mergeStableRelease('2.7.8', targetSha, operations)).rejects.toThrow(
+      `head changed from ${releaseSha} to ${changedHeadSha} after Checks`
+    )
+    expect(squashMerged).toBe(false)
   })
 })

--- a/scripts/release-github.test.ts
+++ b/scripts/release-github.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 
-import { mergeStableRelease, type StableReleaseOperations } from './release-github'
+import {
+  createStableReleaseOperations,
+  mergeStableRelease,
+  type StableReleaseOperations,
+} from './release-github'
 
 const targetSha = '1'.repeat(40)
 const releaseSha = '2'.repeat(40)
@@ -13,7 +17,7 @@ function makePullRequest(overrides: Record<string, unknown> = {}) {
     merged_at: null,
     merge_commit_sha: null,
     head: {
-      ref: 'release-v2.7.8',
+      ref: `release-v2.7.8-${targetSha}`,
       sha: releaseSha,
     },
     ...overrides,
@@ -34,7 +38,7 @@ function makeOperations(
     getWorkflowRun: async () => {
       throw new Error('unexpected workflow run read')
     },
-    enqueuePullRequest: async () => {},
+    squashPullRequest: async () => {},
     getPullRequest: async () => makePullRequest(),
     verifyMergedCommit: async () => {},
     sleep: async () => {},
@@ -43,7 +47,7 @@ function makeOperations(
 }
 
 describe('stable release pull request coordinator', () => {
-  test('runs full CI, enters the merge queue, and returns the merged commit', async () => {
+  test('runs full CI, squash-merges the protected pull request, and returns the merged commit', async () => {
     const events: string[] = []
     let checksDispatched = false
     let pullReads = 0
@@ -76,8 +80,8 @@ describe('stable release pull request coordinator', () => {
         checksDispatched = true
         events.push('dispatched checks')
       },
-      enqueuePullRequest: async () => {
-        events.push('entered merge queue')
+      squashPullRequest: async () => {
+        events.push('squashed pull request')
       },
       getPullRequest: async () => {
         pullReads++
@@ -98,10 +102,10 @@ describe('stable release pull request coordinator', () => {
     )
     expect(events).toEqual([
       'verified release commit',
-      'pushed release-v2.7.8',
+      `pushed release-v2.7.8-${targetSha}`,
       'opened pull request',
       'dispatched checks',
-      'entered merge queue',
+      'squashed pull request',
       `verified ${mergedSha}`,
     ])
   })
@@ -121,8 +125,8 @@ describe('stable release pull request coordinator', () => {
       dispatchChecks: async () => {
         events.push('dispatched')
       },
-      enqueuePullRequest: async () => {
-        events.push('queued')
+      squashPullRequest: async () => {
+        events.push('squashed')
       },
       verifyMergedCommit: async () => {
         events.push('verified merged commit')
@@ -150,8 +154,8 @@ describe('stable release pull request coordinator', () => {
     expect(releaseBranchCreated).toBe(false)
   })
 
-  test('does not enqueue a release whose full CI failed', async () => {
-    let enqueued = false
+  test('does not squash-merge a release whose full CI failed', async () => {
+    let squashMerged = false
     const operations = makeOperations({
       findPullRequests: async () => [makePullRequest()],
       listChecksRuns: async () => [
@@ -164,14 +168,73 @@ describe('stable release pull request coordinator', () => {
           created_at: '2026-08-24T00:00:00Z',
         },
       ],
-      enqueuePullRequest: async () => {
-        enqueued = true
+      squashPullRequest: async () => {
+        squashMerged = true
       },
     })
 
     await expect(mergeStableRelease('2.7.8', targetSha, operations)).rejects.toThrow(
       'Checks run 8 concluded failure'
     )
-    expect(enqueued).toBe(false)
+    expect(squashMerged).toBe(false)
+  })
+
+  test('rechecks main after full CI and leaves the attempt branch intact if it advanced', async () => {
+    let mainReads = 0
+    let squashMerged = false
+    const operations = makeOperations({
+      getCurrentMainSha: async () => {
+        mainReads++
+        return mainReads === 1 ? targetSha : '4'.repeat(40)
+      },
+      listChecksRuns: async () => [
+        {
+          id: 9,
+          event: 'workflow_dispatch',
+          head_sha: releaseSha,
+          status: 'completed',
+          conclusion: 'success',
+          created_at: '2026-08-24T00:00:00Z',
+        },
+      ],
+      squashPullRequest: async () => {
+        squashMerged = true
+      },
+    })
+
+    await expect(mergeStableRelease('2.7.8', targetSha, operations)).rejects.toThrow(
+      'main advanced'
+    )
+    expect(mainReads).toBe(2)
+    expect(squashMerged).toBe(false)
+  })
+
+  test('invokes the protected-branch merge with an exact head and explicit squash', async () => {
+    const commands: { command: string; args: string[] }[] = []
+    const operations = createStableReleaseOperations(
+      'tamagui/tamagui',
+      async (command, args) => {
+        commands.push({ command, args })
+        return ''
+      }
+    )
+
+    await operations.squashPullRequest(makePullRequest())
+
+    expect(commands).toEqual([
+      {
+        command: 'gh',
+        args: [
+          'pr',
+          'merge',
+          '42',
+          '--repo',
+          'tamagui/tamagui',
+          '--squash',
+          '--match-head-commit',
+          releaseSha,
+        ],
+      },
+    ])
   })
 })

--- a/scripts/release-github.test.ts
+++ b/scripts/release-github.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'bun:test'
+
+import { mergeStableRelease, type StableReleaseOperations } from './release-github'
+
+const targetSha = '1'.repeat(40)
+const releaseSha = '2'.repeat(40)
+const mergedSha = '3'.repeat(40)
+
+function makePullRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    number: 42,
+    state: 'open' as const,
+    merged_at: null,
+    merge_commit_sha: null,
+    head: {
+      ref: 'release-v2.7.8',
+      sha: releaseSha,
+    },
+    ...overrides,
+  }
+}
+
+function makeOperations(
+  overrides: Partial<StableReleaseOperations> = {}
+): StableReleaseOperations {
+  return {
+    verifyPreparedCommit: async () => {},
+    findPullRequests: async () => [],
+    getCurrentMainSha: async () => targetSha,
+    ensureReleaseBranch: async () => {},
+    createPullRequest: async () => makePullRequest(),
+    listChecksRuns: async () => [],
+    dispatchChecks: async () => {},
+    getWorkflowRun: async () => {
+      throw new Error('unexpected workflow run read')
+    },
+    enqueuePullRequest: async () => {},
+    getPullRequest: async () => makePullRequest(),
+    verifyMergedCommit: async () => {},
+    sleep: async () => {},
+    ...overrides,
+  }
+}
+
+describe('stable release pull request coordinator', () => {
+  test('runs full CI, enters the merge queue, and returns the merged commit', async () => {
+    const events: string[] = []
+    let checksDispatched = false
+    let pullReads = 0
+
+    const operations = makeOperations({
+      verifyPreparedCommit: async () => {
+        events.push('verified release commit')
+      },
+      ensureReleaseBranch: async (branch) => {
+        events.push(`pushed ${branch}`)
+      },
+      createPullRequest: async () => {
+        events.push('opened pull request')
+        return makePullRequest()
+      },
+      listChecksRuns: async () => {
+        if (!checksDispatched) return []
+        return [
+          {
+            id: 7,
+            event: 'workflow_dispatch',
+            head_sha: releaseSha,
+            status: 'completed',
+            conclusion: 'success',
+            created_at: '2026-08-24T00:00:00Z',
+          },
+        ]
+      },
+      dispatchChecks: async () => {
+        checksDispatched = true
+        events.push('dispatched checks')
+      },
+      enqueuePullRequest: async () => {
+        events.push('entered merge queue')
+      },
+      getPullRequest: async () => {
+        pullReads++
+        if (pullReads === 1) return makePullRequest()
+        return makePullRequest({
+          state: 'closed',
+          merged_at: '2026-08-24T00:30:00Z',
+          merge_commit_sha: mergedSha,
+        })
+      },
+      verifyMergedCommit: async (sha) => {
+        events.push(`verified ${sha}`)
+      },
+    })
+
+    await expect(mergeStableRelease('2.7.8', targetSha, operations)).resolves.toBe(
+      mergedSha
+    )
+    expect(events).toEqual([
+      'verified release commit',
+      'pushed release-v2.7.8',
+      'opened pull request',
+      'dispatched checks',
+      'entered merge queue',
+      `verified ${mergedSha}`,
+    ])
+  })
+
+  test('resumes from an already merged release without opening another pull request', async () => {
+    const events: string[] = []
+    const mergedPullRequest = makePullRequest({
+      state: 'closed',
+      merged_at: '2026-08-24T00:30:00Z',
+      merge_commit_sha: mergedSha,
+    })
+    const operations = makeOperations({
+      findPullRequests: async () => [mergedPullRequest],
+      ensureReleaseBranch: async () => {
+        events.push('pushed')
+      },
+      dispatchChecks: async () => {
+        events.push('dispatched')
+      },
+      enqueuePullRequest: async () => {
+        events.push('queued')
+      },
+      verifyMergedCommit: async () => {
+        events.push('verified merged commit')
+      },
+    })
+
+    await expect(mergeStableRelease('2.7.8', targetSha, operations)).resolves.toBe(
+      mergedSha
+    )
+    expect(events).toEqual(['verified merged commit'])
+  })
+
+  test('does not create a release branch after main advances', async () => {
+    let releaseBranchCreated = false
+    const operations = makeOperations({
+      getCurrentMainSha: async () => '4'.repeat(40),
+      ensureReleaseBranch: async () => {
+        releaseBranchCreated = true
+      },
+    })
+
+    await expect(mergeStableRelease('2.7.8', targetSha, operations)).rejects.toThrow(
+      'main advanced'
+    )
+    expect(releaseBranchCreated).toBe(false)
+  })
+
+  test('does not enqueue a release whose full CI failed', async () => {
+    let enqueued = false
+    const operations = makeOperations({
+      findPullRequests: async () => [makePullRequest()],
+      listChecksRuns: async () => [
+        {
+          id: 8,
+          event: 'workflow_dispatch',
+          head_sha: releaseSha,
+          status: 'completed',
+          conclusion: 'failure',
+          created_at: '2026-08-24T00:00:00Z',
+        },
+      ],
+      enqueuePullRequest: async () => {
+        enqueued = true
+      },
+    })
+
+    await expect(mergeStableRelease('2.7.8', targetSha, operations)).rejects.toThrow(
+      'Checks run 8 concluded failure'
+    )
+    expect(enqueued).toBe(false)
+  })
+})

--- a/scripts/release-github.ts
+++ b/scripts/release-github.ts
@@ -33,7 +33,7 @@ export type StableReleaseOperations = {
   listChecksRuns(headSha: string): Promise<WorkflowRun[]>
   dispatchChecks(branch: string): Promise<void>
   getWorkflowRun(runId: number): Promise<WorkflowRun>
-  enqueuePullRequest(pullRequest: ReleasePullRequest): Promise<void>
+  squashPullRequest(pullRequest: ReleasePullRequest): Promise<void>
   getPullRequest(number: number): Promise<ReleasePullRequest>
   verifyMergedCommit(sha: string): Promise<void>
   sleep(ms: number): Promise<void>
@@ -104,7 +104,7 @@ export async function mergeStableRelease(
   await operations.verifyPreparedCommit(version, targetSha)
 
   // refs/heads/release already exists, so a release/... namespace cannot be created.
-  const branch = `release-v${version}`
+  const branch = `release-v${version}-${targetSha}`
   const existingPullRequests = await operations.findPullRequests(branch)
   if (existingPullRequests.length > 1) {
     throw new Error(`Multiple pull requests use ${branch}`)
@@ -138,7 +138,11 @@ export async function mergeStableRelease(
 
   pullRequest = await operations.getPullRequest(pullRequest.number)
   if (!pullRequest.merged_at) {
-    await operations.enqueuePullRequest(pullRequest)
+    const mainSha = await operations.getCurrentMainSha()
+    if (mainSha !== targetSha) {
+      throw new Error(`main advanced from ${targetSha} to ${mainSha}`)
+    }
+    await operations.squashPullRequest(pullRequest)
   }
 
   for (let attempt = 0; attempt < 50; attempt++) {
@@ -161,6 +165,8 @@ export async function mergeStableRelease(
   throw new Error(`Timed out waiting for release pull request #${pullRequest.number}`)
 }
 
+export type CommandRunner = (command: string, args: string[]) => Promise<string>
+
 async function run(command: string, args: string[]) {
   const { stdout } = await execFileAsync(command, args, {
     maxBuffer: 10 * 1024 * 1024,
@@ -173,7 +179,8 @@ function parseJSON<T>(value: string): T {
 }
 
 export function createStableReleaseOperations(
-  repository: string
+  repository: string,
+  execute: CommandRunner = run
 ): StableReleaseOperations {
   const [owner] = repository.split('/')
   if (!owner || !repository.includes('/')) {
@@ -182,16 +189,16 @@ export function createStableReleaseOperations(
 
   const getPullRequest = async (number: number) =>
     parseJSON<ReleasePullRequest>(
-      await run('gh', ['api', `repos/${repository}/pulls/${number}`])
+      await execute('gh', ['api', `repos/${repository}/pulls/${number}`])
     )
 
   return {
     async verifyPreparedCommit(version, targetSha) {
-      const subject = await run('git', ['show', '-s', '--format=%s', 'HEAD'])
+      const subject = await execute('git', ['show', '-s', '--format=%s', 'HEAD'])
       if (subject !== `v${version}`) {
         throw new Error(`Prepared commit subject is ${subject}, expected v${version}`)
       }
-      const parent = await run('git', ['rev-parse', 'HEAD^'])
+      const parent = await execute('git', ['rev-parse', 'HEAD^'])
       if (parent !== targetSha) {
         throw new Error(`Prepared commit parent is ${parent}, expected ${targetSha}`)
       }
@@ -199,7 +206,7 @@ export function createStableReleaseOperations(
 
     async findPullRequests(branch) {
       return parseJSON<ReleasePullRequest[]>(
-        await run('gh', [
+        await execute('gh', [
           'api',
           '--method',
           'GET',
@@ -217,26 +224,26 @@ export function createStableReleaseOperations(
     },
 
     async getCurrentMainSha() {
-      await run('git', ['fetch', '--no-tags', 'origin', 'main'])
-      return run('git', ['rev-parse', 'FETCH_HEAD'])
+      await execute('git', ['fetch', '--no-tags', 'origin', 'main'])
+      return execute('git', ['rev-parse', 'FETCH_HEAD'])
     },
 
     async ensureReleaseBranch(branch) {
-      const remote = await run('git', [
+      const remote = await execute('git', [
         'ls-remote',
         '--heads',
         'origin',
         `refs/heads/${branch}`,
       ])
       if (!remote) {
-        await run('git', ['push', 'origin', `HEAD:refs/heads/${branch}`])
+        await execute('git', ['push', 'origin', `HEAD:refs/heads/${branch}`])
         return
       }
 
-      await run('git', ['fetch', '--no-tags', 'origin', `refs/heads/${branch}`])
+      await execute('git', ['fetch', '--no-tags', 'origin', `refs/heads/${branch}`])
       const [localTree, remoteTree] = await Promise.all([
-        run('git', ['rev-parse', 'HEAD^{tree}']),
-        run('git', ['rev-parse', 'FETCH_HEAD^{tree}']),
+        execute('git', ['rev-parse', 'HEAD^{tree}']),
+        execute('git', ['rev-parse', 'FETCH_HEAD^{tree}']),
       ])
       if (localTree !== remoteTree) {
         throw new Error(`Existing ${branch} has different release content`)
@@ -245,7 +252,7 @@ export function createStableReleaseOperations(
 
     async createPullRequest(branch, version) {
       return parseJSON<ReleasePullRequest>(
-        await run('gh', [
+        await execute('gh', [
           'api',
           '--method',
           'POST',
@@ -257,14 +264,14 @@ export function createStableReleaseOperations(
           '-f',
           'base=main',
           '-f',
-          'body=Generated by the stable release workflow. Full CI must pass before this enters the merge queue.',
+          'body=Generated by the stable release workflow. Full CI must pass before this is squash-merged into protected main.',
         ])
       )
     },
 
     async listChecksRuns(headSha) {
       const response = parseJSON<{ workflow_runs: WorkflowRun[] }>(
-        await run('gh', [
+        await execute('gh', [
           'api',
           '--method',
           'GET',
@@ -279,7 +286,7 @@ export function createStableReleaseOperations(
     },
 
     async dispatchChecks(branch) {
-      await run('gh', [
+      await execute('gh', [
         'api',
         '--method',
         'POST',
@@ -291,43 +298,18 @@ export function createStableReleaseOperations(
 
     async getWorkflowRun(runId) {
       return parseJSON<WorkflowRun>(
-        await run('gh', ['api', `repos/${repository}/actions/runs/${runId}`])
+        await execute('gh', ['api', `repos/${repository}/actions/runs/${runId}`])
       )
     },
 
-    async enqueuePullRequest(pullRequest) {
-      const queueState = parseJSON<{
-        data: {
-          repository: {
-            pullRequest: {
-              autoMergeRequest: unknown
-              mergeQueueEntry: unknown
-            }
-          }
-        }
-      }>(
-        await run('gh', [
-          'api',
-          'graphql',
-          '-F',
-          `owner=${owner}`,
-          '-F',
-          `name=${repository.slice(owner.length + 1)}`,
-          '-F',
-          `number=${pullRequest.number}`,
-          '-f',
-          'query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){autoMergeRequest{enabledAt} mergeQueueEntry{position state}}}}',
-        ])
-      ).data.repository.pullRequest
-
-      if (queueState.autoMergeRequest || queueState.mergeQueueEntry) return
-
-      await run('gh', [
+    async squashPullRequest(pullRequest) {
+      await execute('gh', [
         'pr',
         'merge',
         String(pullRequest.number),
         '--repo',
         repository,
+        '--squash',
         '--match-head-commit',
         pullRequest.head.sha,
       ])
@@ -336,8 +318,8 @@ export function createStableReleaseOperations(
     getPullRequest,
 
     async verifyMergedCommit(sha) {
-      await run('git', ['fetch', '--no-tags', 'origin', 'main'])
-      await run('git', ['merge-base', '--is-ancestor', sha, 'FETCH_HEAD'])
+      await execute('git', ['fetch', '--no-tags', 'origin', 'main'])
+      await execute('git', ['merge-base', '--is-ancestor', sha, 'FETCH_HEAD'])
     },
 
     sleep(ms) {

--- a/scripts/release-github.ts
+++ b/scripts/release-github.ts
@@ -1,0 +1,368 @@
+import { execFile } from 'node:child_process'
+import { appendFile } from 'node:fs/promises'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+type ReleasePullRequest = {
+  number: number
+  state: 'open' | 'closed'
+  merged_at: string | null
+  merge_commit_sha: string | null
+  head: {
+    ref: string
+    sha: string
+  }
+}
+
+type WorkflowRun = {
+  id: number
+  event: string
+  head_sha: string
+  status: string
+  conclusion: string | null
+  created_at: string
+}
+
+export type StableReleaseOperations = {
+  verifyPreparedCommit(version: string, targetSha: string): Promise<void>
+  findPullRequests(branch: string): Promise<ReleasePullRequest[]>
+  getCurrentMainSha(): Promise<string>
+  ensureReleaseBranch(branch: string): Promise<void>
+  createPullRequest(branch: string, version: string): Promise<ReleasePullRequest>
+  listChecksRuns(headSha: string): Promise<WorkflowRun[]>
+  dispatchChecks(branch: string): Promise<void>
+  getWorkflowRun(runId: number): Promise<WorkflowRun>
+  enqueuePullRequest(pullRequest: ReleasePullRequest): Promise<void>
+  getPullRequest(number: number): Promise<ReleasePullRequest>
+  verifyMergedCommit(sha: string): Promise<void>
+  sleep(ms: number): Promise<void>
+}
+
+function latestRun(runs: WorkflowRun[], headSha: string) {
+  return runs
+    .filter((run) => run.head_sha === headSha)
+    .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))[0]
+}
+
+async function requireSuccessfulChecks(
+  headSha: string,
+  branch: string,
+  operations: StableReleaseOperations
+) {
+  let runs = await operations.listChecksRuns(headSha)
+  let run = latestRun(runs, headSha)
+
+  if (!run) {
+    const previousRunIds = new Set(runs.map(({ id }) => id))
+    await operations.dispatchChecks(branch)
+
+    for (let attempt = 0; attempt < 12; attempt++) {
+      await operations.sleep(10_000)
+      runs = await operations.listChecksRuns(headSha)
+      run = latestRun(
+        runs.filter(
+          ({ id, event }) => event === 'workflow_dispatch' && !previousRunIds.has(id)
+        ),
+        headSha
+      )
+      if (run) break
+    }
+
+    if (!run) {
+      throw new Error(`Checks did not start for ${headSha}`)
+    }
+  }
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (run.status === 'completed') {
+      if (run.conclusion !== 'success') {
+        throw new Error(`Checks run ${run.id} concluded ${run.conclusion}`)
+      }
+      return
+    }
+
+    await operations.sleep(120_000)
+    run = await operations.getWorkflowRun(run.id)
+  }
+
+  throw new Error(`Timed out waiting for Checks run ${run.id}`)
+}
+
+export async function mergeStableRelease(
+  version: string,
+  targetSha: string,
+  operations: StableReleaseOperations
+) {
+  if (!/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Stable release version must be X.Y.Z, received ${version}`)
+  }
+  if (!/^[0-9a-f]{40}$/.test(targetSha)) {
+    throw new Error(`Invalid release source SHA ${targetSha}`)
+  }
+
+  await operations.verifyPreparedCommit(version, targetSha)
+
+  // refs/heads/release already exists, so a release/... namespace cannot be created.
+  const branch = `release-v${version}`
+  const existingPullRequests = await operations.findPullRequests(branch)
+  if (existingPullRequests.length > 1) {
+    throw new Error(`Multiple pull requests use ${branch}`)
+  }
+
+  let pullRequest = existingPullRequests[0]
+  if (pullRequest?.merged_at) {
+    if (!pullRequest.merge_commit_sha) {
+      throw new Error(`Merged pull request #${pullRequest.number} has no merge commit`)
+    }
+    await operations.verifyMergedCommit(pullRequest.merge_commit_sha)
+    return pullRequest.merge_commit_sha
+  }
+  if (pullRequest?.state === 'closed') {
+    throw new Error(
+      `Release pull request #${pullRequest.number} was closed without merging`
+    )
+  }
+
+  if (!pullRequest) {
+    const mainSha = await operations.getCurrentMainSha()
+    if (mainSha !== targetSha) {
+      throw new Error(`main advanced from ${targetSha} to ${mainSha}`)
+    }
+  }
+
+  await operations.ensureReleaseBranch(branch)
+  pullRequest ||= await operations.createPullRequest(branch, version)
+
+  await requireSuccessfulChecks(pullRequest.head.sha, branch, operations)
+
+  pullRequest = await operations.getPullRequest(pullRequest.number)
+  if (!pullRequest.merged_at) {
+    await operations.enqueuePullRequest(pullRequest)
+  }
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    pullRequest = await operations.getPullRequest(pullRequest.number)
+    if (pullRequest.merged_at) {
+      if (!pullRequest.merge_commit_sha) {
+        throw new Error(`Merged pull request #${pullRequest.number} has no merge commit`)
+      }
+      await operations.verifyMergedCommit(pullRequest.merge_commit_sha)
+      return pullRequest.merge_commit_sha
+    }
+    if (pullRequest.state === 'closed') {
+      throw new Error(
+        `Release pull request #${pullRequest.number} closed without merging`
+      )
+    }
+    await operations.sleep(120_000)
+  }
+
+  throw new Error(`Timed out waiting for release pull request #${pullRequest.number}`)
+}
+
+async function run(command: string, args: string[]) {
+  const { stdout } = await execFileAsync(command, args, {
+    maxBuffer: 10 * 1024 * 1024,
+  })
+  return stdout.trim()
+}
+
+function parseJSON<T>(value: string): T {
+  return JSON.parse(value) as T
+}
+
+export function createStableReleaseOperations(
+  repository: string
+): StableReleaseOperations {
+  const [owner] = repository.split('/')
+  if (!owner || !repository.includes('/')) {
+    throw new Error(`Invalid GitHub repository ${repository}`)
+  }
+
+  const getPullRequest = async (number: number) =>
+    parseJSON<ReleasePullRequest>(
+      await run('gh', ['api', `repos/${repository}/pulls/${number}`])
+    )
+
+  return {
+    async verifyPreparedCommit(version, targetSha) {
+      const subject = await run('git', ['show', '-s', '--format=%s', 'HEAD'])
+      if (subject !== `v${version}`) {
+        throw new Error(`Prepared commit subject is ${subject}, expected v${version}`)
+      }
+      const parent = await run('git', ['rev-parse', 'HEAD^'])
+      if (parent !== targetSha) {
+        throw new Error(`Prepared commit parent is ${parent}, expected ${targetSha}`)
+      }
+    },
+
+    async findPullRequests(branch) {
+      return parseJSON<ReleasePullRequest[]>(
+        await run('gh', [
+          'api',
+          '--method',
+          'GET',
+          `repos/${repository}/pulls`,
+          '-f',
+          'state=all',
+          '-f',
+          `head=${owner}:${branch}`,
+          '-f',
+          'base=main',
+          '-f',
+          'per_page=100',
+        ])
+      )
+    },
+
+    async getCurrentMainSha() {
+      await run('git', ['fetch', '--no-tags', 'origin', 'main'])
+      return run('git', ['rev-parse', 'FETCH_HEAD'])
+    },
+
+    async ensureReleaseBranch(branch) {
+      const remote = await run('git', [
+        'ls-remote',
+        '--heads',
+        'origin',
+        `refs/heads/${branch}`,
+      ])
+      if (!remote) {
+        await run('git', ['push', 'origin', `HEAD:refs/heads/${branch}`])
+        return
+      }
+
+      await run('git', ['fetch', '--no-tags', 'origin', `refs/heads/${branch}`])
+      const [localTree, remoteTree] = await Promise.all([
+        run('git', ['rev-parse', 'HEAD^{tree}']),
+        run('git', ['rev-parse', 'FETCH_HEAD^{tree}']),
+      ])
+      if (localTree !== remoteTree) {
+        throw new Error(`Existing ${branch} has different release content`)
+      }
+    },
+
+    async createPullRequest(branch, version) {
+      return parseJSON<ReleasePullRequest>(
+        await run('gh', [
+          'api',
+          '--method',
+          'POST',
+          `repos/${repository}/pulls`,
+          '-f',
+          `title=v${version}`,
+          '-f',
+          `head=${branch}`,
+          '-f',
+          'base=main',
+          '-f',
+          'body=Generated by the stable release workflow. Full CI must pass before this enters the merge queue.',
+        ])
+      )
+    },
+
+    async listChecksRuns(headSha) {
+      const response = parseJSON<{ workflow_runs: WorkflowRun[] }>(
+        await run('gh', [
+          'api',
+          '--method',
+          'GET',
+          `repos/${repository}/actions/workflows/checks.yaml/runs`,
+          '-f',
+          `head_sha=${headSha}`,
+          '-f',
+          'per_page=20',
+        ])
+      )
+      return response.workflow_runs
+    },
+
+    async dispatchChecks(branch) {
+      await run('gh', [
+        'api',
+        '--method',
+        'POST',
+        `repos/${repository}/actions/workflows/checks.yaml/dispatches`,
+        '-f',
+        `ref=${branch}`,
+      ])
+    },
+
+    async getWorkflowRun(runId) {
+      return parseJSON<WorkflowRun>(
+        await run('gh', ['api', `repos/${repository}/actions/runs/${runId}`])
+      )
+    },
+
+    async enqueuePullRequest(pullRequest) {
+      const queueState = parseJSON<{
+        data: {
+          repository: {
+            pullRequest: {
+              autoMergeRequest: unknown
+              mergeQueueEntry: unknown
+            }
+          }
+        }
+      }>(
+        await run('gh', [
+          'api',
+          'graphql',
+          '-F',
+          `owner=${owner}`,
+          '-F',
+          `name=${repository.slice(owner.length + 1)}`,
+          '-F',
+          `number=${pullRequest.number}`,
+          '-f',
+          'query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){autoMergeRequest{enabledAt} mergeQueueEntry{position state}}}}',
+        ])
+      ).data.repository.pullRequest
+
+      if (queueState.autoMergeRequest || queueState.mergeQueueEntry) return
+
+      await run('gh', [
+        'pr',
+        'merge',
+        String(pullRequest.number),
+        '--repo',
+        repository,
+        '--match-head-commit',
+        pullRequest.head.sha,
+      ])
+    },
+
+    getPullRequest,
+
+    async verifyMergedCommit(sha) {
+      await run('git', ['fetch', '--no-tags', 'origin', 'main'])
+      await run('git', ['merge-base', '--is-ancestor', sha, 'FETCH_HEAD'])
+    },
+
+    sleep(ms) {
+      return new Promise((resolve) => setTimeout(resolve, ms))
+    },
+  }
+}
+
+if (import.meta.main) {
+  const version = process.env.RELEASE_VERSION
+  const targetSha = process.env.TARGET_SHA
+  const repository = process.env.GITHUB_REPOSITORY
+  const outputPath = process.env.GITHUB_OUTPUT
+
+  if (!version || !targetSha || !repository || !outputPath) {
+    throw new Error(
+      'RELEASE_VERSION, TARGET_SHA, GITHUB_REPOSITORY, and GITHUB_OUTPUT are required'
+    )
+  }
+
+  const mergedSha = await mergeStableRelease(
+    version,
+    targetSha,
+    createStableReleaseOperations(repository)
+  )
+  await appendFile(outputPath, `merged-sha=${mergedSha}\n`)
+  console.info(`Release v${version} merged at ${mergedSha}`)
+}

--- a/scripts/release-github.ts
+++ b/scripts/release-github.ts
@@ -33,7 +33,7 @@ export type StableReleaseOperations = {
   listChecksRuns(headSha: string): Promise<WorkflowRun[]>
   dispatchChecks(branch: string): Promise<void>
   getWorkflowRun(runId: number): Promise<WorkflowRun>
-  squashPullRequest(pullRequest: ReleasePullRequest): Promise<void>
+  squashPullRequest(number: number, checkedHeadSha: string): Promise<void>
   getPullRequest(number: number): Promise<ReleasePullRequest>
   verifyMergedCommit(sha: string): Promise<void>
   sleep(ms: number): Promise<void>
@@ -134,15 +134,21 @@ export async function mergeStableRelease(
   await operations.ensureReleaseBranch(branch)
   pullRequest ||= await operations.createPullRequest(branch, version)
 
-  await requireSuccessfulChecks(pullRequest.head.sha, branch, operations)
+  const checkedHeadSha = pullRequest.head.sha
+  await requireSuccessfulChecks(checkedHeadSha, branch, operations)
 
   pullRequest = await operations.getPullRequest(pullRequest.number)
+  if (pullRequest.head.sha !== checkedHeadSha) {
+    throw new Error(
+      `Release pull request #${pullRequest.number} head changed from ${checkedHeadSha} to ${pullRequest.head.sha} after Checks`
+    )
+  }
   if (!pullRequest.merged_at) {
     const mainSha = await operations.getCurrentMainSha()
     if (mainSha !== targetSha) {
       throw new Error(`main advanced from ${targetSha} to ${mainSha}`)
     }
-    await operations.squashPullRequest(pullRequest)
+    await operations.squashPullRequest(pullRequest.number, checkedHeadSha)
   }
 
   for (let attempt = 0; attempt < 50; attempt++) {
@@ -302,16 +308,16 @@ export function createStableReleaseOperations(
       )
     },
 
-    async squashPullRequest(pullRequest) {
+    async squashPullRequest(number, checkedHeadSha) {
       await execute('gh', [
         'pr',
         'merge',
-        String(pullRequest.number),
+        String(number),
         '--repo',
         repository,
         '--squash',
         '--match-head-commit',
-        pullRequest.head.sha,
+        checkedHeadSha,
       ])
     },
 


### PR DESCRIPTION
## Summary

- prepare stable version commits on a branch keyed by version and source SHA
- run one full Checks workflow on the exact version commit
- recheck main, then squash the exact checked head through a protected pull request
- build and publish the merged SHA through npm trusted publishing, then create the stable tag
- keep canary publishing separate and free of remote Git mutations

## Failure evidence

Release run 32674469962 prepared the 2.7.8 commit, then GitHub rejected the direct HEAD:main push with GH013 because protected main requires a pull request and the checks status. Publish and tag steps were skipped.

## Validation

- 29 release-script tests pass, including the production gh command boundary
- targeted TypeScript no-emit check passes
- actionlint passes for release.yml
- oxfmt passes
- patch dry run selects 2.7.8 on npm latest without publishing

Full root typecheck and build remain deferred under the machine capacity constraint.