### PR TITLE
set minH for header popover menu

### DIFF
--- a/code/tamagui.dev/features/site/header/Header.tsx
+++ b/code/tamagui.dev/features/site/header/Header.tsx
@@ -554,6 +554,7 @@ const HeaderLinksPopoverContent = React.memo((props: { active: ID | '' }) => {
       bg="$background06"
       backdropFilter="blur(40px)"
       maxH="90vh"
+      minH={360}
       maxW={360}
       minW={360}
       elevation="$2"


### PR DESCRIPTION
Currently, on tamagui.dev, when you open the menu in the header, its height doesn't allow for the menu contents to be viewed easily: 
<img width="685" height="153" alt="Screenshot_2026-09-10_08-10-28" src="https://github.com/user-attachments/assets/8d0376c1-2dc3-4fcf-9349-864c4ff15f29" />

I just added a minHeight that matches its minWidth, and the menu contents are more visible: 
<img width="383" height="434" alt="Screenshot_2026-09-10_08-10-51" src="https://github.com/user-attachments/assets/276e417e-708e-464a-880d-cc40dab2043a" />
