### PR TITLE
fix(core): stop stripping onScroll on native so ScrollView handlers fire

### DIFF
--- a/code/core/core-test/getSplitStyles.native.test.tsx
+++ b/code/core/core-test/getSplitStyles.native.test.tsx
@@ -351,6 +351,19 @@ describe('getSplitStyles', () => {
     expect(style?.padding).toBeUndefined()
     expect(style?.paddingTop).toBeUndefined()
   })
+
+  test('onScroll is forwarded on native', () => {
+    const onScroll = () => {}
+    const { viewProps } = getSplitStylesFor({ onScroll })
+    expect(viewProps.onScroll).toBe(onScroll)
+  })
+
+  test('onScroll survives a styled() wrapper on native', () => {
+    const StyledView = styled(View, { backgroundColor: 'red' })
+    const onScroll = () => {}
+    const { viewProps } = getSplitStylesFor({ onScroll }, StyledView)
+    expect(viewProps.onScroll).toBe(onScroll)
+  })
 })
 
 describe.skip('getSplitStyles - pseudo prop merging', () => {

--- a/code/core/web/src/helpers/webPropsToSkip.native.ts
+++ b/code/core/web/src/helpers/webPropsToSkip.native.ts
@@ -45,7 +45,8 @@ export const webPropsToSkip = {
   onChange: 1,
   onInput: 1,
   onBeforeInput: 1,
-  onScroll: 1,
+  // onScroll is not listed here: it is a real React Native prop on
+  // ScrollView, FlatList and TextInput, so skipping it breaks them.
   onCopy: 1,
   onCut: 1,
   onPaste: 1,

--- a/code/core/web/types/helpers/webPropsToSkip.native.d.ts
+++ b/code/core/web/types/helpers/webPropsToSkip.native.d.ts
@@ -32,7 +32,6 @@ export declare const webPropsToSkip: {
     onChange: number;
     onInput: number;
     onBeforeInput: number;
-    onScroll: number;
     onCopy: number;
     onCut: number;
     onPaste: number;


### PR DESCRIPTION
Fixes #4163

## What breaks

On native, `onScroll` never reaches the underlying React Native component. A plain Tamagui `ScrollView` scrolls normally but the handler is never called, with no error or warning. The reporter's workaround was to wrap the ScrollView in reanimated's `createAnimatedComponent`, whose `PropsFilter` re-injects the prop.

The same strip hits `Input` on native: `code/ui/input/src/Input.native.tsx` destructures `onScroll` and passes it into the styled `TextInput` frame, where it is dropped again.

## Root cause

`code/core/web/src/helpers/webPropsToSkip.native.ts:48` lists `onScroll: 1` among the web-only event handlers.

`code/core/web/src/helpers/skipProps.ts:29` merges that object into `skipProps` when `TAMAGUI_TARGET === 'native'`, and `getSplitStyles.tsx:385` drops any prop found in `skipProps` for a non-HOC component. `ScrollView` is a plain `styled(ScrollViewNative, ...)` (`code/ui/scroll-view/src/ScrollView.tsx:6`), so it takes that path and loses the prop before render.

`onScroll` is not web-only: it is a real prop on RN `ScrollView`, `FlatList` and `TextInput`. On web the list is empty (`webPropsToSkip.ts`), so web already forwards it, which is why the behaviour diverges by platform.

## The fix

Remove `onScroll` from the native skip list. This follows the existing precedent in the same file, where `pointerEvents` is explicitly excluded from the spread of `webOnlyStylePropsView` because it is a valid RN prop.

`code/core/web/types/helpers/webPropsToSkip.native.d.ts` is regenerated to match, since `types/` is tracked here and `SKIP_JS=1 bun run build` in `code/core/web` would otherwise leave the tree dirty with exactly that one-line deletion. It is the only file in `types/` that moves.

The skip list is global to native styled components, so this also lets `onScroll` reach RN `View` and `Text` hosts, where it simply never fires. Rendering `<View onScroll>`, `<Text onScroll>` and `<styled(View) onScroll>` under `TAMAGUI_TARGET=native` produces no throw and no warning, and the handler lands on the host element in all three cases (the only `console.error` in that run is the unrelated `react-test-renderer is deprecated` notice).

## How this was verified

Two tests added to `code/core/core-test/getSplitStyles.native.test.tsx`, one for a bare `View` and one behind a `styled()` wrapper.

Counterfactual, reverting only `webPropsToSkip.native.ts` and rebuilding. Rebuilding `@tamagui/web` alone is a no-op for these tests, because `code/packages/vite-plugin-internal/src/getConfig.ts` aliases both `@tamagui/core` and `@tamagui/web` to `@tamagui/core/native-test`, so `@tamagui/core` has to be rebuilt:

```
 x getSplitStyles > onScroll is forwarded on native
   -> expected undefined to be [Function onScroll] // Object.is equality
 x getSplitStyles > onScroll survives a styled() wrapper on native
   -> expected undefined to be [Function onScroll] // Object.is equality
 Tests  2 failed | 15 passed | 2 skipped (19)
```

With the fix restored: `17 passed | 2 skipped (19)`.

Full `unit-tests` CI job locally, after `bun run build:js`:

- `test:native` for `@tamagui/core-test`, `@tamagui/components-test`, `@tamagui/static-tests`: 3/3 tasks green (97 passed / 7 expected fail / 11 skipped, 27 passed, 32 passed).
- `test:web --filter='!@tamagui/kitchen-sink'`: `@tamagui/core-test` 210 passed, `@tamagui/components-test` 30 passed, `@tamagui/build` 14 passed, `create-tamagui` 24 passed. The `next15-plus-cli-optimize` starter fails on this machine with `error: Script not found "tamagui"`, which is a local CLI linking problem unrelated to this change.

## Follow-up, not in this PR

`onChange` sits in the same list, but it is not the same case and should probably stay skipped.

`code/ui/input/src/Input.native.tsx` destructures `onChange` at line 27 and never forwards it. Instead `handleChangeText` (lines 184 to 189) synthesizes a web-shaped event from `onChangeText`:

```tsx
onChange({ target: { value: text }, type: 'change' } as any)
```

So on native, Tamagui deliberately gives `onChange` the web payload, `e.target.value`. React Native's own `TextInput.onChange` is `NativeSyntheticEvent<TextInputChangeEventData>`, where the value is at `e.nativeEvent.text`. Unskipping `onChange` would let the raw RN event reach handlers on styled RN hosts while `Input` keeps synthesizing the web-shaped one, so the same prop name would carry two different payload shapes depending on which component you used. `onScroll` has no such shim anywhere, which is why it is safe to unskip and `onChange` is not.

