### PR TITLE
fix(adapt): resolve activation on the first commit so adapted subtrees mount once

### DIFF
--- a/code/kitchen-sink/src/usecases/AdaptFirstCommitCase.tsx
+++ b/code/kitchen-sink/src/usecases/AdaptFirstCommitCase.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Adapt, Paragraph, YStack } from 'tamagui'
+import { Button } from '../components/Button'
+import { Select } from '../components/Select'
+import { Sheet } from '../components/Sheet'
+
+/**
+ * Adapt activation has to be correct on the first commit.
+ *
+ * SelectInner picks SelectSheetImpl or SelectInlineImpl from useAdaptIsActive.
+ * When the Adapt child publishes when/platform from a layout effect the first
+ * commit sees false, so the inline impl mounts and is immediately replaced by
+ * the sheet impl - the whole Select subtree, and everything the user put in it,
+ * mounts twice.
+ *
+ * MountProbe sits inside the Select so it remounts whenever that swap happens.
+ * `when={true}` forces the adapted path regardless of viewport or touch.
+ */
+const items = ['Apple', 'Pear', 'Blackberry']
+
+function MountProbe({ onMount }: { onMount: () => void }) {
+  useEffect(() => {
+    onMount()
+  }, [onMount])
+
+  return null
+}
+
+export function AdaptFirstCommitCase() {
+  const [open, setOpen] = useState(false)
+  const [value, setValue] = useState('apple')
+  const [mounts, setMounts] = useState(0)
+
+  const onProbeMount = useCallback(() => {
+    setMounts((count) => count + 1)
+  }, [])
+
+  return (
+    <YStack p="4" gap="4" items="center">
+      <Paragraph testID="impl-mount-count">{mounts}</Paragraph>
+
+      <Select open={open} onOpenChange={setOpen} value={value} onValueChange={setValue}>
+        <MountProbe onMount={onProbeMount} />
+
+        <Select.Trigger testID="open-select" width={220}>
+          <Select.Value placeholder="Select a fruit" />
+          <Select.Icon />
+        </Select.Trigger>
+
+        <Adapt when={true}>
+          <Sheet transition="medium" zIndex={250_000} modal snapPointsMode="fit">
+            <Sheet.Overlay bg="shadow6" opacity="enter:0 exit:0" />
+            <Sheet.Handle bg="color5" />
+            <Sheet.Container testID="sheet-frame" padding="4" gap="4">
+              <Sheet.Background bg="background" borderRadius="6" />
+              <Sheet.ScrollView>
+                <Adapt.Contents />
+              </Sheet.ScrollView>
+            </Sheet.Container>
+          </Sheet>
+        </Adapt>
+
+        <Select.Content>
+          <Select.Viewport minW={200}>
+            <Select.Group>
+              <Select.Label testID="select-content-marker">Fruits</Select.Label>
+              {items.map((item) => (
+                <Select.Item
+                  key={item}
+                  value={item.toLowerCase()}
+                  testID={`select-option-${item.toLowerCase()}`}
+                >
+                  <Select.ItemText>{item}</Select.ItemText>
+                </Select.Item>
+              ))}
+            </Select.Group>
+          </Select.Viewport>
+        </Select.Content>
+      </Select>
+
+      <Button testID="close-select" onPress={() => setOpen(false)}>
+        Close
+      </Button>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/AdaptNestedBoundaryCase.tsx
+++ b/code/kitchen-sink/src/usecases/AdaptNestedBoundaryCase.tsx
@@ -1,0 +1,75 @@
+import { useState } from 'react'
+import { Adapt, Dialog, Paragraph, Popover, Sheet, YStack } from 'tamagui'
+import { Button } from '../components/Button'
+
+/**
+ * An adapting component only adapts on its OWN <Adapt />.
+ *
+ * This Dialog has no Adapt at all. Its content holds a Popover that does have
+ * one, so a parent that searches its whole child element tree for an <Adapt />
+ * finds the Popover's and adapts the Dialog too - the dialog content then
+ * publishes into a slot nothing renders and disappears entirely.
+ *
+ * `when={true}` on the Popover keeps the adapted path viewport-independent.
+ */
+export function AdaptNestedBoundaryCase() {
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [popoverOpen, setPopoverOpen] = useState(false)
+
+  return (
+    <YStack p="4" gap="4" items="center">
+      <Button testID="open-dialog" onPress={() => setDialogOpen(true)}>
+        Open Dialog
+      </Button>
+
+      <Dialog modal open={dialogOpen} onOpenChange={setDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay key="overlay" opacity="0.5 enter:0 exit:0" />
+
+          <Dialog.Content
+            key="content"
+            testID="dialog-content"
+            padding="4"
+            gap="4"
+            width={420}
+          >
+            <Dialog.Title>Dialog with no Adapt</Dialog.Title>
+
+            <Paragraph testID="dialog-content-marker">
+              unique-content-marker-dialog
+            </Paragraph>
+
+            <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+              <Popover.Trigger asChild>
+                <Button testID="open-popover">Open Popover</Button>
+              </Popover.Trigger>
+
+              <Adapt when={true}>
+                <Sheet transition="medium" zIndex={250_000} modal snapPointsMode="fit">
+                  <Sheet.Overlay bg="shadow6" opacity="enter:0 exit:0" />
+                  <Sheet.Handle bg="color5" />
+                  <Sheet.Container testID="sheet-frame" padding="4" gap="4">
+                    <Sheet.Background bg="background" borderRadius="6" />
+                    <Sheet.ScrollView>
+                      <Adapt.Contents />
+                    </Sheet.ScrollView>
+                  </Sheet.Container>
+                </Sheet>
+              </Adapt>
+
+              <Popover.Content key="popover-content" padding="4" bg="background">
+                <Paragraph testID="popover-content-marker">
+                  unique-content-marker-popover
+                </Paragraph>
+              </Popover.Content>
+            </Popover>
+
+            <Button testID="close-dialog" onPress={() => setDialogOpen(false)}>
+              Close
+            </Button>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog>
+    </YStack>
+  )
+}

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -102,6 +102,7 @@ const loaders: Record<string, () => ComponentType<any>> = {
     require('./DialogSheetAdaptUnmountCase').DialogSheetAdaptUnmountCase,
   AdaptLiveSlotSpikeCase: () =>
     require('./AdaptLiveSlotSpikeCase').AdaptLiveSlotSpikeCase,
+  AdaptFirstCommitCase: () => require('./AdaptFirstCommitCase').AdaptFirstCommitCase,
   Example: () => require('./Example').Example,
   ExitCompletionCase: () => require('./ExitCompletionCase').ExitCompletionCase,
   OnTransitionCase: () => require('./OnTransitionCase').OnTransitionCase,

--- a/code/kitchen-sink/src/usecases/index.web.ts
+++ b/code/kitchen-sink/src/usecases/index.web.ts
@@ -103,6 +103,8 @@ const loaders: Record<string, () => ComponentType<any>> = {
   AdaptLiveSlotSpikeCase: () =>
     require('./AdaptLiveSlotSpikeCase').AdaptLiveSlotSpikeCase,
   AdaptFirstCommitCase: () => require('./AdaptFirstCommitCase').AdaptFirstCommitCase,
+  AdaptNestedBoundaryCase: () =>
+    require('./AdaptNestedBoundaryCase').AdaptNestedBoundaryCase,
   Example: () => require('./Example').Example,
   ExitCompletionCase: () => require('./ExitCompletionCase').ExitCompletionCase,
   OnTransitionCase: () => require('./OnTransitionCase').OnTransitionCase,

--- a/code/kitchen-sink/tests/AdaptFirstCommit.test.tsx
+++ b/code/kitchen-sink/tests/AdaptFirstCommit.test.tsx
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test'
+import { setupPage } from './test-utils'
+
+/**
+ * An adapted Select must resolve Adapt activation on its first commit.
+ *
+ * When AdaptParent learned when/platform from the Adapt child's layout effect,
+ * SelectInner rendered SelectInlineImpl first and SelectSheetImpl one commit
+ * later, remounting everything the user nested in the Select. The probe inside
+ * the Select counts its own mounts, so an adapted Select must report exactly 1.
+ */
+test.describe('Adapt first-commit activation', () => {
+  test.use({ viewport: { width: 600, height: 900 } })
+
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page, {
+      name: 'AdaptFirstCommitCase',
+      type: 'useCase',
+    })
+  })
+
+  test('the adapted Select subtree mounts once', async ({ page }) => {
+    const count = page.getByTestId('impl-mount-count')
+
+    await expect(page.getByTestId('open-select')).toBeVisible()
+    await expect(count).toHaveText('1')
+
+    await page.getByTestId('open-select').click()
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            document
+              .querySelector('[data-testid="sheet-frame"][data-state]')
+              ?.getAttribute('data-state')
+          ),
+        { timeout: 5000 }
+      )
+      .toBe('open')
+
+    await expect(page.getByTestId('select-content-marker')).toBeAttached()
+    await expect(count).toHaveText('1')
+  })
+})

--- a/code/kitchen-sink/tests/AdaptNestedBoundary.test.tsx
+++ b/code/kitchen-sink/tests/AdaptNestedBoundary.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+import { setupPage } from './test-utils'
+
+/**
+ * A component adapts on its own <Adapt />, never on one belonging to an
+ * adapting component nested inside its content.
+ *
+ * The Dialog here has no Adapt. The Popover inside its content has one, and a
+ * parent that searches its whole child element tree finds it: the Dialog then
+ * thinks it is adapted, publishes its content into a slot nothing renders, and
+ * the dialog disappears.
+ */
+test.describe('Adapt nested boundary', () => {
+  test.use({ viewport: { width: 600, height: 900 } })
+
+  test.beforeEach(async ({ page }) => {
+    await setupPage(page, {
+      name: 'AdaptNestedBoundaryCase',
+      type: 'useCase',
+    })
+  })
+
+  test('a nested Popover Adapt does not adapt the Dialog around it', async ({ page }) => {
+    await page.getByTestId('open-dialog').click()
+
+    // the dialog stays a dialog
+    await expect(page.getByTestId('dialog-content-marker')).toBeVisible()
+
+    // and the popover still adapts to its sheet
+    await page.getByTestId('open-popover').click()
+
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(() =>
+            document
+              .querySelector('[data-testid="sheet-frame"][data-state]')
+              ?.getAttribute('data-state')
+          ),
+        { timeout: 5000 }
+      )
+      .toBe('open')
+
+    await expect(page.getByTestId('popover-content-marker')).toBeVisible()
+  })
+})

--- a/code/ui/adapt/src/Adapt.tsx
+++ b/code/ui/adapt/src/Adapt.tsx
@@ -213,6 +213,9 @@ export const useAdaptContext = (scope?: string) => {
 
 type AdaptParentProps = {
   children?: React.ReactNode
+  // the children the user gave the adapting component, where their <Adapt /> lives.
+  // AdaptParent's own children are that component's internals, one wrapper deep.
+  adaptChildren?: React.ReactNode
   Contents?: AdaptParentContextI['Contents']
   scope: string
   open?: boolean
@@ -224,33 +227,31 @@ type AdaptParentProps = {
 // element tree during render. learning it from the child's layout effect left
 // every consumer seeing "inactive" on the first commit, so an adapted Select
 // mounted SelectInlineImpl and swapped it for SelectSheetImpl one commit later,
-// remounting the whole subtree. breadth-first so a nested adapting component's
-// own <Adapt /> can never shadow this one's. an <Adapt /> that a userland
+// remounting the whole subtree. only direct children are scanned, descending
+// into fragments: any deeper and a nested adapting component's own <Adapt />
+// would adapt this one too. Children.toArray already flattens arrays and drops
+// false, so `{cond && <Adapt />}` still reads. an <Adapt /> that a userland
 // component renders is not in this tree, so it reports itself from its effect
 // instead and still costs that extra commit.
 function findAdaptConfig(children: React.ReactNode, scope: string): AdaptConfig | null {
-  let level = React.Children.toArray(children)
+  for (const child of React.Children.toArray(children)) {
+    if (!React.isValidElement(child)) continue
 
-  while (level.length) {
-    const next: typeof level = []
-
-    for (const child of level) {
-      if (!React.isValidElement(child)) continue
-      const childProps = child.props as AdaptProps
-
-      if (child.type === Adapt) {
-        if (childProps.scope == null || childProps.scope === scope) {
-          return childProps
-        }
-        continue
-      }
-
-      if (childProps.children && typeof childProps.children !== 'function') {
-        next.push(...React.Children.toArray(childProps.children))
-      }
+    if (child.type === React.Fragment) {
+      const found = findAdaptConfig(
+        (child.props as { children?: React.ReactNode }).children,
+        scope
+      )
+      if (found) return found
+      continue
     }
 
-    level = next
+    if (child.type === Adapt) {
+      const childProps = child.props as AdaptProps
+      if (childProps.scope == null || childProps.scope === scope) {
+        return childProps
+      }
+    }
   }
 
   return null
@@ -258,6 +259,7 @@ function findAdaptConfig(children: React.ReactNode, scope: string): AdaptConfig 
 
 export const AdaptParent = ({
   children,
+  adaptChildren,
   Contents,
   scope,
   open,
@@ -273,8 +275,8 @@ export const AdaptParent = ({
   }
 
   const staticConfig = React.useMemo(
-    () => findAdaptConfig(children, scope),
-    [children, scope]
+    () => findAdaptConfig(adaptChildren, scope) ?? findAdaptConfig(children, scope),
+    [adaptChildren, children, scope]
   )
   const [publishedConfig, setPublishedConfig] = React.useState<AdaptConfig | null>(null)
   const rawActive = useAdaptIsActiveGiven(staticConfig ?? publishedConfig)

--- a/code/ui/adapt/src/Adapt.tsx
+++ b/code/ui/adapt/src/Adapt.tsx
@@ -88,16 +88,13 @@ export type AdaptTarget<State = unknown> = {
   state: State
 }
 
+export type AdaptConfig = Pick<AdaptProps, 'when' | 'platform'>
+
 export type AdaptParentContextI = {
   Contents: Component
   scopeName: string
-  platform: AdaptPlatform
-  setPlatform: (when: AdaptPlatform) => any
-  when: AdaptWhen
-  setWhen: (when: AdaptWhen) => any
   active: boolean
-  rawActive: boolean
-  setRawActive: (active: boolean) => void
+  setAdaptConfig: (config: AdaptConfig | null) => void
   portalName?: string
   lastScope?: string
   slot: AdaptSlotStore | null
@@ -139,13 +136,8 @@ const adaptContextKeys = [
   'Contents',
   'scopeName',
   'portalName',
-  'platform',
-  'setPlatform',
-  'when',
-  'setWhen',
   'active',
-  'rawActive',
-  'setRawActive',
+  'setAdaptConfig',
   'slot',
   'handoff',
   'targetFullyHidden',
@@ -165,13 +157,8 @@ export const AdaptContext = createStyledContext<
     Contents: null as any,
     scopeName: '',
     portalName: '',
-    platform: null as any,
-    setPlatform: (x: AdaptPlatform) => {},
-    when: null as any,
-    setWhen: () => {},
     active: false,
-    rawActive: false,
-    setRawActive: () => {},
+    setAdaptConfig: () => {},
     slot: null,
     handoff: {
       hidden: true,
@@ -231,12 +218,42 @@ type AdaptParentProps = {
   open?: boolean
   onOpenChange?: (open: boolean) => void
   state?: unknown
-  // unused, removed with the old paths in PRs B-E
-  portal?:
-    | boolean
-    | {
-        forwardProps?: any
+}
+
+// an <Adapt /> written into the adapting component's children is read off the
+// element tree during render. learning it from the child's layout effect left
+// every consumer seeing "inactive" on the first commit, so an adapted Select
+// mounted SelectInlineImpl and swapped it for SelectSheetImpl one commit later,
+// remounting the whole subtree. breadth-first so a nested adapting component's
+// own <Adapt /> can never shadow this one's. an <Adapt /> that a userland
+// component renders is not in this tree, so it reports itself from its effect
+// instead and still costs that extra commit.
+function findAdaptConfig(children: React.ReactNode, scope: string): AdaptConfig | null {
+  let level = React.Children.toArray(children)
+
+  while (level.length) {
+    const next: typeof level = []
+
+    for (const child of level) {
+      if (!React.isValidElement(child)) continue
+      const childProps = child.props as AdaptProps
+
+      if (child.type === Adapt) {
+        if (childProps.scope == null || childProps.scope === scope) {
+          return childProps
+        }
+        continue
       }
+
+      if (childProps.children && typeof childProps.children !== 'function') {
+        next.push(...React.Children.toArray(childProps.children))
+      }
+    }
+
+    level = next
+  }
+
+  return null
 }
 
 export const AdaptParent = ({
@@ -255,9 +272,23 @@ export const AdaptParent = ({
     slotRef.current = createAdaptSlotStore()
   }
 
-  const [when, setWhen] = React.useState<AdaptWhen>(null)
-  const [platform, setPlatform] = React.useState<AdaptPlatform>(null)
-  const [rawActive, setRawActive] = React.useState(false)
+  const staticConfig = React.useMemo(
+    () => findAdaptConfig(children, scope),
+    [children, scope]
+  )
+  const [publishedConfig, setPublishedConfig] = React.useState<AdaptConfig | null>(null)
+  const rawActive = useAdaptIsActiveGiven(staticConfig ?? publishedConfig)
+
+  // written during render because a child's layout effect calls setAdaptConfig
+  // before this component's own effects run
+  const staticConfigRef = React.useRef(staticConfig)
+  staticConfigRef.current = staticConfig
+
+  const setAdaptConfig = React.useCallback((config: AdaptConfig | null) => {
+    if (staticConfigRef.current) return
+    setPublishedConfig(config)
+  }, [])
+
   const [exiting, setExiting] = React.useState(false)
   const [present, setPresent] = React.useState(false)
   const [targetFullyHidden, setTargetFullyHidden] = React.useState(!open)
@@ -276,13 +307,6 @@ export const AdaptParent = ({
     rawActive && wasTargetHiddenRef.current && hasHadActiveTargetRef.current && open
   )
 
-  rawActiveRef.current = rawActive
-  openRef.current = open
-  if (rawActive) {
-    hasHadActiveTargetRef.current = true
-  }
-  wasTargetHiddenRef.current = targetHidden
-
   const releasePresenceLatch = React.useCallback(() => {
     setExiting(false)
     if (!rawActiveRef.current) {
@@ -297,6 +321,15 @@ export const AdaptParent = ({
   }, [shouldStartExit])
 
   useIsomorphicLayoutEffect(() => {
+    // committed snapshot: skipNextAnimation compares the next render against
+    // these, and onTransition reads them non-reactively
+    rawActiveRef.current = rawActive
+    openRef.current = open
+    if (rawActive) {
+      hasHadActiveTargetRef.current = true
+    }
+    wasTargetHiddenRef.current = targetHidden
+
     if (open && rawActive) {
       setTargetFullyHidden(false)
       return
@@ -308,7 +341,7 @@ export const AdaptParent = ({
     if (!open && !active) {
       setTargetFullyHidden(true)
     }
-  }, [active, open, rawActive])
+  }, [active, open, rawActive, targetHidden])
 
   useIsomorphicLayoutEffect(() => {
     if (rawActive) {
@@ -404,13 +437,8 @@ export const AdaptParent = ({
     <LastAdaptContextScope.Provider value={scope}>
       <ProvideAdaptContext
         Contents={FinalContents}
-        when={when}
-        platform={platform}
-        setPlatform={setPlatform}
-        setWhen={setWhen}
         active={active}
-        rawActive={rawActive}
-        setRawActive={setRawActive}
+        setAdaptConfig={setAdaptConfig}
         portalName={portalName}
         scopeName={scope}
         slot={slotRef.current}
@@ -464,24 +492,19 @@ AdaptContents.shouldForwardSpace = true
 
 export const Adapt = withStaticProperties(
   function Adapt(props: AdaptProps) {
-    const { platform, when, children, scope } = props
+    const { children, platform, scope, when } = props
     const context = useAdaptContext(scope)
-    const rawEnabled = useAdaptIsActiveGiven(props)
-    const enabled = rawEnabled || context.active
+    const enabled = context.active
     const isRenderCallback = typeof children === 'function'
 
+    // only reaches the parent when it could not read this element off its own
+    // children, i.e. a userland component renders the <Adapt />
     useIsomorphicLayoutEffect(() => {
-      context?.setWhen?.((when || rawEnabled) as AdaptWhen)
-      context?.setPlatform?.(platform || null)
-      context?.setRawActive?.(rawEnabled)
-    }, [
-      when,
-      platform,
-      rawEnabled,
-      context.setWhen,
-      context.setPlatform,
-      context.setRawActive,
-    ])
+      context.setAdaptConfig({ when, platform })
+      return () => {
+        context.setAdaptConfig(null)
+      }
+    }, [when, platform, context.setAdaptConfig])
 
     useIsomorphicLayoutEffect(() => {
       if (!enabled || !isRenderCallback) return
@@ -496,14 +519,6 @@ export const Adapt = withStaticProperties(
       context.registerRenderCallback,
       context.unregisterRenderCallback,
     ])
-
-    useIsomorphicLayoutEffect(() => {
-      return () => {
-        context?.setWhen?.(null)
-        context?.setPlatform?.(null)
-        context?.setRawActive?.(false)
-      }
-    }, [])
 
     let output: React.ReactNode
 
@@ -524,7 +539,6 @@ export const Adapt = withStaticProperties(
 export const AdaptPortalContents = (props: {
   children: React.ReactNode
   scope?: string
-  passThrough?: boolean
 }) => {
   const isActive = useAdaptIsActive(props.scope)
   const { slot } = useAdaptContext(props.scope)
@@ -557,19 +571,29 @@ function AdaptSlotPublisher({
   slot: AdaptSlotStore | null
   children: React.ReactNode
 }) {
-  const publishedRef = React.useRef(false)
+  const publishedRef = React.useRef<{
+    isActive: boolean
+    element: React.ReactNode
+  } | null>(null)
 
-  // Publish the live element value after every commit. Do not memoize this handoff:
-  // stale element deps caused the Sheet overlay-hoist regression this replaces.
+  // Publish the live element value after every commit. Do not memoize this handoff
+  // on a dep array: stale element deps caused the Sheet overlay-hoist regression
+  // this replaces. Comparing against what was actually published is safe, and
+  // keeps an unchanged element from re-rendering every slot consumer.
   useIsomorphicLayoutEffect(() => {
     if (!slot) return
 
+    const published = publishedRef.current
+    if (published && published.isActive === isActive && published.element === children) {
+      return
+    }
+
+    publishedRef.current = { isActive, element: children }
+
     if (isActive) {
       slot.publish(children)
-      publishedRef.current = true
     } else {
       slot.clear()
-      publishedRef.current = false
     }
 
     slot.notify()
@@ -577,11 +601,11 @@ function AdaptSlotPublisher({
 
   useIsomorphicLayoutEffect(() => {
     return () => {
-      if (publishedRef.current) {
+      if (publishedRef.current?.isActive) {
         slot?.clear()
         slot?.notify()
-        publishedRef.current = false
       }
+      publishedRef.current = null
     }
   }, [slot])
 
@@ -591,11 +615,10 @@ function AdaptSlotPublisher({
 const emptySubscribe = () => () => {}
 const emptySnapshot = () => 0
 
-const useAdaptIsActiveGiven = ({
-  when,
-  platform,
-}: Pick<AdaptProps, 'when' | 'platform'>) => {
+const useAdaptIsActiveGiven = (config: AdaptConfig | null) => {
   const media = useMedia()
+  const when = config?.when
+  const platform = config?.platform
 
   if (when == null && platform == null) {
     return false
@@ -625,9 +648,7 @@ const useAdaptIsActiveGiven = ({
 }
 
 export const useAdaptIsActive = (scope?: string) => {
-  const props = useAdaptContext(scope)
-  const isActiveGiven = useAdaptIsActiveGiven(props)
-  return props.active || isActiveGiven
+  return useAdaptContext(scope).active
 }
 
 export function useAdaptTarget<State = unknown>(

--- a/code/ui/adapt/types/Adapt.d.ts
+++ b/code/ui/adapt/types/Adapt.d.ts
@@ -35,16 +35,12 @@ export type AdaptTarget<State = unknown> = {
     handoff: AdaptTargetHandoff;
     state: State;
 };
+export type AdaptConfig = Pick<AdaptProps, 'when' | 'platform'>;
 export type AdaptParentContextI = {
     Contents: Component;
     scopeName: string;
-    platform: AdaptPlatform;
-    setPlatform: (when: AdaptPlatform) => any;
-    when: AdaptWhen;
-    setWhen: (when: AdaptWhen) => any;
     active: boolean;
-    rawActive: boolean;
-    setRawActive: (active: boolean) => void;
+    setAdaptConfig: (config: AdaptConfig | null) => void;
     portalName?: string;
     lastScope?: string;
     slot: AdaptSlotStore | null;
@@ -75,7 +71,7 @@ export type AdaptProps = {
     children: React.JSX.Element | ((contents: React.ReactNode, adapt: AdaptRenderState) => React.ReactNode);
 };
 type Component = (props: any) => any;
-export declare const AdaptContext: import("@tamagui/core").StyledContext<AdaptParentContextI, "Contents" | "active" | "handoff" | "platform" | "portalName" | "rawActive" | "registerContents" | "registerRenderCallback" | "registerTarget" | "scopeName" | "setPlatform" | "setRawActive" | "setWhen" | "slot" | "targetFullyHidden" | "unregisterContents" | "unregisterRenderCallback" | "unregisterTarget" | "when">;
+export declare const AdaptContext: import("@tamagui/core").StyledContext<AdaptParentContextI, "Contents" | "active" | "handoff" | "portalName" | "registerContents" | "registerRenderCallback" | "registerTarget" | "scopeName" | "setAdaptConfig" | "slot" | "targetFullyHidden" | "unregisterContents" | "unregisterRenderCallback" | "unregisterTarget">;
 export declare const ProvideAdaptContext: ({ children, ...context }: AdaptParentContextI & {
     children: any;
 }) => React.JSX.Element;
@@ -90,9 +86,6 @@ type AdaptParentProps = {
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
     state?: unknown;
-    portal?: boolean | {
-        forwardProps?: any;
-    };
 };
 export declare const AdaptParent: ({ children, Contents, scope, open, onOpenChange, state, }: AdaptParentProps) => React.JSX.Element;
 export declare function AdaptContents({ scope, ...rest }: {
@@ -107,7 +100,6 @@ export declare const Adapt: ((props: AdaptProps) => React.JSX.Element) & {
 export declare const AdaptPortalContents: (props: {
     children: React.ReactNode;
     scope?: string;
-    passThrough?: boolean;
 }) => React.JSX.Element;
 export declare const useAdaptIsActive: (scope?: string) => boolean;
 export declare function useAdaptTarget<State = unknown>(scope?: string): AdaptTarget<State> | null;

--- a/code/ui/adapt/types/Adapt.d.ts
+++ b/code/ui/adapt/types/Adapt.d.ts
@@ -81,13 +81,14 @@ export declare const useAdaptContext: (scope?: string) => AdaptParentContextI;
  */
 type AdaptParentProps = {
     children?: React.ReactNode;
+    adaptChildren?: React.ReactNode;
     Contents?: AdaptParentContextI['Contents'];
     scope: string;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
     state?: unknown;
 };
-export declare const AdaptParent: ({ children, Contents, scope, open, onOpenChange, state, }: AdaptParentProps) => React.JSX.Element;
+export declare const AdaptParent: ({ children, adaptChildren, Contents, scope, open, onOpenChange, state, }: AdaptParentProps) => React.JSX.Element;
 export declare function AdaptContents({ scope, ...rest }: {
     scope?: string;
 }): React.FunctionComponentElement<any>;

--- a/code/ui/components-test/Adapt.native.test.tsx
+++ b/code/ui/components-test/Adapt.native.test.tsx
@@ -50,7 +50,7 @@ describe('Adapt native live slot contents', () => {
 
     function Harness({ label }: { label: string }) {
       return (
-        <AdaptParent scope={scope} portal>
+        <AdaptParent scope={scope}>
           <Adapt when>
             <Adapt.Contents />
           </Adapt>

--- a/code/ui/dialog/src/Dialog.tsx
+++ b/code/ui/dialog/src/Dialog.tsx
@@ -1050,7 +1050,13 @@ const Dialog = withStaticProperties(
     } satisfies DialogContextValue
 
     return (
-      <AdaptParent scope={adaptScope} open={open} onOpenChange={setOpen} state={context}>
+      <AdaptParent
+        scope={adaptScope}
+        adaptChildren={children}
+        open={open}
+        onOpenChange={setOpen}
+        state={context}
+      >
         <DialogProvider scope={scope} {...context}>
           {children}
         </DialogProvider>

--- a/code/ui/popover/src/Popover.tsx
+++ b/code/ui/popover/src/Popover.tsx
@@ -1015,7 +1015,12 @@ export const Popover = withStaticProperties(
     }, [open, setOpen])
 
     return (
-      <AdaptParent scope={adaptScope} open={open} onOpenChange={setOpen}>
+      <AdaptParent
+        scope={adaptScope}
+        adaptChildren={props.children}
+        open={open}
+        onOpenChange={setOpen}
+      >
         <PopoverInner
           adaptScope={adaptScope}
           ref={ref}

--- a/code/ui/select/src/Select.tsx
+++ b/code/ui/select/src/Select.tsx
@@ -393,7 +393,12 @@ export function SelectRoot<
   )
 
   return (
-    <AdaptParent scope={adaptScope} open={open} onOpenChange={handleAdaptOpenChange}>
+    <AdaptParent
+      scope={adaptScope}
+      adaptChildren={props.children}
+      open={open}
+      onOpenChange={handleAdaptOpenChange}
+    >
       <SelectInner
         {...(props as SelectScopedProps<SelectProps<string, boolean>>)}
         scope={props.scope}

--- a/code/ui/select/src/SelectViewport.native.tsx
+++ b/code/ui/select/src/SelectViewport.native.tsx
@@ -1,6 +1,6 @@
 import {
-  AdaptContext,
   AdaptPortalContents,
+  ProvideAdaptContext,
   useAdaptContext,
   useAdaptIsActive,
 } from '@tamagui/adapt'
@@ -26,17 +26,17 @@ export const SelectViewport = createStyledHOC(
     const context = useSelectContext(scope)
     const itemParentContext = useSelectItemParentContext(scope)
     const themeName = useThemeName()
-    const adaptContext = useAdaptContext()
+    const adaptContext = useAdaptContext(context.adaptScope)
     const isAdapted = useAdaptIsActive(context.adaptScope)
 
     const contents = (
       <Theme name={themeName}>
         <ForwardSelectContext itemContext={itemParentContext} context={context}>
-          <AdaptContext.Provider {...adaptContext}>
+          <ProvideAdaptContext {...adaptContext}>
             <SelectViewportFrame {...viewportProps} ref={forwardedRef}>
               {children}
             </SelectViewportFrame>
-          </AdaptContext.Provider>
+          </ProvideAdaptContext>
         </ForwardSelectContext>
       </Theme>
     )


### PR DESCRIPTION
`AdaptParent` seeded `when`/`platform` as null and learned them from the child `<Adapt />`'s layout effect. Every `useAdaptIsActive` consumer therefore saw `false` on the first commit: `SelectInner` picked `SelectInlineImpl`, the effect flipped activation, and `SelectSheetImpl` mounted in its place, remounting the whole Select subtree and everything the caller nested in it. Popover and Dialog have the same shape.

## What changed

**Activation is resolved during render.** `AdaptParent` now reads `when`/`platform` off the `<Adapt />` element in its own `children` (breadth-first, so a nested adapting component's `<Adapt />` cannot shadow this one's) and derives `rawActive` from that plus `useMedia()`. No effect round trip, so `active` is correct on the first commit and no swap happens.

An `<Adapt />` that a *userland* component renders is not in that element tree (`PopoverScopedCase` and `DialogScopedCase` both do this), so it still reports itself from a layout effect through a single `setAdaptConfig` on the context. When the parent already found the element statically, that setter is a no-op, so the static path never pays for an extra render. `setWhen`, `setPlatform`, `setRawActive` and the `when`/`platform`/`rawActive` context keys are gone, replaced by that one setter.

**`SelectViewport.native` re-provided the unscoped context.** It rendered a raw `AdaptContext.Provider {...adaptContext}` with no `scope`, writing a context nobody reads. It now uses `ProvideAdaptContext`, like `Dialog.tsx` and `Popover.tsx`, and reads its context with the explicit `context.adaptScope`.

**`skipNextAnimation` read refs the render body then overwrote.** Under a StrictMode double render the second pass compared the first pass's writes against themselves. The ref writes moved into the existing layout effect.

**The slot publish effect called `slot.notify()` on every commit**, re-rendering every slot consumer even when nothing changed. It now bails when both `isActive` and the published element are unchanged.

**Dead props deleted:** `portal` on `AdaptParent` (and its only caller, `Adapt.native.test.tsx`) and `passThrough` on `AdaptPortalContents` (no callers).

## Validation

- New `AdaptFirstCommitCase` + `AdaptFirstCommit.test.tsx` count mounts of the subtree under the chosen Select impl. Written first and watched fail on the unfixed tree (`Expected: "1"  Received: "2"`), passes after.
- `tests/Adapt* tests/Select* tests/Popover* tests/Dialog* tests/Sheet*`: 233 passed / 6 skipped on `default` + `animated-css`; 208 passed / 14 skipped on `animated-reanimated` + `animated-motion`.
- Full `default` kitchen-sink project: 691 passed, 5 skipped.
- `code/ui/components-test`: `Adapt.native`, `Select.native`, `SheetScope.native` pass. `PortalTeleportRootHost.native` fails identically on unmodified `origin/v3-beta`, so it is pre-existing.
- Repo root: `bun run build`, `bun run lint`, `bun run check`, `bun run typecheck` all clean.
