### PR TITLE
test(kitchen-sink): start accordion frame window on motion

### DIFF
--- a/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
+++ b/code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx
@@ -12,7 +12,8 @@ import { Accordion, Button, Paragraph, Square, View, YStack, isWeb } from 'tamag
 function useHeightFrameRecorder(animatedRef: any, duration = 750) {
   const [label, setLabel] = useState('idle')
   const recording = useSharedValue(false)
-  const startedAt = useSharedValue(0)
+  const initialHeight = useSharedValue<number | null>(null)
+  const motionStartedAt = useSharedValue<number | null>(null)
   const cycle = useSharedValue(0)
   const samples = useSharedValue<number[]>([])
   const nextCycleRef = useRef(0)
@@ -28,16 +29,32 @@ function useHeightFrameRecorder(animatedRef: any, duration = 750) {
         if (isWeb || !recording.value) return
         const frame = measure(animatedRef)
         if (!frame) return
-        if (startedAt.value === 0) {
-          startedAt.value = timestamp
-        }
         samples.value = [...samples.value, frame.height]
-        if (timestamp - startedAt.value >= duration) {
+        if (initialHeight.value === null) {
+          initialHeight.value = frame.height
+          return
+        }
+        // opening mounts and measures closed content before it has a numeric target.
+        // keep those baseline frames, but start the sampling window when motion begins.
+        if (motionStartedAt.value === null) {
+          if (Math.abs(frame.height - initialHeight.value) <= 0.25) return
+          motionStartedAt.value = timestamp
+        }
+        if (timestamp - motionStartedAt.value >= duration) {
           recording.value = false
           runOnJS(finishRecording)(cycle.value, samples.value)
         }
       },
-      [animatedRef, cycle, duration, finishRecording, recording, samples, startedAt]
+      [
+        animatedRef,
+        cycle,
+        duration,
+        finishRecording,
+        initialHeight,
+        motionStartedAt,
+        recording,
+        samples,
+      ]
     )
   )
 
@@ -45,11 +62,12 @@ function useHeightFrameRecorder(animatedRef: any, duration = 750) {
     if (isWeb) return
     const nextCycle = ++nextCycleRef.current
     setLabel(`recording:${nextCycle}`)
-    startedAt.value = 0
+    initialHeight.value = null
+    motionStartedAt.value = null
     samples.value = []
     cycle.value = nextCycle
     recording.value = true
-  }, [cycle, recording, samples, startedAt])
+  }, [cycle, initialHeight, motionStartedAt, recording, samples])
 
   return [label, startRecording] as const
 }


### PR DESCRIPTION
## Cause

The iOS recorder started its 1.5 second sample budget on the first closed-height measurement after `onPressIn`. Under the failing CI load, the closed item spent that budget mounting and measuring at height 0 before numeric-height motion began. The retry captured nineteen zeros and then observed the opened content at height 84. The default-open close case passed because it already had a numeric height when recording started.

## Fix

Keep the baseline frames, but start the unchanged sampling duration at the first measured height change. An endpoint snap still produces endpoint-only samples and fails the existing intermediate-height assertion.

No timeout, retry, platform skip, fallback, or behavioral assertion changed. Main has no compatible runtime fix to cherry-pick; its divergent commits remove or conditionally skip this opening coverage.

## Validation

- `bun x oxfmt --check code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx`
- `bun x oxlint code/kitchen-sink/src/usecases/AccordionDefaultOpenCase.tsx`
- `git diff --check`
- `bun install --frozen-lockfile`
- `RCT_USE_PREBUILT_RNCORE=0 bun run pod` completed dependency preparation

The local iOS build and Detox run were withheld after the designated manager reported host capacity saturation. Remaining native command for its dedicated lane:

```sh
cd code/kitchen-sink && DETOX_DEVICE_UDID=<dedicated-simulator-udid> bun run detox:run:ios "opens, reverses, and closes through intermediate numeric heights"
```

Root lint, root check, and a fresh typecheck were also withheld under that capacity instruction.