### PR TITLE
fix(animations-reanimated): guard onStart on non-animation values

### DIFF
--- a/code/core/animations-reanimated/src/createAnimations.tsx
+++ b/code/core/animations-reanimated/src/createAnimations.tsx
@@ -426,7 +426,13 @@ const applyAnimation = (
   // wrapper substitutes the seed for whatever start value reanimated passes.
   // color history gets the same treatment only when reanimated's own parser
   // rejects it, preserving valid in-flight values during interruption.
-  if (seedValue !== undefined || validateStartAsColor) {
+  // inside initialUpdaterRun withSpring returns a raw value, not a definition —
+  // writing onStart onto it throws and poisons animation app-wide until reload.
+  if (
+    (seedValue !== undefined || validateStartAsColor) &&
+    animatedValue !== null &&
+    (typeof animatedValue === 'object' || typeof animatedValue === 'function')
+  ) {
     const innerOnStart = animatedValue.onStart
     animatedValue.onStart = (
       animation: unknown,


### PR DESCRIPTION
Fixes #4193 

## Summary

Prevents the `Cannot create property 'onStart' on number 'N'` crash in `@tamagui/animations-reanimated`.

`applyAnimation` attaches a seed-substituting `onStart` wrapper onto the value returned by `withSpring`/`withTiming` without checking that the call actually produced an animation definition. When the style updater runs inside reanimated's `initialUpdaterRun` — `useAnimatedStyle`'s first style computation, which happens on remount of an already-painted component — `defineAnimation` short-circuits and returns the raw starting value, a primitive:

- in react-native-reanimated `src/animation/util.ts`, `initialUpdaterRun` sets `IN_STYLE_UPDATER.current = true`, and `defineAnimation` returns `starting` when that flag is set on the JS runtime;
- tamagui then writes `.onStart` onto that primitive → `TypeError: Cannot create property 'onStart' on number '54'`;
- `initialUpdaterRun` has no try/finally, so the throw leaves `IN_STYLE_UPDATER.current` stuck at `true` — every subsequent `withSpring`/`withTiming` call also returns a raw value, and animation breaks app-wide until a full JS reload.

## The fix

A definition from `withSpring`/`withTiming` is either the decorated animation object (UI thread) or the `__isAnimationDefinition` factory function (JS thread) — both can carry the `onStart` property. Only the primitive short-circuit path is now skipped: the key just paints its target for that first computation instead of crashing, and seeds plus the color-validation wrapper are untouched on every normal path.

This is the tamagui-side half of the fix suggested in #4193; either half independently prevents the crash. The reanimated-side half (try/finally around `initialUpdaterRun`) is tracked in software-mansion/react-native-reanimated#10433.

## Testing

- Package build (esm/cjs/types), `oxfmt --check` and `oxlint` all pass.
- Walkthrough of the #4193 repro (remount of a painted `width={54}` + `animation="quick"` + `pressStyle` component): on that remount `withSpring` returns `54`, the assignment is now skipped, the render completes, and the next mapper runs (outside `initialUpdaterRun`) produce real animation definitions again — before the patch the same path threw the documented `TypeError`.
