### PR TITLE
fix(switch): mirror the thumb translate under rtl so it travels across the frame

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3142,6 +3142,7 @@
         "@tamagui/stacks": "workspace:*",
         "@tamagui/switch-headless": "workspace:*",
         "@tamagui/use-controllable-state": "workspace:*",
+        "@tamagui/use-direction": "workspace:*",
         "@tamagui/use-previous": "workspace:*",
       },
       "devDependencies": {

--- a/code/ui/components-test/Switch.web.test.tsx
+++ b/code/ui/components-test/Switch.web.test.tsx
@@ -1,0 +1,49 @@
+import '@testing-library/jest-dom'
+import 'vitest-axe/extend-expect'
+
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import { TamaguiProvider, createTamagui } from '@tamagui/core'
+import { Switch, SwitchStyledContext } from '@tamagui/switch'
+import { DirectionProvider } from '@tamagui/use-direction'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+const FRAME_WIDTH = 40
+const THUMB_TEST_ID = 'switch-thumb'
+
+// the thumb reads the measured frame width off context, and jsdom reports no
+// layout, so feed the width in directly to keep the travel distance non-zero
+function ThumbTest({ dir, active }: { dir: 'ltr' | 'rtl'; active: boolean }) {
+  return (
+    <TamaguiProvider config={conf} defaultTheme="light">
+      <DirectionProvider dir={dir}>
+        <SwitchStyledContext.Provider active={active} frameWidth={FRAME_WIDTH}>
+          <Switch.Thumb unstyled data-testid={THUMB_TEST_ID} />
+        </SwitchStyledContext.Provider>
+      </DirectionProvider>
+    </TamaguiProvider>
+  )
+}
+
+// renders unchecked then checks it, so the thumb starts at its resting edge
+// and we read the travel it makes towards the other edge
+function getCheckedTravel(dir: 'ltr' | 'rtl') {
+  const rendered = render(<ThumbTest dir={dir} active={false} />)
+  rendered.rerender(<ThumbTest dir={dir} active />)
+  const thumb = rendered.getByTestId(THUMB_TEST_ID)
+  const translate = /translateX\((-?[\d.]+)px\)/.exec(getComputedStyle(thumb).transform)
+  rendered.unmount()
+  return translate ? Number(translate[1]) : Number.NaN
+}
+
+describe('Switch.Thumb travel', () => {
+  it('should move the thumb towards the trailing edge in ltr', () => {
+    expect(getCheckedTravel('ltr')).toBeGreaterThan(0)
+  })
+
+  it('should mirror the thumb travel in rtl', () => {
+    expect(getCheckedTravel('rtl')).toBe(-getCheckedTravel('ltr'))
+  })
+})

--- a/code/ui/switch/package.json
+++ b/code/ui/switch/package.json
@@ -45,6 +45,7 @@
     "@tamagui/stacks": "workspace:*",
     "@tamagui/switch-headless": "workspace:*",
     "@tamagui/use-controllable-state": "workspace:*",
+    "@tamagui/use-direction": "workspace:*",
     "@tamagui/use-previous": "workspace:*"
   },
   "devDependencies": {

--- a/code/ui/switch/src/createSwitch.tsx
+++ b/code/ui/switch/src/createSwitch.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tamagui/core'
 import { useSwitch } from '@tamagui/switch-headless'
 import { useControllableState } from '@tamagui/use-controllable-state'
+import { useDirection } from '@tamagui/use-direction'
 import * as React from 'react'
 import type { LayoutChangeEvent } from 'react-native'
 import { SwitchStyledContext } from './StyledContext'
@@ -72,6 +73,10 @@ export function createSwitch<
       )
       const distance = frameWidth - thumbWidth
       const x = initialChecked ? (active ? 0 : -distance) : active ? distance : 0
+      // alignSelf resolves against the writing direction so the resting edge
+      // flips under rtl, but the translate below never does
+      const direction = useDirection()
+      const thumbX = direction === 'rtl' ? -x : x
 
       return (
         <Thumb
@@ -81,7 +86,7 @@ export function createSwitch<
             size,
           })}
           alignSelf={initialChecked ? 'flex-end' : 'flex-start'}
-          x={x}
+          x={thumbX}
           onLayout={composeEventHandlers(props.onLayout, (e) => {
             const next = e.nativeEvent.layout.width
             setThumbWidth(next)


### PR DESCRIPTION
Refs #2970

> **Draft.** The approach below does not hold up. `useDirection()` is not connected to the
> signal that flips `alignSelf`, so the case reported in #2970 (Android, `I18nManager` RTL,
> no `DirectionProvider`) is unaffected, and an LTR document with a `DirectionProvider`
> would translate the thumb the wrong way. The `Fixes` link is removed so this cannot close
> the issue. See the comment below. Reworking it to derive one flag from the layout direction.

### What breaks

Under RTL the `Switch` thumb slides the wrong way. Instead of crossing the track it moves out of the frame, which is what the reproduction in the issue shows.

### Root cause

`code/ui/switch/src/createSwitch.tsx:75-86`. The thumb is positioned by two properties that disagree about direction:

```tsx
alignSelf={initialChecked ? 'flex-end' : 'flex-start'}
x={x}
```

`alignSelf` resolves against the writing direction, so the resting edge already flips when the direction is RTL. The `x` translate does not flip: `translateX` is a physical transform on both web and React Native. So the thumb is anchored on the right and then translated further right by `frameWidth - thumbWidth`, ending up outside the frame.

That matches the workaround a second reporter posted on the issue, which negates `translateX` by hand when RTL.

### The fix

Read the direction with `useDirection()` from `@tamagui/use-direction` (the same hook `Slider`, `Tabs`, `Accordion`, `ToggleGroup`, `RovingFocusGroup` and `createBaseMenu` already use) and negate the translate when it is `rtl`, so the translate agrees with the anchor:

```tsx
const direction = useDirection()
const thumbX = direction === 'rtl' ? -x : x
```

LTR is untouched: `useDirection()` returns `'ltr'` when there is no `DirectionProvider`, so `thumbX === x`.

### How I proved it

New test `code/ui/components-test/Switch.web.test.tsx`. It renders `Switch.Thumb` inside a `SwitchStyledContext.Provider` with a frame width (jsdom reports no layout, so the width is supplied directly), toggles it to checked, and reads the resulting `translateX`. One test guards the existing LTR travel, the other asserts RTL travel mirrors it.

Green with the fix:

```
 ✓ Switch.web.test.tsx > Switch.Thumb travel > should move the thumb towards the trailing edge in ltr
 ✓ Switch.web.test.tsx > Switch.Thumb travel > should mirror the thumb travel in rtl
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Counterfactual, reverting only `createSwitch.tsx` to its state on `main` and rebuilding the package (these tests resolve `@tamagui/switch` from `dist`):

```
 ✓ Switch.web.test.tsx > Switch.Thumb travel > should move the thumb towards the trailing edge in ltr
 × Switch.web.test.tsx > Switch.Thumb travel > should mirror the thumb travel in rtl
   → expected 40 to be -40 // Object.is equality
```

The RTL thumb translates `+40` instead of `-40`, which is the defect. The LTR guard stays green through both runs, so the test is not passing or failing for an unrelated reason.

Full CI test jobs after the change:

- `bun turbo run test:web --filter='!@tamagui/kitchen-sink' --concurrency=1`: `@tamagui/components-test` 32 passed (6 files). The only failing task is `integration`, which cannot launch Playwright locally because the browser binaries are not installed; unrelated to this change.
- `bun turbo run test:native --filter=@tamagui/static-tests --filter=@tamagui/core-test --filter=@tamagui/components-test --concurrency=1`: 3 successful, 3 total.

`bun run check:deps` (manypkg), oxlint and oxfmt are clean on the changed files. `@tamagui/use-direction` was added to `@tamagui/switch` dependencies, which is the only reason `bun.lock` is touched.

