### PR TITLE
fix: deliver the host to a swapped forwarded ref, and stop slider drift on scroll

### DIFF
--- a/code/core/core-test/composedRef.web.test.tsx
+++ b/code/core/core-test/composedRef.web.test.tsx
@@ -1,0 +1,127 @@
+process.env.TAMAGUI_TARGET = 'web'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { act, render } from '@testing-library/react'
+import { StrictMode, useState } from 'react'
+import { describe, expect, test } from 'vitest'
+
+import { TamaguiProvider, View, createTamagui } from '@tamagui/core'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+/**
+ * Regression for GitHub issue #4031.
+ *
+ * createComponent caches the composed ref on stateRef so the host isn't detached
+ * and reattached every render. The cached callback used to close over the
+ * forwardedRef from the first render forever, so a parent that swaps ref identity
+ * (which is what react-hook-form does when it re-registers a field after
+ * reset()) never received the node again, and setFocus()/shouldFocusError silently
+ * stopped working.
+ *
+ * Every case runs in StrictMode too. StrictMode double-invokes render, so any
+ * handover that compares against a "previous" value written during render reads
+ * back its own write on the second pass and bails: green here, broken for
+ * anyone running StrictMode in dev.
+ */
+
+const modes = [
+  ['plain', ({ children }: { children: React.ReactNode }) => <>{children}</>],
+  ['strict', StrictMode],
+] as const
+
+describe.each(modes)('composed ref (%s)', (_name, Mode) => {
+  test('a swapped forwarded ref receives the host node', () => {
+    const first: { current: HTMLElement | null } = { current: null }
+    const second: { current: HTMLElement | null } = { current: null }
+
+    let swap: () => void = () => {}
+
+    function Test() {
+      const [useSecond, setUseSecond] = useState(false)
+      swap = () => setUseSecond(true)
+      return (
+        <TamaguiProvider config={conf} defaultTheme="light">
+          <View ref={useSecond ? (second as any) : (first as any)} />
+        </TamaguiProvider>
+      )
+    }
+
+    render(
+      <Mode>
+        <Test />
+      </Mode>
+    )
+    expect(first.current).not.toBe(null)
+
+    act(() => swap())
+
+    // the newly passed ref must hold the node...
+    expect(second.current).not.toBe(null)
+    // ...and the one that was swapped out must be released
+    expect(first.current).toBe(null)
+  })
+
+  test('a swapped callback ref is invoked with the host node', () => {
+    const calls: Array<['a' | 'b', boolean]> = []
+    const refA = (node: any) => calls.push(['a', !!node])
+    const refB = (node: any) => calls.push(['b', !!node])
+
+    let swap: () => void = () => {}
+
+    function Test() {
+      const [useB, setUseB] = useState(false)
+      swap = () => setUseB(true)
+      return (
+        <TamaguiProvider config={conf} defaultTheme="light">
+          <View ref={useB ? refB : refA} />
+        </TamaguiProvider>
+      )
+    }
+
+    render(
+      <Mode>
+        <Test />
+      </Mode>
+    )
+    expect(calls).toContainEqual(['a', true])
+
+    act(() => swap())
+
+    expect(calls).toContainEqual(['a', false])
+    expect(calls).toContainEqual(['b', true])
+  })
+
+  test('a stable forwarded ref is not detached on re-render', () => {
+    // the cache exists so react doesn't tear the host off and reattach it every
+    // render, so the handover must only fire when the ref identity actually changes
+    const calls: boolean[] = []
+    const ref = (node: any) => calls.push(!!node)
+
+    let rerender: () => void = () => {}
+
+    function Test() {
+      const [, setTick] = useState(0)
+      rerender = () => setTick((t) => t + 1)
+      return (
+        <TamaguiProvider config={conf} defaultTheme="light">
+          <View ref={ref} />
+        </TamaguiProvider>
+      )
+    }
+
+    render(
+      <Mode>
+        <Test />
+      </Mode>
+    )
+    const afterMount = [...calls]
+
+    act(() => rerender())
+    act(() => rerender())
+
+    // strictmode does its own mount/unmount/remount cycle, so pin that the
+    // re-renders added nothing rather than pinning an absolute call count
+    expect(calls).toEqual(afterMount)
+  })
+})

--- a/code/core/web/src/createComponent.tsx
+++ b/code/core/web/src/createComponent.tsx
@@ -1,4 +1,4 @@
-import { composeRefs } from '@tamagui/compose-refs'
+import { composeRefs, setRef } from '@tamagui/compose-refs'
 import {
   getPlatformDriver,
   isAndroid,
@@ -1178,16 +1178,43 @@ export function createComponent<
         stateRef.current.willHydrate
       ) || nonTamaguiProps
 
+    // the composed ref keeps one identity for the life of the component so react
+    // never detaches and reattaches the host mid-life. that means it can't close
+    // over forwardedRef, which would pin the first render's ref forever - read it
+    // off stateRef instead, and record what it actually attached to so a swapped
+    // ref can be handed the host below (#4031)
+    stateRef.current.composedForwardedRef = forwardedRef
+
     if (!stateRef.current.composedRef) {
       stateRef.current.composedRef = composeRefs<TamaguiElement>(
-        (x) => (stateRef.current.host = x as TamaguiElement),
-        forwardedRef,
+        (x) => {
+          stateRef.current.host = x as TamaguiElement
+          const current = stateRef.current.composedForwardedRef
+          stateRef.current.attachedForwardedRef = x ? current : undefined
+          setRef<TamaguiElement>(current, x as TamaguiElement)
+        },
         setElementProps,
         animatedRef
       )
     }
 
     viewProps.ref = stateRef.current.composedRef
+
+    // react only re-runs a ref callback when its identity changes, and ours never
+    // does, so hand the host over by hand when a parent swaps the forwarded ref -
+    // react-hook-form re-registering a field after reset() is the common case.
+    // the comparison reads what the ref callback attached, never a value written
+    // during render: a render-phase "previous" pointer reads back its own write
+    // on react's second pass and the handover silently no-ops under StrictMode
+    useIsomorphicLayoutEffect(() => {
+      const attached = stateRef.current.attachedForwardedRef
+      if (attached === forwardedRef) return
+      if (attached) setRef<TamaguiElement | null>(attached, null)
+      stateRef.current.attachedForwardedRef = forwardedRef
+      if (stateRef.current.host) {
+        setRef<TamaguiElement>(forwardedRef, stateRef.current.host)
+      }
+    }, [forwardedRef])
 
     // handle pointer events (native: maps to touch events, web: no-op)
     usePointerEvents(props, viewProps)

--- a/code/core/web/src/types.tsx
+++ b/code/core/web/src/types.tsx
@@ -597,6 +597,12 @@ export type TamaguiComponentStateRef = {
 
   host?: TamaguiElement
   composedRef?: (x: TamaguiElement) => void
+  // the forwarded ref composedRef writes to right now, read at attach time so the
+  // cached callback never pins the first render's ref
+  composedForwardedRef?: React.Ref<TamaguiElement>
+  // the forwarded ref composedRef last handed the host to, so a swap can be
+  // detected without a render-phase "previous" pointer (see createComponent)
+  attachedForwardedRef?: React.Ref<TamaguiElement>
   willHydrate?: boolean
   hasMeasured?: boolean
   hasAnimated?: boolean

--- a/code/core/web/types/types.d.ts
+++ b/code/core/web/types/types.d.ts
@@ -300,6 +300,8 @@ export type TamaguiComponentStateRef = {
     startedUnhydrated: boolean;
     host?: TamaguiElement;
     composedRef?: (x: TamaguiElement) => void;
+    composedForwardedRef?: React.Ref<TamaguiElement>;
+    attachedForwardedRef?: React.Ref<TamaguiElement>;
     willHydrate?: boolean;
     hasMeasured?: boolean;
     hasAnimated?: boolean;

--- a/code/kitchen-sink/src/constants/test-ids.ts
+++ b/code/kitchen-sink/src/constants/test-ids.ts
@@ -49,4 +49,9 @@ export const TEST_IDS = {
   accentBgToken: 'accent-bg-token',
   baseBackground: 'base-background',
   baseButton: 'base-button',
+  // Slider scroll offset test IDs (Issue #4146)
+  sliderScrollVertical: 'slider-scroll-vertical',
+  sliderScrollVerticalValue: 'slider-scroll-vertical-value',
+  sliderScrollHorizontal: 'slider-scroll-horizontal',
+  sliderScrollHorizontalValue: 'slider-scroll-horizontal-value',
 } as const

--- a/code/kitchen-sink/src/usecases/SliderScrollOffsetCase.tsx
+++ b/code/kitchen-sink/src/usecases/SliderScrollOffsetCase.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { Slider, Text, YStack } from 'tamagui'
+
+import { TEST_IDS } from '../constants/test-ids'
+
+/**
+ * Test case for GitHub issue #4146: slider thumb stops following the cursor once
+ * the page is scrolled.
+ *
+ * A responder event's pageX/pageY are document-relative, while the track is
+ * measured with getBoundingClientRect (viewport-relative). Mixing the two makes
+ * the reported value drift by exactly the scroll offset, so the case puts a tall
+ * spacer above the sliders to force a scroll before dragging.
+ */
+export function SliderScrollOffsetCase() {
+  const [vertical, setVertical] = useState([50])
+  const [horizontal, setHorizontal] = useState([50])
+
+  return (
+    <YStack padding="$4" gap="$4">
+      {/* pushes the sliders below the fold so the drag happens while scrolled */}
+      <YStack height={1200} backgroundColor="$color3" />
+
+      <Text id={TEST_IDS.sliderScrollVerticalValue}>{vertical[0]}</Text>
+      <Slider
+        id={TEST_IDS.sliderScrollVertical}
+        orientation="vertical"
+        height={200}
+        width={20}
+        value={vertical}
+        onValueChange={setVertical}
+        min={0}
+        max={100}
+        step={1}
+      >
+        <Slider.Track>
+          <Slider.TrackActive />
+        </Slider.Track>
+        <Slider.Thumb index={0} circular size="$2" />
+      </Slider>
+
+      {/* makes the document wider than the viewport so the horizontal slider can
+          only be reached by scrolling on x, which is what its test needs */}
+      <YStack width={3000} height={1} />
+
+      <Text id={TEST_IDS.sliderScrollHorizontalValue} marginLeft={1400}>
+        {horizontal[0]}
+      </Text>
+      <Slider
+        id={TEST_IDS.sliderScrollHorizontal}
+        orientation="horizontal"
+        marginLeft={1400}
+        width={200}
+        value={horizontal}
+        onValueChange={setHorizontal}
+        min={0}
+        max={100}
+        step={1}
+      >
+        <Slider.Track>
+          <Slider.TrackActive />
+        </Slider.Track>
+        <Slider.Thumb index={0} circular size="$2" />
+      </Slider>
+
+      <YStack height={600} />
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -284,6 +284,8 @@ const loaders: Record<string, () => ComponentType<any>> = {
   VariantsOrder: () => require('./VariantsOrder').VariantsOrder,
   ZIndex: () => require('./ZIndex').ZIndex,
   NestedPressExclusive: () => require('./NestedPressExclusive').NestedPressExclusive,
+  SliderScrollOffsetCase: () =>
+    require('./SliderScrollOffsetCase').SliderScrollOffsetCase,
 }
 
 export const useCases: Record<string, ComponentType<any>> = {}

--- a/code/kitchen-sink/tests/SliderScrollOffset.test.tsx
+++ b/code/kitchen-sink/tests/SliderScrollOffset.test.tsx
@@ -1,0 +1,114 @@
+import { expect, test } from '@playwright/test'
+import { setupPage } from './test-utils'
+import { TEST_IDS } from '../src/constants/test-ids'
+
+/**
+ * Tests for GitHub issue #4146: the slider thumb stops following the cursor once
+ * the page is scrolled.
+ *
+ * A responder event's pageX/pageY come straight off the DOM event and are
+ * document-relative, while the track is measured with getBoundingClientRect and
+ * is viewport-relative. Mixing the two makes the dragged value drift by exactly
+ * the scroll offset, and with a tall page it saturates at the minimum.
+ *
+ * The press itself is unaffected (it uses locationY, which is already relative to
+ * the responder element), so these tests have to *drag* to exercise the bug.
+ */
+
+test.beforeEach(async ({ page }) => {
+  await setupPage(page, { name: 'SliderScrollOffsetCase', type: 'useCase' })
+})
+
+test('vertical slider tracks the cursor after the page is scrolled', async ({ page }) => {
+  const slider = page.locator(`#${TEST_IDS.sliderScrollVertical}`)
+  await slider.scrollIntoViewIfNeeded()
+
+  // the whole point of the repro: without a scroll offset the bug can't show
+  const scrollY = await page.evaluate(() => window.scrollY)
+  expect(scrollY).toBeGreaterThan(0)
+
+  const box = (await slider.boundingBox())!
+  expect(box).not.toBeNull()
+
+  // drag from the middle of the track to a quarter down from the top
+  const targetY = box.y + box.height * 0.25
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(box.x + box.width / 2, targetY, { steps: 10 })
+  await page.mouse.up()
+
+  // vertical runs bottom(min) -> top(max)
+  const expected = 100 - ((targetY - box.y) / box.height) * 100
+  const value = Number(
+    await page.locator(`#${TEST_IDS.sliderScrollVerticalValue}`).innerText()
+  )
+  expect(value).toBeGreaterThan(expected - 4)
+  expect(value).toBeLessThan(expected + 4)
+})
+
+test('horizontal slider tracks the cursor after the page is scrolled', async ({
+  page,
+}) => {
+  const slider = page.locator(`#${TEST_IDS.sliderScrollHorizontal}`)
+  await slider.scrollIntoViewIfNeeded()
+
+  // a horizontal drag only drifts if the page is scrolled on x, and the slider
+  // may already be in view on a wide viewport, so scroll x by hand. the case has
+  // a 3000px spacer so there is always room for this
+  await page.evaluate(() => window.scrollBy(400, 0))
+  const scrollX = await page.evaluate(() => window.scrollX)
+  expect(scrollX).toBeGreaterThan(0)
+
+  const box = (await slider.boundingBox())!
+  expect(box).not.toBeNull()
+
+  const targetX = box.x + box.width * 0.75
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(targetX, box.y + box.height / 2, { steps: 10 })
+  await page.mouse.up()
+
+  const expected = ((targetX - box.x) / box.width) * 100
+  const value = Number(
+    await page.locator(`#${TEST_IDS.sliderScrollHorizontalValue}`).innerText()
+  )
+  expect(value).toBeGreaterThan(expected - 4)
+  expect(value).toBeLessThan(expected + 4)
+})
+
+test('vertical slider tracks the cursor after a scroll that does not re-measure', async ({
+  page,
+}) => {
+  const slider = page.locator(`#${TEST_IDS.sliderScrollVertical}`)
+  await slider.scrollIntoViewIfNeeded()
+
+  // park the track a fixed distance down the viewport so the nudge below can't
+  // push it out of view or cross an IntersectionObserver threshold
+  await page.evaluate(() => {
+    const el = document.getElementById('slider-scroll-vertical')!
+    window.scrollBy(0, el.getBoundingClientRect().top - 300)
+  })
+  // the measure is debounced 200ms behind the observer, so let it settle first,
+  // otherwise the cached offset is stale for a reason this test isn't about
+  await page.waitForTimeout(500)
+
+  // nudge the page while the track stays fully visible. nothing re-measures on
+  // scroll: only resize, an observer threshold crossing, and a 1s interval. so
+  // the cached offset is now wrong, and any math that subtracts it drifts by 60px.
+  // locationY is read against the live rect and doesn't care.
+  await page.evaluate(() => window.scrollBy(0, 60))
+
+  const box = (await slider.boundingBox())!
+  const targetY = box.y + box.height * 0.25
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(box.x + box.width / 2, targetY, { steps: 10 })
+  await page.mouse.up()
+
+  const expected = 100 - ((targetY - box.y) / box.height) * 100
+  const value = Number(
+    await page.locator(`#${TEST_IDS.sliderScrollVerticalValue}`).innerText()
+  )
+  expect(value).toBeGreaterThan(expected - 4)
+  expect(value).toBeLessThan(expected + 4)
+})

--- a/code/ui/slider/src/Slider.tsx
+++ b/code/ui/slider/src/Slider.tsx
@@ -72,6 +72,27 @@ if (process.env.TAMAGUI_TARGET === 'web') {
   }
 }
 
+// on web a responder event's pageX/pageY come straight off the DOM event and are
+// document-relative, while `measure` reports the track through getBoundingClientRect
+// and is viewport-relative. subtracting the cached offset therefore mixes origins and
+// the thumb lags the cursor by exactly the page scroll (#4146). locationX/locationY
+// are `client - track.getBoundingClientRect()`, read fresh on every event, so they
+// need no offset at all - which is why onSlideStart was already correct. that also
+// closes the window where the cached offset is stale: nothing re-measures on scroll,
+// only on resize, an IntersectionObserver threshold crossing, and a 1s interval.
+// native measures the track and the touch against the screen, so it keeps the offset.
+const getTrackPosition = (
+  event: GestureReponderEvent,
+  offset: number,
+  orientation: 'horizontal' | 'vertical'
+) => {
+  const { locationX, locationY, pageX, pageY } = event.nativeEvent
+  if (isWeb) {
+    return orientation === 'horizontal' ? locationX : locationY
+  }
+  return (orientation === 'horizontal' ? pageX : pageY) - offset
+}
+
 /* -------------------------------------------------------------------------------------------------
  * SliderHorizontal
  * -----------------------------------------------------------------------------------------------*/
@@ -136,13 +157,17 @@ const SliderHorizontal = React.forwardRef<View, SliderHorizontalProps>(
             }
           }}
           onSlideMove={(event) => {
-            const value = getValueFromPointer(event.nativeEvent.pageX - state.offset)
+            const value = getValueFromPointer(
+              getTrackPosition(event, state.offset, 'horizontal')
+            )
             if (value) {
               onSlideMove?.(value, event)
             }
           }}
           onSlideEnd={(event) => {
-            const value = getValueFromPointer(event.nativeEvent.pageX - state.offset)
+            const value = getValueFromPointer(
+              getTrackPosition(event, state.offset, 'horizontal')
+            )
             if (value) {
               onSlideEnd?.(event, value)
             }
@@ -276,13 +301,17 @@ const SliderVertical = React.forwardRef<View, SliderVerticalProps>(
             }
           }}
           onSlideMove={(event) => {
-            const value = getValueFromPointer(event.nativeEvent.pageY - state.offset)
+            const value = getValueFromPointer(
+              getTrackPosition(event, state.offset, 'vertical')
+            )
             if (value) {
               onSlideMove?.(value, event)
             }
           }}
           onSlideEnd={(event) => {
-            const value = getValueFromPointer(event.nativeEvent.pageY - state.offset)
+            const value = getValueFromPointer(
+              getTrackPosition(event, state.offset, 'vertical')
+            )
             onSlideEnd?.(event, value)
           }}
           onStepKeyDown={(event) => {


### PR DESCRIPTION
Cleaned-up implementations of two community fixes, credited to @dennytosp who found and first fixed both. Replaces #4179 and #4178.

## 1. `createComponent`: a swapped forwarded ref never got the host (#4031)

`createComponent` caches the composed ref on `stateRef` so React doesn't tear the host off and reattach it on every render. The cached callback closed over the *first* render's `forwardedRef` forever, so when a parent swapped ref identity, the new ref never received the node. react-hook-form re-registering a field after `reset()` is the case people hit: `setFocus()` and `shouldFocusError` silently stop working.

The callback now reads the current forwarded ref off `stateRef` at attach time, and records what it actually attached to:

```ts
stateRef.current.composedForwardedRef = forwardedRef

if (!stateRef.current.composedRef) {
  stateRef.current.composedRef = composeRefs<TamaguiElement>(
    (x) => {
      stateRef.current.host = x as TamaguiElement
      const current = stateRef.current.composedForwardedRef
      stateRef.current.attachedForwardedRef = x ? current : undefined
      setRef<TamaguiElement>(current, x as TamaguiElement)
    },
    setElementProps,
    animatedRef
  )
}
```

React only re-runs a ref callback when its identity changes, and ours deliberately never does, so the handover is done in a layout effect keyed on `forwardedRef`. The comparison reads what the ref callback *attached*, never a value written during render: a render-phase "previous" pointer reads back its own write on React's second pass, so the handover no-ops under StrictMode.

`composedRef.web.test.tsx` covers a swapped object ref, a swapped callback ref, and the no-detach-on-rerender guarantee, each in both plain React and StrictMode. Verified they fail on `main` (4 of 6 red, the two no-detach cases stay green) and pass with the fix.

## 2. Slider: the thumb stops following the cursor once the page is scrolled (#4146)

On web a responder event's `pageX`/`pageY` come straight off the DOM event and are document-relative, while `measure` reports the track through `getBoundingClientRect` and is viewport-relative. Subtracting the cached offset mixed the two origins, so a dragged value drifted by exactly the page scroll, saturating at the minimum on a tall page.

`locationX`/`locationY` are `client - track.getBoundingClientRect()`, read fresh on every event, so they need no offset at all. That is why `onSlideStart` was already correct, and it also closes the window where the cached offset is stale: nothing re-measures on scroll, only resize, an IntersectionObserver threshold crossing, and a 1s interval. Native keeps the offset, since it measures both track and touch against the screen.

```ts
const getTrackPosition = (
  event: GestureReponderEvent,
  offset: number,
  orientation: 'horizontal' | 'vertical'
) => {
  const { locationX, locationY, pageX, pageY } = event.nativeEvent
  if (isWeb) {
    return orientation === 'horizontal' ? locationX : locationY
  }
  return (orientation === 'horizontal' ? pageX : pageY) - offset
}
```

Three Playwright tests in `SliderScrollOffset.test.tsx`: a vertical drag after a vertical scroll, a horizontal drag after a horizontal scroll (the case has a 3000px spacer so this actually scrolls on x), and a vertical drag after a scroll small enough that nothing re-measures, which is the stale-offset window specifically. All three fail on `main` and pass with the fix.

## Validation

- `code/core/core-test`: 6/6 pass with the fix, 4 fail without it
- `code/kitchen-sink`: 3/3 Playwright tests pass with the fix, 3/3 fail without it
- `bun run typecheck` and `bun run lint` clean