### PR TITLE
fix(button): apply Button.Icon color variants from an overridden styled context

### DIFF
--- a/code/ui/button/src/Button.tsx
+++ b/code/ui/button/src/Button.tsx
@@ -178,18 +178,21 @@ const Icon = (props: {
   children: React.ReactNode
   scaleIcon?: number
   size?: SizeTokens
+  color?: ButtonContextStyles['color']
+  style?: { color?: ButtonContextStyles['color'] }
 }) => {
-  const { children, scaleIcon = 1, size } = props
+  const { children, scaleIcon = 1, size, color, style } = props
   const styledContext = context.useStyledContext()
   if (!styledContext) {
     throw new Error('Button.Icon must be used within a Button')
   }
 
   const sizeToken = size ?? styledContext.size
+  // a styled() wrapper around Button.Icon resolves its own variants and hands
+  // the result down as a style object, so prefer that over the Button context
+  const colorProp = color ?? style?.color ?? styledContext.color
   const iconColorProp =
-    styledContext.color === 'unset' || typeof styledContext.color === 'number'
-      ? undefined
-      : styledContext.color
+    colorProp === 'unset' || typeof colorProp === 'number' ? undefined : colorProp
   const iconColor = useCurrentColor(iconColorProp)
 
   const iconSize =

--- a/code/ui/button/src/Button.tsx
+++ b/code/ui/button/src/Button.tsx
@@ -178,10 +178,9 @@ const Icon = (props: {
   children: React.ReactNode
   scaleIcon?: number
   size?: SizeTokens
-  color?: ButtonContextStyles['color']
-  style?: { color?: ButtonContextStyles['color'] }
+  style?: GetProps<typeof SizableText>['style']
 }) => {
-  const { children, scaleIcon = 1, size, color, style } = props
+  const { children, scaleIcon = 1, size, style } = props
   const styledContext = context.useStyledContext()
   if (!styledContext) {
     throw new Error('Button.Icon must be used within a Button')
@@ -190,7 +189,9 @@ const Icon = (props: {
   const sizeToken = size ?? styledContext.size
   // a styled() wrapper around Button.Icon resolves its own variants and hands
   // the result down as a style object, so prefer that over the Button context
-  const colorProp = color ?? style?.color ?? styledContext.color
+  const styleColor =
+    style && typeof style === 'object' && !Array.isArray(style) ? style.color : undefined
+  const colorProp = styleColor ?? styledContext.color
   const iconColorProp =
     colorProp === 'unset' || typeof colorProp === 'number' ? undefined : colorProp
   const iconColor = useCurrentColor(iconColorProp)

--- a/code/ui/button/types/Button.d.ts
+++ b/code/ui/button/types/Button.d.ts
@@ -1,4 +1,5 @@
 import type { TextContextStyles } from '@tamagui/text';
+import { SizableText } from '@tamagui/text';
 import type { GetProps, SizeTokens } from '@tamagui/web';
 import type { FunctionComponent, JSX } from 'react';
 type ButtonVariant = 'outlined';
@@ -216,6 +217,7 @@ export declare const Button: import("react").ForwardRefExoticComponent<Omit<impo
         children: React.ReactNode;
         scaleIcon?: number;
         size?: SizeTokens;
+        style?: GetProps<typeof SizableText>["style"];
     }) => any;
 };
 export type ButtonProps = GetProps<typeof ButtonComponent>;

--- a/code/ui/components-test/ButtonIconContext.native.test.tsx
+++ b/code/ui/components-test/ButtonIconContext.native.test.tsx
@@ -1,0 +1,103 @@
+import { Button } from '@tamagui/button'
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import {
+  TamaguiProvider,
+  createStyledContext,
+  createTamagui,
+  styled,
+} from '@tamagui/core'
+import TestRenderer, { act } from 'react-test-renderer'
+import { describe, expect, test } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+const FRAME_COLOR = 'rgb(1, 1, 1)'
+const ICON_COLOR = 'rgb(9, 8, 7)'
+
+const ButtonContext = createStyledContext<{ variant?: 'primary' | 'secondary' }>({
+  variant: 'primary',
+})
+
+const ButtonFrame = styled(Button, {
+  context: ButtonContext,
+  variants: {
+    variant: {
+      primary: {},
+      secondary: { color: FRAME_COLOR },
+    },
+  } as const,
+  defaultVariants: { variant: 'primary' },
+})
+
+const ButtonIcon = styled(Button.Icon, {
+  context: ButtonContext,
+  variants: {
+    variant: {
+      primary: {},
+      secondary: { color: ICON_COLOR },
+    },
+  } as const,
+})
+
+const PlainIcon = styled(Button.Icon, {
+  context: ButtonContext,
+  variants: {
+    variant: { primary: {}, secondary: {} },
+  } as const,
+})
+
+function Glyph(_props: { color?: string; size?: number }) {
+  return null
+}
+
+async function renderIcon(element: React.ReactElement) {
+  let rendered: TestRenderer.ReactTestRenderer | null = null
+
+  await act(async () => {
+    rendered = TestRenderer.create(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        {element}
+      </TamaguiProvider>
+    )
+  })
+
+  return rendered!.root.findByType(Glyph).props.color
+}
+
+describe('Button.Icon with an overridden styled context on native', () => {
+  test('applies its own variant color', async () => {
+    const color = await renderIcon(
+      <ButtonFrame variant="secondary">
+        <ButtonIcon>
+          <Glyph />
+        </ButtonIcon>
+      </ButtonFrame>
+    )
+
+    expect(color).toBe(ICON_COLOR)
+  })
+
+  test('keeps the variant color when the instance adds unrelated styles', async () => {
+    const color = await renderIcon(
+      <ButtonFrame variant="secondary">
+        <ButtonIcon style={{ opacity: 0.5 }}>
+          <Glyph />
+        </ButtonIcon>
+      </ButtonFrame>
+    )
+
+    expect(color).toBe(ICON_COLOR)
+  })
+
+  test('still falls back to the Button color when the icon sets none', async () => {
+    const color = await renderIcon(
+      <ButtonFrame variant="secondary">
+        <PlainIcon>
+          <Glyph />
+        </PlainIcon>
+      </ButtonFrame>
+    )
+
+    expect(color).toBe(FRAME_COLOR)
+  })
+})

--- a/code/ui/components-test/ButtonIconContext.web.test.tsx
+++ b/code/ui/components-test/ButtonIconContext.web.test.tsx
@@ -1,0 +1,97 @@
+import '@testing-library/jest-dom'
+
+import { Button } from '@tamagui/button'
+import { getDefaultTamaguiConfig } from '@tamagui/config-default'
+import {
+  TamaguiProvider,
+  createStyledContext,
+  createTamagui,
+  styled,
+} from '@tamagui/core'
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+const conf = createTamagui(getDefaultTamaguiConfig())
+
+const FRAME_COLOR = 'rgb(1, 1, 1)'
+const ICON_COLOR = 'rgb(9, 8, 7)'
+
+const ButtonContext = createStyledContext<{ variant?: 'primary' | 'secondary' }>({
+  variant: 'primary',
+})
+
+const ButtonFrame = styled(Button, {
+  context: ButtonContext,
+  variants: {
+    variant: {
+      primary: {},
+      secondary: { color: FRAME_COLOR },
+    },
+  } as const,
+  defaultVariants: { variant: 'primary' },
+})
+
+const ButtonText = styled(Button.Text, {
+  context: ButtonContext,
+  variants: {
+    variant: {
+      primary: {},
+      secondary: { color: ICON_COLOR },
+    },
+  } as const,
+})
+
+const ButtonIcon = styled(Button.Icon, {
+  context: ButtonContext,
+  variants: {
+    variant: {
+      primary: {},
+      secondary: { color: ICON_COLOR },
+    },
+  } as const,
+})
+
+const PlainIcon = styled(Button.Icon, {
+  context: ButtonContext,
+  variants: {
+    variant: { primary: {}, secondary: {} },
+  } as const,
+})
+
+function Glyph(props: { color?: string; size?: number }) {
+  return <span data-testid="glyph" data-color={String(props.color)} />
+}
+
+describe('Button.Icon with an overridden styled context', () => {
+  it('applies its own variant color like Button.Text does', () => {
+    const rendered = render(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <ButtonFrame variant="secondary">
+          <ButtonIcon>
+            <Glyph />
+          </ButtonIcon>
+          <ButtonText>label</ButtonText>
+        </ButtonFrame>
+      </TamaguiProvider>
+    )
+
+    // Button.Text is a real styled component and already reads the overridden
+    // context, so it is the control for the icon assertion below
+    expect(getComputedStyle(rendered.getByText('label')).color).toBe(ICON_COLOR)
+    expect(rendered.getByTestId('glyph')).toHaveAttribute('data-color', ICON_COLOR)
+  })
+
+  it('still falls back to the Button color when the icon sets none', () => {
+    const rendered = render(
+      <TamaguiProvider config={conf} defaultTheme="light">
+        <ButtonFrame variant="secondary">
+          <PlainIcon>
+            <Glyph />
+          </PlainIcon>
+        </ButtonFrame>
+      </TamaguiProvider>
+    )
+
+    expect(rendered.getByTestId('glyph')).toHaveAttribute('data-color', FRAME_COLOR)
+  })
+})


### PR DESCRIPTION
### What breaks

`Button.Icon` silently ignores the variants declared on a `styled(Button.Icon, { context })` wrapper. `Button.Text`, declared exactly the same way, works. So the two halves of one button disagree:

```tsx
const ButtonContext = createStyledContext<{ variant?: 'primary' | 'secondary' }>({
  variant: 'primary',
})

const variants = {
  variant: { primary: {}, secondary: { color: '$blue10' } },
} as const

const Text = styled(Button.Text, { context: ButtonContext, variants }) // blue
const Icon = styled(Button.Icon, { context: ButtonContext, variants }) // not blue
```

The icon renders with whatever color the surrounding `Button` happened to place on the shared context, or the theme default when the button set none. Its own variant never applies.

### Root cause

`code/ui/button/src/Button.tsx`. `Button.Icon` is a plain function component rather than a `styled()` one, and it takes its color only from the module-local Button context:

```ts
const iconColorProp =
  styledContext.color === 'unset' || typeof styledContext.color === 'number'
    ? undefined
    : styledContext.color
```

When `styled()` wraps a plain function component it resolves the variants itself and hands the result down as a `style` object. Measured with a probe component: `styled(Probe, { context, variants: { variant: { secondary: { color: 'rgb(9, 8, 7)', scaleIcon: 2 } } } })` renders `Probe` with `{ scaleIcon: 2, className: 'is_View ', style: { color: 'rgb(9, 8, 7)' } }`. `Button.Icon` never reads that, so the wrapper's work is thrown away.

`Button.Text` is a real `styled(SizableText, { context })`, which is why wrapping it composes correctly. That asymmetry is the whole bug.

### The fix

Read the color out of the `style` object that `styled()` has already computed and is already passing down, and fall back to the Button context exactly as before. One source file.

No new public prop, no new mechanism, and no change to the styled context. The only behaviour that changes is the one that was broken.

The `style` prop is typed as `GetProps<typeof SizableText>['style']` rather than a narrower hand-written shape, so that `styled(Button.Icon, ...)` users can still pass any style. With a one-key type, `<Button.Icon style={{ opacity: 0.5 }}>` fails to compile.

I looked at going through `usePropsAndStyle`, the way `helpers-icon/src/themed.tsx` does. It does not fit here: `themed()` marks itself `isHOC`, so `styled()` hands it flat props that `usePropsAndStyle` can then resolve. `Button.Icon` is not an HOC, so it receives a `style` object instead, and `usePropsAndStyle` leaves an incoming `style` object in `props` untouched and returns an empty style. Making `Button.Icon` an HOC to reach that path would change how every existing `styled(Button.Icon, ...)` receives className and styles, which is far more than this bug warrants.

### Scope: `size` declared in a wrapper variant is separate and pre-existing

Worth calling out because it looks adjacent. A wrapper that declares `size` next to `color` still does not get `$10`, and this change cannot reach that. `styled()` resolves a variant-declared `size` to a CSS variable, off the space scale, before the icon runs, so `Button.Icon` receives `size: "var(--t-space-10)"` and `getFontSize` cannot parse it. Measured against a config with distinct font size tokens (`$1: 11` through `$10: 110`):

| icon size from | `main` | this branch |
|---|---|---|
| wrapper variant `size: '$10'` | 11 | 11 |
| wrapper variant `size: 44` | 22 | 22 |
| instance prop `size="$10"` | 110 | 110 |

Identical on both sides. Instance props survive resolution untouched, which is why `<Button.Icon size="$10">` and `scaleIcon` both work today. Closing the variant-declared case means making `Button.Icon` a real `styled()` component with its own `size` variant, which is a much bigger change than this bug needs.

One gotcha for anyone measuring this: the default test config defines a single font size token, so every `getFontSize` returns 15 and no size difference is observable unless you supply a config with a real size scale.

### How I proved it

Two test files. `code/ui/components-test/ButtonIconContext.web.test.tsx` gives the `Button` frame one color and the `Button.Icon` wrapper a different one, so the assertion can only pass if the icon reads its own variant rather than inheriting. `Button.Text` with the same declaration is asserted first as a control. `ButtonIconContext.native.test.tsx` covers the same ground under `TAMAGUI_TARGET=native`, plus an instance `style={{ opacity: 0.5 }}` merged on top of the variant. Both files pin the existing fallback, that an icon which declares no color still inherits the button's.

Counterfactual, with only the source change reverted and the package rebuilt (these suites resolve `@tamagui/button` from `dist`, not `src`):

```
 x applies its own variant color like Button.Text does
   -> expect(element).toHaveAttribute("data-color", "rgb(9, 8, 7)")
      Expected the element to have attribute:
        data-color="rgb(9, 8, 7)"
      Received:
        data-color="rgb(1, 1, 1)"
 v still falls back to the Button color when the icon sets none
```

`rgb(1, 1, 1)` is the frame's color, which is precisely the reported symptom. Restored and rebuilt, both pass.

I also mutation-tested the new logic rather than relying on a full revert. Each mutant is killed on both web and native:

| mutant | killed by |
|---|---|
| drop the `style` color read | applies its own variant color |
| context wins over the wrapper instead of losing | applies its own variant color |
| drop the context fallback | still falls back to the Button color when the icon sets none |
| break the plain-object guard so a real style object is rejected | applies its own variant color |

Suite counts from the CI jobs, unmodified `main` vs this branch, both measured here:

| | `main` | this branch |
|---|---|---|
| `test:web` passed | 524 | 526 |
| `test:web` failed | 12 | 12 |
| `test:native` passed | 154 | 157 |

The deltas are this PR's two web and three native tests, and no existing expectation was touched. The 12 web failures are the same on both sides and are environmental on my machine, not caused by any source change: `next15-plus-cli-optimize` and `test-next-turbopack` both die on `error: Script not found "tamagui"`, and `integration` and `sandbox` cannot launch Playwright because the browser binaries are not installed.

Also ran `oxfmt --check` and `oxlint` on the changed files, and `tsc -b code/ui/button` clean. `code/ui/button/types/Button.d.ts` is regenerated and committed, matching what #4182 did for `code/core/web/types/types.d.ts`.

### Note

`ListItem.Icon` (`code/ui/list-item/src/ListItem.tsx`) has the identical shape and the identical gap, and passes `styledContext.color` straight into `useCurrentColor` without even the `'unset'` and number guard `Button.Icon` has. I left it untouched to keep this diff to one component, happy to follow up separately if you want it matched.
