### PR TITLE
test(animations-reanimated): cover the raw-primitive guard in applyAnimation

### DIFF
--- a/code/ui/components-test/ReanimatedInitialUpdater.native.test.tsx
+++ b/code/ui/components-test/ReanimatedInitialUpdater.native.test.tsx
@@ -1,0 +1,83 @@
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { YStack } from '@tamagui/stacks'
+import TestRenderer, { act } from 'react-test-renderer'
+import { afterEach, expect, test, vi } from 'vitest'
+
+vi.mock('react-native-reanimated', async (importOriginal) => {
+  const reanimated = await importOriginal<typeof import('react-native-reanimated')>()
+
+  return {
+    ...reanimated,
+    // mirrors defineAnimation on the ReactNative runtime: during
+    // initialUpdaterRun (IN_STYLE_UPDATER) withTiming/withSpring return the
+    // plain starting value, not an animation descriptor
+    withTiming: ((toValue: unknown) => toValue) as typeof reanimated.withTiming,
+    withSpring: ((toValue: unknown) => toValue) as typeof reanimated.withSpring,
+  }
+})
+
+const { createAnimations } = await import('@tamagui/animations-reanimated')
+
+const animations = createAnimations({
+  medium: {
+    damping: 16,
+    stiffness: 90,
+  },
+})
+
+const config = createTamagui({
+  ...getDefaultTamaguiConfig('native'),
+  animations,
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// when the style updater re-initializes after a color key has already
+// emitted, withTiming/withSpring hand back the raw color string; the onStart
+// seed wrapper must not assume an animation descriptor — assigning onStart
+// onto the primitive throws
+// "Cannot create property 'onStart' on string 'rgba(0, 0, 0, 0)'"
+// and React 19 responds to the render error by unmounting the root.
+test('initial updater run with emitted color history does not throw', async () => {
+  // the updater runs from a mapper microtask after the commit, so the throw
+  // surfaces as an uncaught exception rather than rejecting act
+  const unhandled: string[] = []
+  const onUncaught = (error: unknown) => {
+    unhandled.push(String(error))
+  }
+  process.on('uncaughtException', onUncaught)
+
+  try {
+    let rendered: TestRenderer.ReactTestRenderer | null = null
+
+    await act(async () => {
+      rendered = TestRenderer.create(
+        <TamaguiProvider config={config} defaultTheme="light">
+          <YStack backgroundColor="transparent" transition="medium" />
+        </TamaguiProvider>
+      )
+    })
+
+    await act(async () => {
+      rendered!.update(
+        <TamaguiProvider config={config} defaultTheme="light">
+          <YStack backgroundColor="red" transition="medium" />
+        </TamaguiProvider>
+      )
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    // a render that never happened would satisfy the throw assertion below on
+    // its own, so pin that the tree is actually there
+    expect(rendered!.toJSON()).not.toBe(null)
+    expect(unhandled).toEqual([])
+
+    rendered!.unmount()
+  } finally {
+    process.off('uncaughtException', onUncaught)
+  }
+})


### PR DESCRIPTION
The #4193 fix landed in `25d97e1ab6` + `a756be9a5f` with no test. This salvages the regression test from #4157 (thanks @wootencl), which is the only coverage anywhere for that class of crash.

It mocks `withTiming`/`withSpring` to return the plain starting value, mirroring what `defineAnimation` does on the ReactNative runtime while `IN_STYLE_UPDATER` is set, then renders an animated color and re-renders with a new one. Without the `isAnimationDescriptor` guard the seed wrapper assigns `onStart` onto a raw string and throws.

Two assertions tightened over the original: it now requires zero uncaught exceptions rather than the absence of one message, and it pins that the tree actually rendered so a no-op render can't produce a false green.

Fixes #4193