### PR TITLE
fix(portal): skip gorhom root host under teleport

### DIFF
--- a/code/ui/components-test/PortalTeleportRootHost.native.test.tsx
+++ b/code/ui/components-test/PortalTeleportRootHost.native.test.tsx
@@ -1,0 +1,78 @@
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { getPortal } from '@tamagui/native'
+import { PortalHost, PortalProvider } from '@tamagui/portal'
+import React from 'react'
+import TestRenderer, { act } from 'react-test-renderer'
+import { afterEach, describe, expect, test } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig('native'))
+
+const recordedHostNames: string[] = []
+
+function Portal({ children }: { children?: React.ReactNode }) {
+  return <>{children}</>
+}
+
+function PortalHostFake({ name }: { name: string }) {
+  recordedHostNames.push(name)
+  return null
+}
+
+function PortalProviderFake({ children }: { children?: React.ReactNode }) {
+  return (
+    <>
+      {children}
+      <PortalHostFake name="root" />
+    </>
+  )
+}
+
+function installFakeTeleport() {
+  recordedHostNames.length = 0
+  ;(globalThis as any).__tamagui_teleport = {
+    Portal,
+    PortalHost: PortalHostFake,
+    PortalProvider: PortalProviderFake,
+  }
+  getPortal().set({ enabled: true, type: 'teleport' })
+}
+
+describe('portal teleport root host', () => {
+  afterEach(() => {
+    getPortal().set({ enabled: false, type: null })
+    delete (globalThis as any).__tamagui_teleport
+    recordedHostNames.length = 0
+  })
+
+  test('renders a single root host under teleport', async () => {
+    installFakeTeleport()
+
+    await act(async () => {
+      TestRenderer.create(
+        <TamaguiProvider config={conf} defaultTheme="light">
+          <PortalProvider>{null}</PortalProvider>
+        </TamaguiProvider>
+      )
+    })
+
+    expect(recordedHostNames).toEqual(['root'])
+  })
+
+  test('renders a named teleport host', async () => {
+    installFakeTeleport()
+
+    await act(async () => {
+      TestRenderer.create(
+        <TamaguiProvider config={conf} defaultTheme="light">
+          <PortalProvider>
+            <PortalHost name="x" />
+          </PortalProvider>
+        </TamaguiProvider>
+      )
+    })
+
+    expect(recordedHostNames.filter((name) => name === 'root')).toEqual(['root'])
+    expect(recordedHostNames).toContain('x')
+  })
+})


### PR DESCRIPTION
## Summary

react-native-teleport keeps one native host per name and the last registered wins. Tamagui's PortalProvider was also rendering a styleless gorhom `<PortalHost name="root">` inside teleport's own PortalProvider, which already mounts an absolute-fill root host. The gorhom host replaced the real one, laid out at zero height, and every teleported sheet drew offscreen.

This branch skips the gorhom root host when `getPortal().state.type === 'teleport'` (`6831debc28`) and adds a native test that records teleport host names: under teleport, Tamagui's PortalProvider must leave exactly one `'root'` host (teleport's), and an explicit `<PortalHost name="x">` still renders.

The same test is on v3-beta (`2baa0f55c9`). A canary for this SHA is already in flight; this PR is the main-line landing.

## Test plan

- [x] `TAMAGUI_TARGET=native vitest` `PortalTeleportRootHost.native.test.tsx` in `code/ui/components-test` (2 passed)
- Temporarily dropping the `portalState.type !== 'teleport'` guard on v3-beta produced two `'root'` hosts and failed the assertion; restoring it passed