### PR TITLE
fix(static): expand conditional style props as a cross product so branches can't shadow

### DIFF
--- a/code/compiler/static-tests/tests/__snapshots__/babel.web.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/babel.web.test.tsx.snap
@@ -41,20 +41,14 @@ export function Test(props) {
 `;
 
 exports[`conditional specific after generic style overrides 1`] = `
-"const _cn1 = "is_View _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px";
-const _cn0 = "is_View _btlr-5px _bbrr-5px _bblr-5px _pt-t-space-2 _pr-t-space-2 _pl-t-space-2 _btrr-10px _pb-18px";
-const _cn9 = "is_View _btlr-2px _bbrr-2px _bblr-2px _pt-t-space-2 _pr-t-space-2 _pl-t-space-2 _btrr-10px _pb-15px";
-const _cn8 = "is_View _bbrr-5px _bblr-5px _btlr-7px _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-2px";
-const _cn7 = "is_View _btlr-7px _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-2px";
-const _cn6 = "is_View _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-1px";
-const _cn5 = "is_View _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-1px";
-const _cn4 = "is_View _bbrr-2px _bblr-2px _btlr-7px _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-2px";
-const _cn3 = "is_View _btlr-7px _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-2px";
-const _cn2 = "is_View _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-1px";
-const _cn = "is_View _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px _mr-1px";
+"const _cn5 = "is_View _pt-t-space-2 _pr-t-space-2 _pb-t-space-2 _pl-t-space-2 _btrr-10px";
+const _cn4 = "is_View _pt-t-space-2 _pr-t-space-2 _pl-t-space-2 _btrr-10px _bbrr-5px _bblr-5px _pb-18px _btlr-7px _mr-2px";
+const _cn3 = "is_View _pt-t-space-2 _pr-t-space-2 _pl-t-space-2 _btrr-10px _btlr-5px _bbrr-5px _bblr-5px _pb-18px _mr-1px";
+const _cn2 = "is_View _pt-t-space-2 _pr-t-space-2 _pl-t-space-2 _btrr-10px _bbrr-2px _bblr-2px _pb-15px _btlr-7px _mr-2px";
+const _cn = "is_View _pt-t-space-2 _pr-t-space-2 _pl-t-space-2 _btrr-10px _btlr-2px _bbrr-2px _bblr-2px _pb-15px _mr-1px";
 import { View } from '@tamagui/core';
 export function Test(props) {
-  return <div className={!!floating && floating2 ? _cn : !floating && !floating2 ? _cn2 : !!floating && floating2 ? _cn3 : !floating && floating2 ? _cn4 : !floating && floating2 ? _cn5 : floating && !floating2 ? _cn6 : !floating && floating2 ? _cn7 : floating && floating2 ? _cn8 : !floating ? _cn9 : floating ? _cn0 : _cn1} />;
+  return <div className={!floating && !floating2 ? _cn : !floating && floating2 ? _cn2 : floating && !floating2 ? _cn3 : floating && floating2 ? _cn4 : _cn5} />;
 }"
 `;
 
@@ -64,17 +58,17 @@ exports[`conditional specific after generic style overrides 2`] = `
 :root ._pb-t-space-2{padding-bottom:var(--t-space-2);}
 :root ._pl-t-space-2{padding-left:var(--t-space-2);}
 :root ._btrr-10px{border-top-right-radius:10px;}
-:root ._btlr-5px{border-top-left-radius:5px;}
 :root ._bbrr-5px{border-bottom-right-radius:5px;}
 :root ._bblr-5px{border-bottom-left-radius:5px;}
 :root ._pb-18px{padding-bottom:18px;}
-:root ._btlr-2px{border-top-left-radius:2px;}
+:root ._btlr-7px{border-top-left-radius:7px;}
+:root ._mr-2px{margin-right:2px;}
+:root ._btlr-5px{border-top-left-radius:5px;}
+:root ._mr-1px{margin-right:1px;}
 :root ._bbrr-2px{border-bottom-right-radius:2px;}
 :root ._bblr-2px{border-bottom-left-radius:2px;}
 :root ._pb-15px{padding-bottom:15px;}
-:root ._btlr-7px{border-top-left-radius:7px;}
-:root ._mr-2px{margin-right:2px;}
-:root ._mr-1px{margin-right:1px;}"
+:root ._btlr-2px{border-top-left-radius:2px;}"
 `;
 
 exports[`conditional spread with hoverStyle preserves ternary 1`] = `
@@ -138,20 +132,18 @@ exports[`conditional styles get full base styles merged onto + shorthand 2`] = `
 `;
 
 exports[`double ternary + spread 1`] = `
-"const _cn7 = "is_View _ai-center";
-const _cn6 = "is_View _ai-center _f-unset";
-const _cn5 = "is_View _ai-center _fg-5 _fs-1 _fb-0px";
+"const _cn5 = "is_View _ai-center";
 const _cn4 = "is_View _f-unset _ai-flex-start _fd-column";
-const _cn3 = "is_View _ai-flex-start _fd-column";
+const _cn3 = "is_View _ai-center _f-unset";
 const _cn2 = "is_View _fg-5 _fs-1 _fb-0px _ai-flex-start _fd-column";
-const _cn = "is_View _ai-flex-start _fd-column";
+const _cn = "is_View _ai-center _fg-5 _fs-1 _fb-0px";
 import { View } from '@tamagui/core';
 export function Test({
   isSettings,
   isVertical,
   children
 }) {
-  return <div className={!!(isSettings || isVertical) && isVertical ? _cn : !(isSettings || isVertical) && isVertical ? _cn2 : !(isSettings || isVertical) && isVertical ? _cn3 : (isSettings || isVertical) && isVertical ? _cn4 : !(isSettings || isVertical) ? _cn5 : isSettings || isVertical ? _cn6 : _cn7}>
+  return <div className={!(isSettings || isVertical) && !isVertical ? _cn : !(isSettings || isVertical) && isVertical ? _cn2 : (isSettings || isVertical) && !isVertical ? _cn3 : (isSettings || isVertical) && isVertical ? _cn4 : _cn5}>
           {children}
         </div>;
 }"

--- a/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
+++ b/code/compiler/static-tests/tests/__snapshots__/webpack.test.tsx.snap
@@ -616,7 +616,7 @@ exports[`webpack-tests > 22. flexWrap with media query conditionals 1`] = `
         class="_dsp_contents  font_body"
       >
         <div
-          class="is_View _fwr-_sm_nowrap _pt-_sm_t-space-4 _pr-_sm_t-space-4 _pb-_sm_t-space-4 _pl-_sm_t-space-4 _fwr-wrap _gap-t-space-2 _fd-row"
+          class="is_View _fd-row _fwr-wrap _gap-t-space-2 _fwr-_sm_nowrap _pt-_sm_t-space-4 _pr-_sm_t-space-4 _pb-_sm_t-space-4 _pl-_sm_t-space-4"
         >
           <span
             class="is_Text _col-color"

--- a/code/compiler/static-tests/tests/ternaryCrossProduct.web.test.tsx
+++ b/code/compiler/static-tests/tests/ternaryCrossProduct.web.test.tsx
@@ -1,0 +1,135 @@
+import dedent from 'dedent'
+import * as React from 'react'
+import { expect, test } from 'vitest'
+
+import { extractForWeb } from './lib/extract'
+
+Error.stackTraceLimit = Number.MAX_SAFE_INTEGER
+process.env.TAMAGUI_TARGET = 'web'
+window['React'] = React
+
+// two conditional style props keyed on *different* tests used to expand into an
+// incrementally accumulated chain that repeated the same test with different
+// class strings - the first occurrence won, so some combinations selected
+// another combination's styles, and the base value leaked over both arms.
+// the expansion is a full cross product now, so every combination gets its own
+// mutually exclusive branch.
+
+// pulls the hoisted `const _cnN = "..."` literals plus the className ternary
+// chain out of the emitted module and evaluates the chain for real
+function evaluateClassNames(js: string | undefined, params: string[]) {
+  if (!js) throw new Error('no output')
+  const consts = js.match(/const _cn\w* = "[^"]*";/g)
+  const chain = js.match(/className=\{([\s\S]*?)\}>/)?.[1]
+  if (!consts || !chain) throw new Error(`could not parse output:\n${js}`)
+  const fn = new Function(...params, `${consts.join('\n')}\nreturn (${chain})`)
+  return (...args: boolean[]) =>
+    String(fn(...args))
+      .split(' ')
+      .filter(Boolean)
+}
+
+// every test in the emitted chain, so we can assert none of them repeats
+function testsOf(js: string | undefined) {
+  const chain = js?.match(/className=\{([\s\S]*?)\}>/)?.[1] ?? ''
+  return chain
+    .split('?')
+    .slice(0, -1)
+    .map((part) => {
+      const alternatives = part.split(':')
+      return alternatives[alternatives.length - 1].trim()
+    })
+}
+
+test('two conditional style props on different conditions each resolve independently', async () => {
+  const output = await extractForWeb(
+    dedent`
+      import { SizableText } from 'tamagui'
+      export function Fixture({ bold, shown, label }) {
+        return (
+          <SizableText size="$2" fontWeight={bold ? '600' : '500'} display={shown ? 'flex' : 'none'}>
+            {label}
+          </SizableText>
+        )
+      }
+    `
+  )
+
+  const classNamesFor = evaluateClassNames(output?.js, ['bold', 'shown'])
+
+  for (const bold of [true, false]) {
+    for (const shown of [true, false]) {
+      const cn = classNamesFor(bold, shown)
+      const where = `bold=${bold} shown=${shown}`
+
+      // each prop resolves to the literal its own arm asks for ...
+      expect(cn, where).toContain(bold ? '_fow-600' : '_fow-500')
+      expect(cn, where).not.toContain(bold ? '_fow-500' : '_fow-600')
+      expect(cn, where).toContain(shown ? '_dsp-flex' : '_dsp-none')
+      expect(cn, where).not.toContain(shown ? '_dsp-none' : '_dsp-flex')
+
+      // ... and never falls back to the size variant's font weight token, which
+      // is what the base style merged into the other ternary's arm used to
+      // reinstate over the arm that actually set fontWeight
+      expect(cn, where).not.toContain('_fow-f-weight-4')
+    }
+  }
+})
+
+test('the emitted ternary chain never repeats a test', async () => {
+  const output = await extractForWeb(
+    dedent`
+      import { SizableText } from 'tamagui'
+      export function Fixture({ bold, shown, label }) {
+        return (
+          <SizableText size="$2" fontWeight={bold ? '600' : '500'} display={shown ? 'flex' : 'none'}>
+            {label}
+          </SizableText>
+        )
+      }
+    `
+  )
+
+  const tests = testsOf(output?.js)
+  // 2 ternaries -> 4 combinations, none of them shadowing another
+  expect(tests).toHaveLength(4)
+  expect(new Set(tests).size).toBe(tests.length)
+})
+
+test('a conditional spread still merges over an unrelated ternary', async () => {
+  const output = await extractForWeb(
+    dedent`
+      import { View } from '@tamagui/core'
+      export function Fixture({ isSettings, isVertical, children }) {
+        return (
+          <View
+            flex={isSettings || isVertical ? 'unset' : 5}
+            alignItems="center"
+            {...(isVertical && { flexDirection: 'column', alignItems: 'flex-start' })}
+          >
+            {children}
+          </View>
+        )
+      }
+    `
+  )
+
+  const classNamesFor = evaluateClassNames(output?.js, ['isSettings', 'isVertical'])
+
+  // isVertical implies the flex ternary's consequent, so the spread's styles and
+  // flex:unset have to land together - the spread's branch used to drop flex
+  const vertical = classNamesFor(false, true)
+  expect(vertical).toContain('_f-unset')
+  expect(vertical).toContain('_fd-column')
+  expect(vertical).toContain('_ai-flex-start')
+
+  const settingsOnly = classNamesFor(true, false)
+  expect(settingsOnly).toContain('_f-unset')
+  expect(settingsOnly).toContain('_ai-center')
+  expect(settingsOnly).not.toContain('_fd-column')
+
+  const neither = classNamesFor(false, false)
+  expect(neither).toContain('_fg-5')
+  expect(neither).toContain('_ai-center')
+  expect(neither).not.toContain('_f-unset')
+})

--- a/code/compiler/static/src/extractor/extractToClassNames.ts
+++ b/code/compiler/static/src/extractor/extractToClassNames.ts
@@ -421,6 +421,9 @@ export async function extractToClassNames({
         // merge the base style forward into both sides
         return {
           ...ternary,
+          // the base as it stands *here* - a style declared after this ternary
+          // was never merged into its arms and must not be merged in later
+          baseStyle: mergeForwardBaseStyle ? { ...mergeForwardBaseStyle } : {},
           alternate: mergedAlternate,
           consequent: mergedConsequent,
         }
@@ -485,80 +488,78 @@ export async function extractToClassNames({
         // normalize tests to reduce duplicates
         const normalizedTernaries = normalizeTernaries(onlyTernaries)
 
+        // both arms of a ternary arrive already merged with the base style, so
+        // merging one arm over another lets the second arm's *inherited* base
+        // values overwrite what the first arm actually set. combine the arms by
+        // what they each actually change, and put the base back underneath the
+        // result below - that way the base can never outrank an arm.
+        const ownStyleOf = (arm: object | null | undefined, base: object) => {
+          const own: Record<string, any> = {}
+          if (arm) {
+            for (const key in arm) {
+              if (base[key] !== arm[key]) {
+                own[key] = arm[key]
+              }
+            }
+            forwardFontFamilyName(arm, own)
+          }
+          return own
+        }
+
+        // build the full cross product of every ternary's two arms: one branch
+        // per combination of conditions, carrying exactly the styles that
+        // combination asks for. an arm the source omits contributes an empty
+        // style, so the branches always partition the whole condition space -
+        // 2^n mutually exclusive, exhaustive branches whose test order cannot
+        // select the wrong one.
+        let branches: { tests: t.Expression[]; style: object }[] = [
+          { tests: [], style: {} },
+        ]
+        // the base every branch sits on: each ternary's own snapshot, merged in
+        // source order, so a later style still beats an earlier one
+        let branchBase: object = {}
+
         for (const ternary of normalizedTernaries) {
-          if (!expandedTernaries.length) {
-            expandTernary(ternary)
-            continue
+          const base = ternary.baseStyle || {}
+          branchBase = mergeProps(branchBase, base)
+          const arms = [
+            [ternary.test, ownStyleOf(ternary.consequent, base)],
+            [t.unaryExpression('!', ternary.test), ownStyleOf(ternary.alternate, base)],
+          ] as const
+          const next: typeof branches = []
+          for (const branch of branches) {
+            for (const [test, arm] of arms) {
+              const style = mergeProps(branch.style, arm)
+              forwardFontFamilyName(arm, style, getFontFamilyNameFromProps(branch.style))
+              next.push({
+                // clone so no test node is aliased into the output twice
+                tests: [...branch.tests, t.cloneNode(test, true)],
+                style,
+              })
+            }
           }
-          // snapshot current array before iterating - expandTernary mutates expandedTernaries
-          const prevTernaries = [...expandedTernaries]
-          for (const prev of prevTernaries) {
-            expandTernary(ternary, prev)
-          }
-        }
-      }
-
-      function expandTernary(ternary: Ternary, prev?: Ternary) {
-        // need to diverge into two (or four if alternate)
-        if (ternary.consequent && Object.keys(ternary.consequent).length) {
-          const fontFamily = getFontFamilyNameFromProps(ternary.consequent)
-
-          expandedTernaries.push({
-            fontFamily,
-            // prevTest && test: merge consequent
-            test: prev
-              ? t.logicalExpression('&&', prev.test, ternary.test)
-              : ternary.test,
-            consequent: prev
-              ? mergeProps(prev.consequent!, ternary.consequent)
-              : ternary.consequent,
-            remove,
-            alternate: null,
-          })
-
-          if (prev) {
-            expandedTernaries.push({
-              fontFamily,
-              // !prevTest && test: just consequent
-              test: t.logicalExpression(
-                '&&',
-                t.unaryExpression('!', prev.test),
-                ternary.test
-              ),
-              consequent: ternary.consequent,
-              alternate: null,
-              remove,
-            })
-          }
+          branches = next
         }
 
-        if (ternary.alternate && Object.keys(ternary.alternate).length) {
-          const fontFamily = getFontFamilyNameFromProps(ternary.alternate)
-          const negated = t.unaryExpression('!', ternary.test)
+        for (const branch of branches) {
+          // a combination that changes nothing off the base renders exactly the
+          // chain's fallback - and because the branches partition the condition
+          // space, dropping one just falls through to it
+          if (!Object.keys(branch.style).length) continue
+          // a branch replaces the whole className, so it has to carry the base
+          // too: the base is only emitted ahead of it when it is a plain string
+          // literal, not when it is a runtime expression
+          const consequent = mergeProps(branchBase, branch.style)
+          forwardFontFamilyName(branch.style, consequent, baseFontFamily)
           expandedTernaries.push({
-            fontFamily,
-            // prevTest && !test: merge alternate
-            test: prev ? t.logicalExpression('&&', prev.test, negated) : negated,
-            consequent: prev
-              ? mergeProps(prev.alternate!, ternary.alternate)
-              : ternary.alternate,
-            remove,
+            fontFamily: getFontFamilyNameFromProps(consequent),
+            test: branch.tests.reduce((left, right) =>
+              t.logicalExpression('&&', left, right)
+            ),
+            consequent,
             alternate: null,
+            remove,
           })
-
-          if (prev) {
-            expandedTernaries.push({
-              fontFamily,
-              test: t.logicalExpression(
-                '&&',
-                t.unaryExpression('!', prev.test),
-                ternary.test
-              ),
-              consequent: ternary.alternate,
-              remove,
-              alternate: null,
-            })
-          }
         }
       }
 

--- a/code/compiler/static/src/types.ts
+++ b/code/compiler/static/src/types.ts
@@ -98,6 +98,8 @@ export interface Ternary {
   alternate: object | null
   fontFamily?: string
   inlineMediaQuery?: string
+  /** the base style as it stood when this ternary's arms were merged */
+  baseStyle?: object
 }
 
 export type ClassNameToStyleObj = {

--- a/code/compiler/static/types/types.d.ts
+++ b/code/compiler/static/types/types.d.ts
@@ -80,6 +80,8 @@ export interface Ternary {
     alternate: object | null;
     fontFamily?: string;
     inlineMediaQuery?: string;
+    /** the base style as it stood when this ternary's arms were merged */
+    baseStyle?: object;
 }
 export type ClassNameToStyleObj = {
     [key: string]: StyleObject;


### PR DESCRIPTION
Fixes #4194.

### The bug

`extractToClassNames` expanded conditional style props by folding each ternary into an accumulator, appending new branches as it went. The resulting chain repeated the same test with different class strings, so `?:` evaluation picked whichever copy came first and later, more specific branches became unreachable.

Compiling the fixture from the issue reproduced its reported output exactly: 10 branches, `!bold && shown` appearing three times with different classes, `_fow-600` / `_fow-500` unreachable in every combination.

The repo's own `conditional specific after generic style overrides` test was pinning that broken output. Evaluating its emitted chain against the expectations written in the comments above it:

| floating | floating2 | before | after |
| --- | --- | --- | --- |
| true | true | missing `_pb-18px _mr-2px _bbrr-5px _bblr-5px _btlr-7px` | correct |
| true | false | missing `_pb-18px _btlr-5px _bbrr-5px _bblr-5px` | correct |
| false | true | missing `_pb-15px` | correct |
| false | false | missing `_pb-15px _btlr-2px _bbrr-2px _bblr-2px` | correct |

### The fix

Expand the ternaries as an explicit cross product instead: every ternary contributes both arms (an omitted arm contributes `{}`), giving 2^n mutually exclusive, exhaustive branches whose test order cannot select the wrong one. Arms are combined by what they actually change — base-inherited keys stripped, base merged back underneath — so a later arm's inherited base value can no longer clobber an earlier arm's real override. A `baseStyle` snapshot is taken per ternary so a style declared *after* a ternary is not merged backwards into its arms.

Branch count is still exponential in the number of distinct conditional props, but strictly smaller than before: 2 props go 10 → 4, 3 props ~50 → 8.

Single-ternary output is byte-identical.

### Testing

New `tests/ternaryCrossProduct.web.test.tsx` evaluates the emitted chain for real rather than snapshotting it.

Red — reverting `extractToClassNames.ts` to `main` and rebuilding `@tamagui/static`:

```
× two conditional style props on different conditions each resolve independently
× the emitted ternary chain never repeats a test
× a conditional spread still merges over an unrelated ternary

AssertionError: bold=true shown=true: expected [...] to include '_fow-600'
AssertionError: expected [ '!!bold && shown', …(9) ] to have a length of 4 but got 10
AssertionError: expected [...] to include '_f-unset'
Tests  3 failed (3)
```

Green:

```
tests/ternaryCrossProduct.web.test.tsx   3 passed
tests/babel.web.test.tsx                 35 passed | 1 skipped
tests/webpack.test.tsx                   18 passed
bun run test:all                         native 3/3, web 13/13, webpack 1/1, exit 0
./node_modules/.bin/tsc -b tsconfig.build.json   exit 0
oxlint / oxfmt --check                   clean
```

Three snapshots updated, each a correctness fix rather than churn: the two multi-ternary `babel.web` cases in the table above, plus one `webpack` case where only class *order* changed (same nine classes; that test's real `computedStyle.flexWrap === 'wrap'` assertion still passes).

Two things a reviewer may want to weigh: `scripts/typecheck.sh` gives a false pass in this repo — `tsc` is not on `PATH` and `tsc: command not found` does not contain "error", so it prints ✅; I ran `./node_modules/.bin/tsc` directly. And the pre-existing behaviour where a *runtime* `className` expression is dropped inside ternary branches is untouched — that test's snapshot is byte-identical.