### PR TITLE
fix(core): expand own variants inside pseudo and media props over a styleable HOC

### DIFF
--- a/code/core/core-test/hocPseudoVariants.web.test.tsx
+++ b/code/core/core-test/hocPseudoVariants.web.test.tsx
@@ -1,0 +1,73 @@
+process.env.TAMAGUI_TARGET = 'web'
+
+import { render } from '@testing-library/react'
+import { beforeAll, describe, expect, test } from 'vitest'
+
+import config from '../config-default'
+import { TamaguiProvider, View, createTamagui, styled } from '../web/src'
+import { simplifiedGetSplitStyles } from './utils'
+
+let conf: any
+
+beforeAll(() => {
+  // @ts-ignore
+  conf = createTamagui(config.getDefaultTamaguiConfig())
+})
+
+const StyledView = styled(View, {
+  name: 'StyledView',
+  variants: {
+    bgColor: {
+      yellow: { backgroundColor: 'yellow' },
+    },
+  } as const,
+})
+
+const HOCView = StyledView.styleable((props: any, ref: any) => (
+  <StyledView ref={ref} {...props} />
+))
+
+const RestyledView = styled(HOCView, {
+  name: 'RestyledView',
+  variants: {
+    bgColor: {
+      red: { backgroundColor: 'red' },
+    },
+  } as const,
+})
+
+describe('variants added on top of a styleable() HOC (#3047)', () => {
+  test('expands our own variant inside hoverStyle before passing it down', () => {
+    const { viewProps } = simplifiedGetSplitStyles(RestyledView, {
+      hoverStyle: { bgColor: 'red' },
+    })
+    expect(viewProps.hoverStyle).toEqual({ backgroundColor: 'red' })
+  })
+
+  test('expands our own variant inside a media prop before passing it down', () => {
+    const { viewProps } = simplifiedGetSplitStyles(RestyledView, {
+      $sm: { bgColor: 'red' },
+    })
+    expect(viewProps.$sm).toEqual({ backgroundColor: 'red' })
+  })
+
+  test('leaves a value only the wrapped component knows about untouched', () => {
+    const { viewProps } = simplifiedGetSplitStyles(RestyledView, {
+      hoverStyle: { bgColor: 'yellow' },
+    })
+    expect(viewProps.hoverStyle).toEqual({ bgColor: 'yellow' })
+  })
+
+  test('renders the hover class for a variant added on top of the HOC', () => {
+    const { getByTestId } = render(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <StyledView data-testid="base" hoverStyle={{ bgColor: 'yellow' }} />
+        <RestyledView data-testid="hoc" hoverStyle={{ bgColor: 'red' }} />
+      </TamaguiProvider>
+    )
+    // the non-HOC case has always worked, it is the control here
+    expect(getByTestId('base').className).toContain('_bg-0hover-yellow')
+    // before the fix this was _bgColor-0hover-red, a property that does not exist
+    expect(getByTestId('hoc').className).toContain('_bg-0hover-red')
+  })
+})

--- a/code/core/core-test/hocPseudoVariants.web.test.tsx
+++ b/code/core/core-test/hocPseudoVariants.web.test.tsx
@@ -14,13 +14,30 @@ beforeAll(() => {
   conf = createTamagui(config.getDefaultTamaguiConfig())
 })
 
+const childVariants = {
+  bgColor: {
+    yellow: { backgroundColor: 'yellow' },
+    '...color': (val: any) => ({ backgroundColor: val }),
+  },
+  // bg is also a shorthand, so renaming it on the way down would lose this variant
+  bg: { brand: { backgroundColor: 'rebeccapurple' } },
+} as const
+
+const ownVariants = {
+  bgColor: {
+    red: { backgroundColor: 'red' },
+  },
+  pad: {
+    big: { padding: 20 },
+  },
+  tone: {
+    ':string': (val: any, { props }: any) => ({ opacity: props.dense ? 0.1 : 0.8 }),
+  },
+} as const
+
 const StyledView = styled(View, {
   name: 'StyledView',
-  variants: {
-    bgColor: {
-      yellow: { backgroundColor: 'yellow' },
-    },
-  } as const,
+  variants: childVariants,
 })
 
 const HOCView = StyledView.styleable((props: any, ref: any) => (
@@ -29,12 +46,17 @@ const HOCView = StyledView.styleable((props: any, ref: any) => (
 
 const RestyledView = styled(HOCView, {
   name: 'RestyledView',
-  variants: {
-    bgColor: {
-      red: { backgroundColor: 'red' },
-    },
-  } as const,
+  variants: ownVariants,
 })
+
+// the same variants with no HOC in between, so the pass-down can be compared against
+// the getSubStyle path that has always worked
+const PlainView = styled(View, {
+  name: 'PlainView',
+  variants: ownVariants,
+})
+
+const themed = () => ({ theme: conf.themes.light, themeName: 'light' })
 
 describe('variants added on top of a styleable() HOC (#3047)', () => {
   test('expands our own variant inside hoverStyle before passing it down', () => {
@@ -51,11 +73,57 @@ describe('variants added on top of a styleable() HOC (#3047)', () => {
     expect(viewProps.$sm).toEqual({ backgroundColor: 'red' })
   })
 
-  test('leaves a value only the wrapped component knows about untouched', () => {
-    const { viewProps } = simplifiedGetSplitStyles(RestyledView, {
-      hoverStyle: { bgColor: 'yellow' },
+  test('leaves values only the wrapped component knows about untouched', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      RestyledView,
+      { hoverStyle: { bgColor: 'yellow', bg: 'brand' } },
+      themed()
+    )
+    expect(viewProps.hoverStyle).toEqual({ bgColor: 'yellow', bg: 'brand' })
+  })
+
+  test('keeps a sibling key our variant cannot resolve while expanding one it can', () => {
+    // bgColor: '$blue10' has no value on our side and resolves to nothing as a plain
+    // style key either, so it has to survive intact for the child spread variant to see
+    const { viewProps } = simplifiedGetSplitStyles(
+      RestyledView,
+      { hoverStyle: { bgColor: '$blue10', pad: 'big' } },
+      themed()
+    )
+    expect(viewProps.hoverStyle).toMatchObject({
+      bgColor: '$blue10',
+      paddingTop: '20px',
+      paddingLeft: '20px',
     })
-    expect(viewProps.hoverStyle).toEqual({ bgColor: 'yellow' })
+  })
+
+  test('expands a variant inside a media object nested in a pseudo', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      RestyledView,
+      { hoverStyle: { $sm: { bgColor: 'red' } } },
+      themed()
+    )
+    expect(viewProps.hoverStyle).toEqual({ $sm: { backgroundColor: 'red' } })
+  })
+
+  test('expands a variant inside a pseudo nested in a media object', () => {
+    const { viewProps } = simplifiedGetSplitStyles(
+      RestyledView,
+      { $sm: { hoverStyle: { bgColor: 'red' } } },
+      themed()
+    )
+    expect(viewProps.$sm).toEqual({ hoverStyle: { backgroundColor: 'red' } })
+  })
+
+  test('a functional variant reads sibling keys from inside the sub-object', () => {
+    // getSubStyle scopes styleState.props to the sub-object, so dense resolves from
+    // inside hoverStyle without an HOC - passing down has to agree with that
+    const { viewProps } = simplifiedGetSplitStyles(
+      RestyledView,
+      { hoverStyle: { tone: 'x', dense: true } },
+      themed()
+    )
+    expect(viewProps.hoverStyle).toMatchObject({ opacity: 0.1 })
   })
 
   test('renders the hover class for a variant added on top of the HOC', () => {
@@ -69,5 +137,18 @@ describe('variants added on top of a styleable() HOC (#3047)', () => {
     expect(getByTestId('base').className).toContain('_bg-0hover-yellow')
     // before the fix this was _bgColor-0hover-red, a property that does not exist
     expect(getByTestId('hoc').className).toContain('_bg-0hover-red')
+  })
+
+  test('renders the same functional variant hover class with and without the HOC', () => {
+    const { getByTestId } = render(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <PlainView data-testid="plain" hoverStyle={{ tone: 'x', dense: true }} />
+        <RestyledView data-testid="hoc" hoverStyle={{ tone: 'x', dense: true }} />
+      </TamaguiProvider>
+    )
+    const opacityClass = (el: Element) =>
+      el.className.split(' ').find((c) => c.startsWith('_o-'))
+    expect(opacityClass(getByTestId('plain'))).toBeTruthy()
+    expect(opacityClass(getByTestId('hoc'))).toBe(opacityClass(getByTestId('plain')))
   })
 })

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -578,7 +578,14 @@ export const getSplitStyles: StyleSplitter = (
       //   }
       // }
 
-      passDownProp(viewProps, keyInit, valInit, isMediaOrPseudo)
+      passDownProp(
+        viewProps,
+        keyInit,
+        isHOC && isMediaOrPseudo
+          ? expandOwnVariantsInSubStyle(styleState, valInit)
+          : valInit,
+        isMediaOrPseudo
+      )
 
       if (process.env.NODE_ENV === 'development' && debug === 'verbose') {
         console.groupEnd()
@@ -1675,6 +1682,29 @@ function recordStyleTokenProvenance(
   } else if (styleState.tokenProvenance && key in styleState.tokenProvenance) {
     delete styleState.tokenProvenance[key]
   }
+}
+
+// styled() on top of a styleable() HOC does not merge our variants into the child
+// (see the isNonStyledHOC branch in styled.tsx), so a variant nested inside a pseudo
+// or media object would never resolve down there. Expand our own variants to plain
+// style keys before passing the object down. Fixes #3047
+function expandOwnVariantsInSubStyle(styleState: GetStyleState, styleIn: any) {
+  const { variants } = styleState.staticConfig
+  if (!variants || !styleIn || typeof styleIn !== 'object') return styleIn
+  const out: Record<string, any> = {}
+  let didExpand = false
+  for (const key in styleIn) {
+    const val = styleIn[key]
+    if (!(key in variants)) {
+      out[key] = val
+      continue
+    }
+    propMapper(key, val, styleState, false, (expandedKey, expandedVal) => {
+      didExpand ||= expandedKey !== key
+      out[expandedKey] = expandedVal
+    })
+  }
+  return didExpand ? out : styleIn
 }
 
 export const getSubStyle = (

--- a/code/core/web/src/helpers/getSplitStyles.tsx
+++ b/code/core/web/src/helpers/getSplitStyles.tsx
@@ -1691,20 +1691,49 @@ function recordStyleTokenProvenance(
 function expandOwnVariantsInSubStyle(styleState: GetStyleState, styleIn: any) {
   const { variants } = styleState.staticConfig
   if (!variants || !styleIn || typeof styleIn !== 'object') return styleIn
-  const out: Record<string, any> = {}
-  let didExpand = false
-  for (const key in styleIn) {
-    const val = styleIn[key]
-    if (!(key in variants)) {
-      out[key] = val
-      continue
+
+  let out: Record<string, any> | undefined
+  const parentProps = styleState.props
+  // spread and functional variants read sibling keys off extras.props, and getSubStyle
+  // scopes those to the sub-object, so resolve them against the same view of the props
+  styleState.props = { ...parentProps, ...styleIn }
+
+  try {
+    for (const key in styleIn) {
+      const val = styleIn[key]
+
+      if (!(key in variants)) {
+        // media inside pseudo (and the reverse) nests arbitrarily, so keep walking
+        if (val && typeof val === 'object') {
+          if (key in validPseudoKeys || getMediaKey(key)) {
+            const nested = expandOwnVariantsInSubStyle(styleState, val)
+            if (nested !== val) {
+              ;(out ||= { ...styleIn })[key] = nested
+            }
+          }
+        }
+        continue
+      }
+
+      let expanded: Record<string, any> | undefined
+      propMapper(key, val, styleState, false, (expandedKey, expandedVal) => {
+        ;(expanded ||= {})[expandedKey] = expandedVal
+      })
+
+      // with no matching value of ours propMapper hands the key back, and emits nothing
+      // at all when the value resolves to nullish. both mean the value belongs to the
+      // wrapped component, so leave it exactly as the caller wrote it for it to resolve
+      if (!expanded || key in expanded) continue
+
+      const next = (out ||= { ...styleIn })
+      delete next[key]
+      Object.assign(next, expanded)
     }
-    propMapper(key, val, styleState, false, (expandedKey, expandedVal) => {
-      didExpand ||= expandedKey !== key
-      out[expandedKey] = expandedVal
-    })
+  } finally {
+    styleState.props = parentProps
   }
-  return didExpand ? out : styleIn
+
+  return out || styleIn
 }
 
 export const getSubStyle = (


### PR DESCRIPTION
## What breaks

Reported in #3047. When `styled()` is applied on top of a `styleable()` HOC, the new variants work as top level props but silently do nothing inside `hoverStyle`, `pressStyle`, `$sm` and the other pseudo/media props.

```tsx
const StyledView = styled(View, {
  variants: { bgColor: { yellow: { backgroundColor: 'yellow' } } } as const,
})

const HOCView = StyledView.styleable((props, ref) => <StyledView ref={ref} {...props} />)

const RestyledView = styled(HOCView, {
  variants: { bgColor: { red: { backgroundColor: 'red' } } } as const,
})

<RestyledView bgColor="red" />                   // red, works
<RestyledView hoverStyle={{ bgColor: 'red' }} /> // never turns red
```

## Root cause

`styled()` deliberately skips merging the parent's variants when the parent is a non styled HOC (`code/core/web/src/styled.tsx:324-350`, the `avoid` branch). So `RestyledView.staticConfig.variants` holds only `bgColor: { red }`, while the component it renders into only knows `bgColor: { yellow }`.

`getSplitStyles` then treats the whole pseudo/media object as opaque for an HOC. In `code/core/web/src/helpers/getSplitStyles.tsx:535-540` any pseudo or media key sets `isHOCShouldPassThrough`, and line 581 passed the raw object straight down with `passDownProp` before `continue`. `bgColor: 'red'` therefore arrived at a component that has no `red` value for that variant, so it fell through as an unknown style key.

The same function already does the right thing one level up. For a plain variant prop the `propMapper` callback re-tests `shouldPassThrough` (lines 681-683) and then passes the *expanded* result down at line 686. Only the nested-in-a-pseudo case was missing that expansion. The dead `// TODO bring this back` block at lines 563-579 describes exactly this gap and even names `getSubStyle`.

Concretely, the rendered class went from a real declaration to a nonexistent property:

```
control (no HOC):  _bg-0hover-yellow
before this fix:   _bgColor-0hover-red
after this fix:    _bg-0hover-red
```

## The fix

`expandOwnVariantsInSubStyle` walks a pseudo or media object before it is passed down from an HOC and swaps each key that one of *our own* variants resolves for the plain style keys it expands to. Three things it is careful about:

**The decision is per key, not per object.** When none of our variant values match, `propMapper` either hands the key straight back, or emits nothing at all if the value then resolves to nullish. Both mean the value is the wrapped component's to interpret, so the key is left exactly as the caller wrote it. That matters for a mixed object: `hoverStyle={{ bgColor: '$blue10', pad: 'big' }}` has to expand `pad` and still deliver `bgColor` untouched, and a component having more than one variant is ordinary usage.

**It recurses into nested pseudo and media objects.** `hoverStyle={{ $sm: { ... } }}` and `$sm={{ hoverStyle: { ... } }}` are supported shapes, handled explicitly by `getSubStyle`, and a one level walk would have left #3047 open for both.

**It scopes `styleState.props` to the sub-object and restores it in a `finally`,** the way `getSubStyle` does, so a spread or functional variant nested in a pseudo reads the same `extras.props` it would read with no HOC in the way. Without that, `hoverStyle={{ tone: 'x', dense: true }}` resolves `tone` against the outer props and quietly disagrees with the non HOC path.

### Why not reuse `getSubStyle`

It is the obvious candidate, and it walks a sub-style object with the identical `propMapper(key, val, styleState, false, cb)` call. It is not a drop in here though: it resolves every key rather than only our own variants, normalizes values, merges transforms against `styleState.style`, runs `fixStyles`, and returns a finished style object. This site needs the opposite, a minimally rewritten *props* object that the wrapped component then runs through its own `getSplitStyles`. The one behaviour worth borrowing is the `styleState.props` scoping, which this does. (Its `skipProps` filter is `!staticConfig.isHOC && ...`, so it is already inert on the path this helper runs on.)

## How I proved it

`code/core/core-test/hocPseudoVariants.web.test.tsx`, 9 cases: expansion inside `hoverStyle` and inside `$sm`, the pass through guard for values only the child knows, a mixed object where one key expands and a sibling cannot be resolved, both nesting directions, functional variant prop scoping, and two render assertions against a non HOC control.

Counterfactual, reverting only `getSplitStyles.tsx` and keeping the tests:

```
  Tests  8 failed | 1 passed (9)

AssertionError: expected { bgColor: 'red' } to deeply equal { backgroundColor: 'red' }
AssertionError: expected { bgColor: '$blue10', pad: 'big' } to match object { bgColor: '$blue10', ... }
AssertionError: expected { '$sm': { bgColor: 'red' } } to deeply equal { '$sm': { backgroundColor: 'red' } }
AssertionError: expected 'is_StyledView is_View _bgColor-0hover...' to contain '_bg-0hover-red'
```

With the fix restored, 9 passed. The one case that passes in both states is the pass through guard, on purpose: it is the check that the change is not over eager.

I also checked that the tests pin the behaviour rather than just exercising it, by breaking each part of the helper in turn and confirming a test goes red:

| broken on purpose | tests that fail |
| --- | --- |
| drop the `key in variants` guard, so every key gets expanded | pass through guard, both nesting cases |
| `return out` instead of `return out || styleIn` | pass through guard |
| drop the `styleState.props` scoping | functional variant scoping, non HOC render control |
| decide expansion per object instead of per key | mixed object, both nesting cases, both functional variant cases |

CI unit-tests job, run locally before and after (`--force --continue`, so nothing is served from the turbo cache):

| task | before | after |
| --- | --- | --- |
| `@tamagui/core-test` test:web | 26 files, 210 passed / 1 skipped / 1 todo | 27 files, 219 passed / 1 skipped / 1 todo |
| `@tamagui/web` test:web | 64 passed, no type errors | 64 passed, no type errors |
| `@tamagui/components-test` test:web | 30 passed | 30 passed |
| `@tamagui/static-tests` test:web | 103 passed / 1 skipped, 18 passed | 103 passed / 1 skipped, 18 passed |
| `@tamagui/input` test:web | 36 passed | 36 passed |
| `create-tamagui` test:web | 24 passed / 1 skipped | 24 passed / 1 skipped |
| `@tamagui/build` test:web | 14 passed | 14 passed |
| `@tamagui/cli` test:web | 10 passed | 10 passed |
| `@tamagui/theme-builder` test:web | 11 passed | 11 passed |
| `@tamagui/static-worker` test:web | 4 passed | 4 passed |
| `@tamagui/core-test` test:native | 95 passed / 7 expected fail / 11 skipped | 95 passed / 7 expected fail / 11 skipped |
| `@tamagui/components-test` test:native | 27 passed | 27 passed |
| `@tamagui/static-tests` test:native | 32 passed | 32 passed |

Turbo reports 11 successful of 15 in both states. The four that are not successful are identical before and after and are local environment gaps, not source: `next15-plus-cli-optimize` and `test-next-turbopack` both die on `error: Script not found "tamagui"`, `integration` and `sandbox` have no Playwright browsers installed here.

The only delta is the 9 new tests. No existing expectation or snapshot was edited. Also green with the change: `bun run typecheck`, `oxfmt --check` and `oxlint` on both touched files.

## Regression risk

This is in `getSplitStyles`, so worth being explicit about the blast radius. The new code runs only where `isHOC && isMediaOrPseudo` already held at the pass-through site, and inside that it only rewrites keys present in the component's own `variants`. Everything else is copied across unchanged, and the input object is returned as is when no key was rewritten. Non-HOC components never reach it.

It does cost one shallow spread of the props per pseudo or media prop on an HOC, for the `styleState.props` scoping described above. `getSubStyle` pays the same cost on the non-HOC path.
