### PR TITLE
ci: carry the workflow_run drift warning on main's release.yml copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,19 @@
 name: Release
 
-# github evaluates workflow_run from the default branch. keep this workflow on
-# main as well as v3-beta so successful v3-beta CI can publish automatically.
+# github evaluates workflow_run from the DEFAULT BRANCH. the beta job below fires
+# on a v3-beta push but runs main's copy of this file, so editing it on v3-beta
+# alone changes nothing and fails silently: the run looks normal and behaves as
+# though your change is not there, because it is not. a fix to this file has to
+# land on main to take effect. that cost three full CI cycles on 2026-08-21,
+# where two consecutive "fixes" to the beta job appeared to do nothing at all.
+#
+# the two copies are therefore kept byte-identical, so that
+#   git diff origin/main:.github/workflows/release.yml origin/v3-beta:.github/workflows/release.yml
+# prints nothing whenever they agree. any output at all means they have drifted
+# and the beta job is not what the branch you are reading says it is. letting the
+# stable jobs alone drift 290 lines made that diff useless to read and sent an
+# investigation on 2026-08-25 after a beta cut that had in fact worked. change
+# this file on both branches, in the same change.
 on:
   workflow_run:
     workflows: [Checks]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,17 +3,22 @@ name: Release
 # github evaluates workflow_run from the DEFAULT BRANCH. the beta job below fires
 # on a v3-beta push but runs main's copy of this file, so editing it on v3-beta
 # alone changes nothing and fails silently: the run looks normal and behaves as
-# though your change is not there, because it is not. a fix to this file has to
-# land on main to take effect. that cost three full CI cycles on 2026-08-21,
+# though your change is not there, because it is not. a fix to the beta job has
+# to land on main to take effect. that cost three full CI cycles on 2026-08-21,
 # where two consecutive "fixes" to the beta job appeared to do nothing at all.
 #
-# the two copies are therefore kept byte-identical, so that
-#   git diff origin/main:.github/workflows/release.yml origin/v3-beta:.github/workflows/release.yml
-# prints nothing whenever they agree. any output at all means they have drifted
-# and the beta job is not what the branch you are reading says it is. letting the
-# stable jobs alone drift 290 lines made that diff useless to read and sent an
-# investigation on 2026-08-25 after a beta cut that had in fact worked. change
-# this file on both branches, in the same change.
+# what has to match across the two branches is the `on:` block and the `beta`
+# job. the jobs after them are expected to differ: main cuts stable releases
+# through a merge queue and calls scripts/release-github.ts, a file that exists
+# only on main, so copying main's whole file onto v3-beta fails `bun run check`
+# with an unlisted-binary error from knip. that was tried on 2026-08-25.
+#
+# so when debugging a beta cut, run
+#   git diff origin/main:.github/workflows/release.yml \
+#     origin/v3-beta:.github/workflows/release.yml
+# and check that every hunk lands in the stable or canary jobs. a hunk in the
+# `on:` block or in the `beta` job means the beta cut is not running what the
+# branch you are reading says it runs.
 on:
   workflow_run:
     workflows: [Checks]


### PR DESCRIPTION
Comment-only change to `.github/workflows/release.yml`. No job, step, trigger, or condition is touched; the body below the header is byte-identical to current main.

GitHub evaluates `workflow_run` from the default branch, so the beta job that actually publishes a v3 beta is **main's** copy of this file. Until now the warning explaining that lived only on the v3-beta copy, which is the one that never runs. This puts it on the copy that does.

It also records the invariant precisely, which the old wording ("keep the two copies in step") got wrong:

- the `on:` block and the `beta` job **must** match on both branches, because a beta cut runs main's version of them. They are currently identical.
- the jobs after them are **expected to differ**. Main cuts stable releases through a merge queue and calls `scripts/release-github.ts`, a file that exists only on main. Copying main's whole file onto v3-beta fails `bun run check` there, because knip reports it as an unlisted binary. I tried exactly that and it went red, so the header now says so.

Paired with 59d626873a on v3-beta, which carries the same corrected header.