### PR TITLE
fix(native-registry): normalize dynamic color objects

### DIFF
--- a/code/core/native-registry/src/__tests__/processStyleColors.test.ts
+++ b/code/core/native-registry/src/__tests__/processStyleColors.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from 'vitest'
 // processColor is the react-native one; stub it to the ARGB packing it returns so
 // the channel unpacking is what gets asserted here rather than RN's css parsing.
 vi.mock('react-native', () => ({
-  processColor: (value: string) => {
+  processColor: (value: unknown) => {
+    if (typeof value === 'object' && value !== null && 'dynamic' in value) {
+      return { dynamic: { light: 0xffffffff, dark: 0xff000000 } }
+    }
     if (value === 'grey') return 0xffe3e3e3
     if (value === 'blue') return 0xff0000ff
     if (value === 'half-red') return 0x80ff0000
@@ -62,6 +65,16 @@ describe('processStyleColors', () => {
   it('passes a platform color object through untouched', () => {
     expect(processStyleColors({ color: 'platform' })).toEqual({
       color: { semantic: 'label' },
+    })
+  })
+
+  it('normalizes dynamic color branches before passing them to Fabric', () => {
+    expect(
+      processStyleColors({
+        color: { dynamic: { light: 'white', dark: 'black' } },
+      })
+    ).toEqual({
+      color: { dynamic: { light: 0xffffffff, dark: 0xff000000 } },
     })
   })
 

--- a/code/core/native-registry/src/processStyleColors.ts
+++ b/code/core/native-registry/src/processStyleColors.ts
@@ -19,7 +19,7 @@
  *    parser but not this one, and the throw kills the mount-item dispatch and
  *    tears the whole React surface down.
  */
-import { processColor } from 'react-native'
+import { processColor, type ColorValue } from 'react-native'
 
 const COLOR_PROPS = new Set([
   'color',
@@ -51,7 +51,10 @@ export function processStyleColors(
     // a style may already carry the packed int form RN accepts (`processColor`
     // output written straight into a style), and that form is misread the same
     // way, so it converts here too rather than only css strings
-    const processed = typeof value === 'string' ? processColor(value) : value
+    const processed =
+      typeof value === 'string' || (typeof value === 'object' && value !== null)
+        ? processColor(value as ColorValue)
+        : value
     if (typeof processed === 'number') {
       out ??= { ...props }
       // processColor packs ARGB, and is signed on Android, hence >>>
@@ -62,9 +65,9 @@ export function processStyleColors(
         b: (processed & 0xff) / 255,
         a: ((processed >>> 24) & 0xff) / 255,
       }
-    } else if (typeof value === 'string' && processed != null) {
-      // a platform color resolves to an opaque object rather than a number, and
-      // Fabric unpacks that shape itself, so it goes over untouched
+    } else if (processed != null && typeof processed === 'object') {
+      // platform and dynamic colors resolve to opaque objects. processColor
+      // normalizes their color branches before Fabric unpacks the shape.
       out ??= { ...props }
       out[key] = processed
     }


### PR DESCRIPTION
## What changed

- process React Native dynamic and platform color objects before they reach Fabric
- preserve normalized opaque color objects while retaining existing packed-color conversion
- cover DynamicColorIOS branch normalization in the native registry tests

## Runtime proof

On the Team Machine rv57 iOS app, switching light to dark previously left ordinary overview and shared PiP content text painted with light-theme colors. The native style engine was passing DynamicColorIOS objects containing raw CSS color strings directly to Fabric. With this change, React Native processColor normalizes both branches first. The same light-to-dark run keeps overview and PiP text readable.

## Validation

- native-registry tests: 8 passed
- bun run build in code/core/native-registry
- Team Machine native-style contracts: 21 passed
- clean iOS simulator light-to-dark homepage and shared PiP runtime proof
- assigned cross-harness review: no findings