### PR TITLE
fix(core): keep config theme declaration order so the default theme isn't dark

### DIFF
--- a/code/core/core-test/defaultThemeOrder.web.test.tsx
+++ b/code/core/core-test/defaultThemeOrder.web.test.tsx
@@ -1,0 +1,64 @@
+process.env.TAMAGUI_TARGET = 'web'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { render } from '@testing-library/react'
+import { describe, expect, test } from 'vitest'
+
+import { TamaguiProvider, View, createTamagui, useThemeName } from '@tamagui/core'
+
+/**
+ * Regression for GitHub issue #3764.
+ *
+ * `TamaguiProvider` falls back to `Object.keys(config.themes)[0]` when no
+ * `defaultTheme` is passed, so the runtime themes object has to keep the order the
+ * config declared. `getThemesDeduped` used to sort theme names alphabetically for
+ * deterministic CSS output, which put `dark` ahead of `light` and silently made
+ * dark the default for every app that doesn't pass `defaultTheme`.
+ */
+
+describe('default theme order', () => {
+  test('runtime themes keep config declaration order', () => {
+    const raw = getDefaultTamaguiConfig()
+    const rawFirst = Object.keys(raw.themes)[0]
+    expect(rawFirst).toBe('light')
+
+    const conf = createTamagui(raw)
+    expect(Object.keys(conf.themes)[0]).toBe(rawFirst)
+  })
+
+  test('a provider with no defaultTheme uses the first declared theme', () => {
+    const conf = createTamagui(getDefaultTamaguiConfig())
+    let seen: string | undefined
+
+    function Probe() {
+      seen = useThemeName()
+      return <View />
+    }
+
+    render(
+      <TamaguiProvider config={conf}>
+        <Probe />
+      </TamaguiProvider>
+    )
+
+    expect(seen).toBe('light')
+  })
+
+  test('an explicit defaultTheme still wins', () => {
+    const conf = createTamagui(getDefaultTamaguiConfig())
+    let seen: string | undefined
+
+    function Probe() {
+      seen = useThemeName()
+      return <View />
+    }
+
+    render(
+      <TamaguiProvider config={conf} defaultTheme="dark">
+        <Probe />
+      </TamaguiProvider>
+    )
+
+    expect(seen).toBe('dark')
+  })
+})

--- a/code/core/web/src/createTamagui.ts
+++ b/code/core/web/src/createTamagui.ts
@@ -151,7 +151,7 @@ export function createTamagui<Conf extends CreateTamaguiProps>(
 
     const themesIn = configIn.themes as ThemesLikeObject
     const dedupedThemes = foundThemes ?? getThemesDeduped(themesIn, tokens.color)
-    const themes = proxyThemesToParents(dedupedThemes)
+    const themes = proxyThemesToParents(dedupedThemes, Object.keys(themesIn))
 
     return {
       themes,

--- a/code/core/web/src/helpers/proxyThemeToParents.ts
+++ b/code/core/web/src/helpers/proxyThemeToParents.ts
@@ -5,7 +5,8 @@ const themesRaw: Record<string, ThemeParsed> = {}
 // this seems expensive but its necessary to do two loops unless we want to refactor a variety of things again
 // not *too* much work but not a big cost doing the two loops
 export function proxyThemesToParents(
-  dedupedThemes: DedupedThemes
+  dedupedThemes: DedupedThemes,
+  declarationOrder?: string[]
 ): Record<string, ThemeParsed> {
   // fill it in so we can look it up next
   for (const { names, theme } of dedupedThemes) {
@@ -25,6 +26,15 @@ export function proxyThemesToParents(
       const proxiedTheme = proxyThemeToParents(themeName, theme)
       themes[themeName] = proxiedTheme
     }
+  }
+
+  // dedupedThemes is sorted for deterministic CSS cascade, but TamaguiProvider
+  // falls back to Object.keys(themes)[0] — reorder to match config (#3764)
+  if (declarationOrder) {
+    const ordered: Record<string, ThemeParsed> = {}
+    for (const k of declarationOrder) if (k in themes) ordered[k] = themes[k]
+    for (const k in themes) if (!(k in ordered)) ordered[k] = themes[k]
+    return ordered
   }
 
   return themes

--- a/code/core/web/types/helpers/proxyThemeToParents.d.ts
+++ b/code/core/web/types/helpers/proxyThemeToParents.d.ts
@@ -1,4 +1,4 @@
 import type { DedupedThemes, ThemeParsed } from '../types';
-export declare function proxyThemesToParents(dedupedThemes: DedupedThemes): Record<string, ThemeParsed>;
+export declare function proxyThemesToParents(dedupedThemes: DedupedThemes, declarationOrder?: string[]): Record<string, ThemeParsed>;
 export declare function proxyThemeToParents(themeName: string, theme: ThemeParsed): {};
 //# sourceMappingURL=proxyThemeToParents.d.ts.map


### PR DESCRIPTION
Reimplements #4181 with a smaller change to the same effect (thanks @dennytosp).

`TamaguiProvider` falls back to `Object.keys(config.themes)[0]` when no `defaultTheme` is passed, and `getThemesDeduped` sorts theme names for a deterministic CSS cascade, so `dark` sorted ahead of `light` and silently became the default for any app that doesn't pass `defaultTheme`.

Instead of threading a declaration-order map through the two-pass insert, `proxyThemesToParents` now takes the config's key order and reorders the result object at the end. The existing loop is untouched; the fix is 9 lines plus one plain object.

Includes a regression test covering the raw config order, the provider fallback, and an explicit `defaultTheme` still winning.

Fixes #3764